### PR TITLE
Uses the `@ingress` annotation to identify ingress handles.

### DIFF
--- a/java/arcs/core/analysis/BUILD
+++ b/java/arcs/core/analysis/BUILD
@@ -15,6 +15,7 @@ arcs_kt_library(
     deps = [
         "//java/arcs/core/data",
         "//java/arcs/core/data:schema_fields",
+        "//java/arcs/core/host",
         "//java/arcs/core/policy",
         "//java/arcs/core/type",
         "//java/arcs/core/util",

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -81,10 +81,10 @@ class PolicyVerifier(val options: PolicyOptions? = null) {
         policyConstraints: PolicyConstraints
     ): List<InformationFlow.IngressInfo> {
         return getIngressHandles(graph).map { handleNode ->
-            val partialClaims = handleNode.handle.type.toSchema().name?.name?.let { schemaName ->
+            val selectorClaims = handleNode.handle.type.toSchema().name?.name?.let { schemaName ->
                 policyConstraints.claims[schemaName]
             }
-            val claims = partialClaims.orEmpty().map { it.inflate(handleNode.handle) }
+            val claims = selectorClaims.orEmpty().map { it.inflate(handleNode.handle) }
             InformationFlow.IngressInfo(handleNode, claims)
         }
     }

--- a/java/arcs/core/analysis/PolicyVerifier.kt
+++ b/java/arcs/core/analysis/PolicyVerifier.kt
@@ -13,8 +13,8 @@ package arcs.core.analysis
 
 import arcs.core.data.AccessPath
 import arcs.core.data.Check
-import arcs.core.data.Claim
 import arcs.core.data.Recipe
+import arcs.core.host.toSchema
 import arcs.core.policy.Policy
 import arcs.core.policy.PolicyConstraints
 import arcs.core.policy.PolicyOptions
@@ -22,7 +22,8 @@ import arcs.core.policy.PolicyViolation
 import arcs.core.policy.translatePolicy
 
 /** A class to verify that recipes are compliant with a policy. */
-class PolicyVerifier(val options: PolicyOptions) {
+@Suppress("UNUSED_PARAMETER") // TODO(b/164153178): Delete PolicyOptions.
+class PolicyVerifier(val options: PolicyOptions? = null) {
     /**
      * Returns true if the recipe is compliant with the given policy.
      *
@@ -32,11 +33,11 @@ class PolicyVerifier(val options: PolicyOptions) {
         checkPolicyName(recipe, policy)
 
         // TODO(b/162083814): This should be moved to the compilation step.
-        val policyConstraints = translatePolicy(policy, options)
+        val policyConstraints = translatePolicy(policy)
         val graph = RecipeGraph(recipe)
 
-        // Map the storeClaims to the corresponding handles.
-        val ingresses = graph.handleNodes.mapNotNull { getIngressInfo(it, policyConstraints) }
+        // Map the claims from the PolicyConstraints to the corresponding handles.
+        val ingresses = getGraphIngresses(graph, policyConstraints)
 
         // Compute the egress check map.
         val egressCheckPredicate = policyConstraints.egressCheck
@@ -70,49 +71,54 @@ class PolicyVerifier(val options: PolicyOptions) {
     }
 
     /**
-     * If there are any claims associated with this handle's stores, creates and returns a
-     * [InformationFlow.IngressInfo] after remapping the root of the claims from the store to this
-     * handle. Otherwise returns null.
+     * Generates a list of [InformationFlow.IngressInfo] for every ingress handle in the graph. The
+     * claims in the returned ingress info for a handle will be derived from the [PolicyConstraints]
+     * that apply to that handle. When there are no such constraints, an empty list of claims will
+     * be used. This will ensure that the data in the ingress handle cannot be egressed.
      */
-    private fun getIngressInfo(
-        handleNode: RecipeGraph.Node.Handle,
+    private fun getGraphIngresses(
+        graph: RecipeGraph,
         policyConstraints: PolicyConstraints
-    ): InformationFlow.IngressInfo? {
-        return policyConstraints.storeClaims[handleNode.handle.id]
-            ?.filterIsInstance<Claim.Assume>()
-            ?.map {
-                Claim.Assume(
-                    AccessPath(handleNode.handle, it.accessPath.selectors),
-                    it.predicate
-                )
+    ): List<InformationFlow.IngressInfo> {
+        return getIngressHandles(graph).map { handleNode ->
+            val partialClaims = handleNode.handle.type.toSchema().name?.name?.let { schemaName ->
+                policyConstraints.claims[schemaName]
             }
-            ?.let { claims -> InformationFlow.IngressInfo(handleNode, claims) }
-            // If there is information in `storeClaims`, use the safest information.
-            ?: getDefaultIngressInfo(handleNode)
+            val claims = partialClaims.orEmpty().map { it.inflate(handleNode.handle) }
+            InformationFlow.IngressInfo(handleNode, claims)
+        }
     }
 
     /**
-     * Returns an [IngressInfo] with empty claims if [handleNode] has (1) only read connections, or
-     * (2) is written to by a particle that only has write connections. Otherwise, returns null.
+     * Returns the set of all ingress handles in the [graph].
      *
-     * When the above conditions are true for a handle, the store corresponding to the handle is a
-     * possibly protected store and this handle should be treated as an ingress. If we don't treat
-     * this handle as an ingress, dataflow analysis would not track data flows from this handle and
-     * a recipe might be verified as being compliant with a policy even if it isn't.
-     *
-     * Returning empty claims makes sure that we can't do anything with the data, and therefore,
-     * the recipe will be rejected if it egresses any data from this store.
+     * Ingress handles are identified as being the outputs of particles marked with the `@ingress`
+     * annotation. We also find handles that look like they might be ingress handles, based on the
+     * shape of the particles that write to them.
      */
-    private fun getDefaultIngressInfo(
-        handleNode: RecipeGraph.Node.Handle
-    ) = InformationFlow.IngressInfo(handleNode, emptyList()).takeIf {
-        handleNode.predecessors.isEmpty() ||
-        handleNode.predecessors.any { predecessor ->
-            predecessor.node is RecipeGraph.Node.Particle &&
-            predecessor.node.particle.spec.connections.all { (_, spec) ->
-                spec.direction.canWrite && !spec.direction.canRead
-            }
+    private fun getIngressHandles(graph: RecipeGraph): Set<RecipeGraph.Node.Handle> {
+        // Compute set of handles explicitly marked as ingress (via @ingress annotations on the
+        // particles that write to them).
+        val ingressParticleNodes = graph.particleNodes.filter {
+            it.particle.spec.dataflowType.ingress
         }
+        val explicitIngressHandles = ingressParticleNodes.flatMap { it.successors }
+            .filterIsInstance<RecipeGraph.Node.Handle>()
+            .toSet()
+
+        // Compute set of handles automatically identified as ingress. These are handles which
+        // "look" like ingress handles, based on the particles that write to them.
+        val defaultIngressHandles = graph.handleNodes.filter { handleNode ->
+            handleNode.predecessors.isEmpty() ||
+            handleNode.predecessors.any { predecessor ->
+                predecessor.node is RecipeGraph.Node.Particle &&
+                predecessor.node.particle.spec.connections.all { (_, spec) ->
+                    spec.direction.canWrite && !spec.direction.canRead
+                }
+            }
+        }.toSet()
+
+        return explicitIngressHandles + defaultIngressHandles
     }
 
     /**

--- a/java/arcs/core/data/proto/AccessPathProtoDecoder.kt
+++ b/java/arcs/core/data/proto/AccessPathProtoDecoder.kt
@@ -69,12 +69,12 @@ fun AccessPath.encode(): AccessPathProto {
     return proto.build()
 }
 
-private fun AccessPathProto.Selector.decode(): AccessPath.Selector = when (selectorCase) {
+fun AccessPathProto.Selector.decode(): AccessPath.Selector = when (selectorCase) {
     AccessPathProto.Selector.SelectorCase.FIELD -> AccessPath.Selector.Field(field)
     else -> throw UnsupportedOperationException("Unsupported AccessPathProto.Selector: $this")
 }
 
-private fun AccessPath.Selector.encode(): AccessPathProto.Selector {
+fun AccessPath.Selector.encode(): AccessPathProto.Selector {
     if (this !is AccessPath.Selector.Field) {
         throw UnsupportedOperationException("Unsupported Selector type: $this")
     }

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -317,19 +317,19 @@ message PolicyConstraintsProto {
 
   InformationFlowLabelProto.Predicate egress_check = 2;
 
-  message PartialClaim {
+  message SelectorClaim {
     repeated AccessPathProto.Selector selectors = 1;
     InformationFlowLabelProto.Predicate predicate = 2;
   }
 
-  message TypeClaims {
+  message SchemaClaims {
     // The name of the schema the claims apply to.
     string schema_name = 1;
 
-    // Partial claims (Assume claims without an AccessPath root).
-    repeated PartialClaim partial_claims = 2;
+    // Selector claims (Assume claims without an AccessPath root).
+    repeated SelectorClaim selector_claims = 2;
   }
-  repeated TypeClaims type_claims = 4;
+  repeated SchemaClaims schema_claims = 4;
 
   reserved 3;
 }

--- a/java/arcs/core/data/proto/manifest.proto
+++ b/java/arcs/core/data/proto/manifest.proto
@@ -317,9 +317,19 @@ message PolicyConstraintsProto {
 
   InformationFlowLabelProto.Predicate egress_check = 2;
 
-  message StoreConstraints {
-    string store_id = 1;
-    repeated ClaimProto claims = 2;
+  message PartialClaim {
+    repeated AccessPathProto.Selector selectors = 1;
+    InformationFlowLabelProto.Predicate predicate = 2;
   }
-  repeated StoreConstraints store_constraints = 3;
+
+  message TypeClaims {
+    // The name of the schema the claims apply to.
+    string schema_name = 1;
+
+    // Partial claims (Assume claims without an AccessPath root).
+    repeated PartialClaim partial_claims = 2;
+  }
+  repeated TypeClaims type_claims = 4;
+
+  reserved 3;
 }

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -153,6 +153,16 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
         policy,
         "Recipe elected a policy named '$electedPolicyName'."
     )
+
+    /** Thrown when unannotated ingress particles are found. */
+    class UnannotatedIngressParticles(
+        policy: Policy,
+        val particleSpecs: List<ParticleSpec>
+    ) : PolicyViolation(
+        policy,
+        "These particles look like ingress particles, but are missing the @ingress annotation: " +
+            particleSpecs.joinToString { it.name }
+    )
 }
 
 /** Converts a list of particles into their names and egress types, as a string. */

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -153,16 +153,6 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
         policy,
         "Recipe elected a policy named '$electedPolicyName'."
     )
-
-    /** Thrown when unannotated ingress particles are found. */
-    class UnannotatedIngressParticles(
-        policy: Policy,
-        val particleSpecs: List<ParticleSpec>
-    ) : PolicyViolation(
-        policy,
-        "These particles look like ingress particles, but are missing the @ingress annotation: " +
-            particleSpecs.joinToString { it.name }
-    )
 }
 
 /** Converts a list of particles into their names and egress types, as a string. */

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -7,7 +7,6 @@ import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
 import arcs.core.data.ParticleSpec
 import arcs.core.data.Recipe
-import arcs.core.data.StoreId
 
 /**
  * Additional checks and claims that should be added to the particles in a recipe, which together
@@ -16,8 +15,17 @@ import arcs.core.data.StoreId
 data class PolicyConstraints(
     val policy: Policy,
     val egressCheck: Predicate,
-    val storeClaims: Map<StoreId, List<Claim>>
+    /** Maps from schema name to a list of claims to apply to stores of that type. */
+    val claims: Map<String, List<PartialClaim>>
 )
+
+/** Equivalent to a [Claim.Assume] object, but without an [AccessPath.Root]. */
+data class PartialClaim(val selectors: List<AccessPath.Selector>, val predicate: Predicate) {
+    /** Converts the [PartialClaim] to a [Claim] rooted at the given [handle]. */
+    fun inflate(handle: Recipe.Handle): Claim {
+        return Claim.Assume(AccessPath(handle, selectors), predicate)
+    }
+}
 
 /**
  * Translates the given [policy] into dataflow analysis checks and claims, which are to be added to
@@ -26,53 +34,37 @@ data class PolicyConstraints(
  * @return additional checks and claims for the particles as a [PolicyConstraints] object
  * @throws PolicyViolation if the [particles] violate the [policy]
  */
-fun translatePolicy(policy: Policy, options: PolicyOptions): PolicyConstraints {
+@Suppress("UNUSED_PARAMETER") // TODO(b/164153178): Delete PolicyOptions.
+fun translatePolicy(policy: Policy, options: PolicyOptions? = null): PolicyConstraints {
     // Compute the predicate that will enforce the policy at an egress.
     val egressCheckPredicate = createEgressCheckPredicate(policy)
 
     // Add claim statements for stores.
-    val storeClaims = mutableMapOf<StoreId, List<Claim>>()
-    policy.targets.forEach { target ->
-        val stores = options.storeMap.mapNotNull { (storeId, schemaName) ->
-            if (schemaName == target.schemaName) storeId else null
-        }
-        if (stores.isEmpty()) {
-            throw PolicyViolation.NoStoreForPolicyTarget(policy, target)
-        }
-        stores.forEach { storeId ->
-            val storeRoot = AccessPath.Root.Store(storeId)
-            storeClaims[storeId] = target.createClaims(storeRoot)
-        }
-    }
+    val claims = policy.targets.associate { target -> target.schemaName to target.createClaims() }
 
-    return PolicyConstraints(
-        policy,
-        egressCheckPredicate,
-        storeClaims.filterValues { it.isNotEmpty() }
-    )
+    return PolicyConstraints(policy, egressCheckPredicate, claims)
 }
 
 /** Returns a list of store [Claim]s for the given [handle] and corresponding [target]. */
-private fun PolicyTarget.createClaims(store: AccessPath.Root.Store): List<Claim> {
-    return fields.flatMap { field -> field.createClaims(store) }
+private fun PolicyTarget.createClaims(): List<PartialClaim> {
+    return fields.flatMap { field -> field.createClaims() }
 }
 
 /**
  * Returns a list of claims for the given [field] (and all subfields), using the given [handle]
  * as the root for the claims.
  */
-private fun PolicyField.createClaims(store: AccessPath.Root.Store): List<Claim> {
-    val claims = mutableListOf<Claim>()
+private fun PolicyField.createClaims(): List<PartialClaim> {
+    val claims = mutableListOf<PartialClaim>()
 
     // Create claim for this field.
     createStoreClaimPredicate()?.let { predicate ->
         val selectors = fieldPath.map { AccessPath.Selector.Field(it) }
-        val accessPath = AccessPath(store, selectors)
-        claims.add(Claim.Assume(accessPath, predicate))
+        claims.add(PartialClaim(selectors, predicate))
     }
 
     // Add claims for subfields.
-    subfields.flatMapTo(claims) { subfield -> subfield.createClaims(store) }
+    subfields.flatMapTo(claims) { subfield -> subfield.createClaims() }
 
     return claims
 }
@@ -142,15 +134,6 @@ sealed class PolicyViolation(val policy: Policy, message: String) : Exception(
         "Invalid egress types found for particles: " +
             invalidEgressParticles.namesAndEgressTypes() +
             ". Egress type allowed by policy: ${policy.egressType}."
-    )
-
-    /** Thrown when there is no store associated with schema. */
-    class NoStoreForPolicyTarget(
-        policy: Policy,
-        target: PolicyTarget
-    ) : PolicyViolation(
-        policy,
-        "No store found for policy target `${target.schemaName}`"
     )
 
     /** Thrown when policy checks are violated by a recipe. */

--- a/java/arcs/core/policy/PolicyConstraints.kt
+++ b/java/arcs/core/policy/PolicyConstraints.kt
@@ -16,12 +16,12 @@ data class PolicyConstraints(
     val policy: Policy,
     val egressCheck: Predicate,
     /** Maps from schema name to a list of claims to apply to stores of that type. */
-    val claims: Map<String, List<PartialClaim>>
+    val claims: Map<String, List<SelectorClaim>>
 )
 
 /** Equivalent to a [Claim.Assume] object, but without an [AccessPath.Root]. */
-data class PartialClaim(val selectors: List<AccessPath.Selector>, val predicate: Predicate) {
-    /** Converts the [PartialClaim] to a [Claim] rooted at the given [handle]. */
+data class SelectorClaim(val selectors: List<AccessPath.Selector>, val predicate: Predicate) {
+    /** Converts the [SelectorClaim] to a [Claim] rooted at the given [handle]. */
     fun inflate(handle: Recipe.Handle): Claim {
         return Claim.Assume(AccessPath(handle, selectors), predicate)
     }
@@ -46,7 +46,7 @@ fun translatePolicy(policy: Policy, options: PolicyOptions? = null): PolicyConst
 }
 
 /** Returns a list of store [Claim]s for the given [handle] and corresponding [target]. */
-private fun PolicyTarget.createClaims(): List<PartialClaim> {
+private fun PolicyTarget.createClaims(): List<SelectorClaim> {
     return fields.flatMap { field -> field.createClaims() }
 }
 
@@ -54,13 +54,13 @@ private fun PolicyTarget.createClaims(): List<PartialClaim> {
  * Returns a list of claims for the given [field] (and all subfields), using the given [handle]
  * as the root for the claims.
  */
-private fun PolicyField.createClaims(): List<PartialClaim> {
-    val claims = mutableListOf<PartialClaim>()
+private fun PolicyField.createClaims(): List<SelectorClaim> {
+    val claims = mutableListOf<SelectorClaim>()
 
     // Create claim for this field.
     createStoreClaimPredicate()?.let { predicate ->
         val selectors = fieldPath.map { AccessPath.Selector.Field(it) }
-        claims.add(PartialClaim(selectors, predicate))
+        claims.add(SelectorClaim(selectors, predicate))
     }
 
     // Add claims for subfields.

--- a/java/arcs/core/policy/proto/PolicyConstraintsProto.kt
+++ b/java/arcs/core/policy/proto/PolicyConstraintsProto.kt
@@ -1,19 +1,22 @@
 package arcs.core.policy.proto
 
-import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.proto.PolicyConstraintsProto
 import arcs.core.data.proto.decode
 import arcs.core.data.proto.encode
+import arcs.core.policy.PartialClaim
 import arcs.core.policy.PolicyConstraints
 
-fun PolicyConstraintsProto.decode(
-    connectionSpecs: Map<String, HandleConnectionSpec>
-): PolicyConstraints {
+fun PolicyConstraintsProto.decode(): PolicyConstraints {
     return PolicyConstraints(
         policy = policy.decode(),
         egressCheck = egressCheck.decode(),
-        storeClaims = storeConstraintsList.associate { constraint ->
-            constraint.storeId to constraint.claimsList.map { it.decode(connectionSpecs) }
+        claims = typeClaimsList.associate { typeClaim ->
+            typeClaim.schemaName to typeClaim.partialClaimsList.map { claim ->
+                PartialClaim(
+                    selectors = claim.selectorsList.map { it.decode() },
+                    predicate = claim.predicate.decode()
+                )
+            }
         }
     )
 }
@@ -22,13 +25,20 @@ fun PolicyConstraints.encode(): PolicyConstraintsProto {
     return PolicyConstraintsProto.newBuilder()
         .setPolicy(policy.encode())
         .setEgressCheck(egressCheck.encode())
-        .addAllStoreConstraints(
-            storeClaims.map { (storeId, claims) ->
-                PolicyConstraintsProto.StoreConstraints.newBuilder()
-                    .setStoreId(storeId)
-                    .addAllClaims(claims.map { it.encode() })
+        .addAllTypeClaims(
+            claims.map { (schemaName, partialClaims) ->
+                PolicyConstraintsProto.TypeClaims.newBuilder()
+                    .setSchemaName(schemaName)
+                    .addAllPartialClaims(partialClaims.map { it.encode() })
                     .build()
             }
         )
+        .build()
+}
+
+private fun PartialClaim.encode(): PolicyConstraintsProto.PartialClaim {
+    return PolicyConstraintsProto.PartialClaim.newBuilder()
+        .addAllSelectors(selectors.map { it.encode() })
+        .setPredicate(predicate.encode())
         .build()
 }

--- a/java/arcs/core/policy/proto/PolicyConstraintsProto.kt
+++ b/java/arcs/core/policy/proto/PolicyConstraintsProto.kt
@@ -3,16 +3,16 @@ package arcs.core.policy.proto
 import arcs.core.data.proto.PolicyConstraintsProto
 import arcs.core.data.proto.decode
 import arcs.core.data.proto.encode
-import arcs.core.policy.PartialClaim
+import arcs.core.policy.SelectorClaim
 import arcs.core.policy.PolicyConstraints
 
 fun PolicyConstraintsProto.decode(): PolicyConstraints {
     return PolicyConstraints(
         policy = policy.decode(),
         egressCheck = egressCheck.decode(),
-        claims = typeClaimsList.associate { typeClaim ->
-            typeClaim.schemaName to typeClaim.partialClaimsList.map { claim ->
-                PartialClaim(
+        claims = schemaClaimsList.associate { schemaClaim ->
+            schemaClaim.schemaName to schemaClaim.selectorClaimsList.map { claim ->
+                SelectorClaim(
                     selectors = claim.selectorsList.map { it.decode() },
                     predicate = claim.predicate.decode()
                 )
@@ -25,19 +25,19 @@ fun PolicyConstraints.encode(): PolicyConstraintsProto {
     return PolicyConstraintsProto.newBuilder()
         .setPolicy(policy.encode())
         .setEgressCheck(egressCheck.encode())
-        .addAllTypeClaims(
-            claims.map { (schemaName, partialClaims) ->
-                PolicyConstraintsProto.TypeClaims.newBuilder()
+        .addAllSchemaClaims(
+            claims.map { (schemaName, selectorClaims) ->
+                PolicyConstraintsProto.SchemaClaims.newBuilder()
                     .setSchemaName(schemaName)
-                    .addAllPartialClaims(partialClaims.map { it.encode() })
+                    .addAllSelectorClaims(selectorClaims.map { it.encode() })
                     .build()
             }
         )
         .build()
 }
 
-private fun PartialClaim.encode(): PolicyConstraintsProto.PartialClaim {
-    return PolicyConstraintsProto.PartialClaim.newBuilder()
+private fun SelectorClaim.encode(): PolicyConstraintsProto.SelectorClaim {
+    return PolicyConstraintsProto.SelectorClaim.newBuilder()
         .addAllSelectors(selectors.map { it.encode() })
         .setPredicate(predicate.encode())
         .build()

--- a/java/arcs/core/policy/proto/PolicyConstraintsProto.kt
+++ b/java/arcs/core/policy/proto/PolicyConstraintsProto.kt
@@ -3,8 +3,8 @@ package arcs.core.policy.proto
 import arcs.core.data.proto.PolicyConstraintsProto
 import arcs.core.data.proto.decode
 import arcs.core.data.proto.encode
-import arcs.core.policy.SelectorClaim
 import arcs.core.policy.PolicyConstraints
+import arcs.core.policy.SelectorClaim
 
 fun PolicyConstraintsProto.decode(): PolicyConstraints {
     return PolicyConstraints(

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -80,12 +80,13 @@ class PolicyVerifierTest {
 
     @Test
     fun unmarkedIngressParticlesRestrictUsage() {
-        assertFailsWith<PolicyViolation.ChecksViolated> {
+        val e = assertFailsWith<PolicyViolation.UnannotatedIngressParticles> {
             verifier.verifyPolicy(
                 recipes.getValue("UnmarkedIngress"),
                 policy
             )
         }
+        assertThat(e.particleSpecs.map { it.name }).containsExactly("IngestAction")
     }
 
     @Test

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -1,7 +1,6 @@
 package arcs.core.analysis
 
 import arcs.core.data.proto.decodeRecipes
-import arcs.core.policy.PolicyOptions
 import arcs.core.policy.PolicyViolation
 import arcs.core.policy.proto.decode
 import arcs.core.testutil.protoloader.loadManifestBinaryProto
@@ -14,11 +13,10 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class PolicyVerifierTest {
     // Test context.
-    private val storeMap = mapOf("action" to "Action", "selection" to "Selection")
     private val manifestProto = loadManifestBinaryProto(getManifestProtoBinPath("policy_test"))
     private val recipes = manifestProto.decodeRecipes().associateBy { it.name!! }
     private val policy = manifestProto.policiesList.single { it.name == "TestPolicy" }.decode()
-    private val verifier = PolicyVerifier(PolicyOptions(storeMap))
+    private val verifier = PolicyVerifier()
 
     @Test
     fun egressingUnrestrictedFieldsIsAllowed() {
@@ -119,28 +117,12 @@ class PolicyVerifierTest {
 
     @Test
     fun policyWithNoEgressIsAllowed() {
-        val testVerifier = PolicyVerifier(PolicyOptions(storeMap))
         assertThat(
-            testVerifier.verifyPolicy(
+            verifier.verifyPolicy(
                 recipes.getValue("NoEgressParticles"),
                 policy
             )
         ).isTrue()
-    }
-
-    @Test
-    fun missingStoreIsDetected() {
-        val incompleteStoreMap = mapOf("action" to "Action")
-        val testVerifier = PolicyVerifier(PolicyOptions(incompleteStoreMap))
-        assertFailsWith<PolicyViolation.NoStoreForPolicyTarget> {
-            testVerifier.verifyPolicy(
-                recipes.getValue("InvalidEgressParticles"),
-                policy
-            )
-        }.also {
-            assertThat(it).hasMessageThat()
-                .contains("No store found for policy target `Selection`")
-        }
     }
 
     @Test

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -79,14 +79,33 @@ class PolicyVerifierTest {
     }
 
     @Test
-    fun unmarkedIngressParticlesRestrictUsage() {
-        val e = assertFailsWith<PolicyViolation.UnannotatedIngressParticles> {
+    fun mappedHandleOfDifferentTypeIsDisallowed() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
             verifier.verifyPolicy(
-                recipes.getValue("UnmarkedIngress"),
+                recipes.getValue("MappedHandleOfDifferentType"),
                 policy
             )
         }
-        assertThat(e.particleSpecs.map { it.name }).containsExactly("IngestAction")
+    }
+
+    @Test
+    fun ingressParticleOfDifferentTypeIsDisallowed() {
+        assertFailsWith<PolicyViolation.ChecksViolated> {
+            verifier.verifyPolicy(
+                recipes.getValue("IngressParticleOfDifferentType"),
+                policy
+            )
+        }
+    }
+
+    @Test
+    fun unusedIngressPointsOfDifferentTypesAreAllowed() {
+        assertThat(
+            verifier.verifyPolicy(
+                recipes.getValue("UnusedIngressPointsOfDifferentType"),
+                policy
+            )
+        ).isTrue()
     }
 
     @Test

--- a/javatests/arcs/core/analysis/PolicyVerifierTest.kt
+++ b/javatests/arcs/core/analysis/PolicyVerifierTest.kt
@@ -79,16 +79,6 @@ class PolicyVerifierTest {
     }
 
     @Test
-    fun unmarkedProtectedStoresRestrictUsage() {
-        assertFailsWith<PolicyViolation.ChecksViolated> {
-            verifier.verifyPolicy(
-                recipes.getValue("UnmarkedProtectedStore"),
-                policy
-            )
-        }
-    }
-
-    @Test
     fun unmarkedIngressParticlesRestrictUsage() {
         assertFailsWith<PolicyViolation.ChecksViolated> {
             verifier.verifyPolicy(

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -74,8 +74,8 @@ particle ParticleWithMissingEgressType
 //-----------------------------------------------------------
 // Complying by not having any egress particles.
 //-----------------------------------------------------------
-@isolated
-particle SomeIsolatedWriter
+@ingress
+particle SomeIngressParticle
   input: writes [Person {name: Text}]
 
 @isolated
@@ -85,7 +85,7 @@ particle SomeIsolatedParticle
 @policy('TestPolicy')
 recipe NoEgressParticles
   input: create 'input'
-  SomeIsolatedWriter
+  SomeIngressParticle
     input: input
   SomeIsolatedParticle
     input: input
@@ -101,8 +101,8 @@ particle JoinActionSelection_EgressUnrestrictedFields
 
 @policy('TestPolicy')
 recipe EgressUnrestrictedFields
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   JoinActionSelection_EgressUnrestrictedFields
     action: action
@@ -114,8 +114,8 @@ recipe EgressUnrestrictedFields
 // Recipe that complies with policy even with multiple egresses.
 @policy('TestPolicy')
 recipe EgressAndLogUnrestrictedFields
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   JoinActionSelection_EgressUnrestrictedFields
     action: action
@@ -137,8 +137,8 @@ particle JoinActionSelection_EgressRedactedField
 
 @policy('TestPolicy')
 recipe EgressRedactedField
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   ActionTimestampToDays
     input: action
@@ -162,8 +162,8 @@ particle JoinActionSelection_EgressRestrictedFields
 
 @policy('TestPolicy')
 recipe AccessRestrictedFieldsNoEgress
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   ActionTimestampToDays
     input: action
@@ -184,8 +184,8 @@ particle JoinActionSelection_EgressRestrictedFields
 
 @policy('TestPolicy')
 recipe EgressRestrictedFields
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   ActionTimestampToDays
     input: action
@@ -209,8 +209,8 @@ particle JoinActionSelection_EgressJoinOnlyField
 
 @policy('TestPolicy')
 recipe EgressJoinOnlyField
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   ActionTimestampToDays
     input: action
@@ -227,8 +227,8 @@ recipe EgressJoinOnlyField
 //-----------------------------------------------------------------------
 @policy('TestPolicy')
 recipe EgressUnredactedField
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   JoinActionSelection_EgressRedactedField
     action: action
@@ -238,7 +238,7 @@ recipe EgressUnredactedField
     joinData: joinData
 
 //-----------------------------------------------------------------------
-// Policy violation by not marking an ingress store appropriately.
+// Policy violation by not annotating an ingress particle appropriately.
 //-----------------------------------------------------------------------
 @isolated
 particle IngestAction
@@ -252,7 +252,7 @@ recipe UnmarkedIngress
   // TODO(b/164153178): we simulate the absence of `@ingress` by not naming the
   // store id as 'action`. When we have proper `@ingress` annotation, we should fix it.
   action: create
-  selection: create 'selection'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   IngestAction
     action: action
@@ -268,8 +268,8 @@ recipe UnmarkedIngress
 //-----------------------------------------------------------------------
 @policy('TestPolicy')
 recipe InvalidEgressParticles
-  action: create 'action'
-  selection: create 'selection'
+  action: map 'action'
+  selection: map 'selection'
   joinData: create @ttl('30m')
   JoinActionSelection_EgressRedactedField
     action: action

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -174,6 +174,81 @@ recipe AccessRestrictedFieldsNoEgress
     joinData: joinData
 
 //-----------------------------------------------------------------------
+// Policy violation by using data from mapped handle of different type.
+//-----------------------------------------------------------------------
+schema CustomAction
+  data: Text
+
+@isolated
+particle CustomActionConverter
+  customAction: reads [CustomAction {data}]
+  action: writes [Action {id, action}]
+
+@policy('TestPolicy')
+recipe MappedHandleOfDifferentType
+  customAction: map 'customAction' // Has type CustomAction, which is not covered by policy.
+  selection: map 'selection'
+  action: create
+  joinData: create @ttl('30m')
+  CustomActionConverter
+    customAction: customAction
+    action: action
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// Policy violation by using data from ingress particle of different type.
+//-----------------------------------------------------------------------
+@ingress
+particle CustomActionProducer
+  customAction: writes [CustomAction {data}]
+
+@policy('TestPolicy')
+recipe IngressParticleOfDifferentType
+  customAction: create
+  selection: map 'selection'
+  action: create
+  joinData: create @ttl('30m')
+  CustomActionProducer
+    customAction: customAction
+  CustomActionConverter
+    customAction: customAction
+    action: action
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
+// No policy violation if ingress points of different types are unused.
+//-----------------------------------------------------------------------
+@policy('TestPolicy')
+recipe UnusedIngressPointsOfDifferentType
+  customAction: map 'customAction' // Ingress point, but ultimately unused
+  unused1: create
+  unused2: create
+  selection: map 'selection'
+  action: map 'action'
+  joinData: create @ttl('30m')
+  CustomActionProducer // Ingress point, but ultimately unused
+    customAction: unused1
+  CustomActionConverter
+    customAction: customAction
+    action: unused2
+  JoinActionSelection_EgressUnrestrictedFields
+    action: action
+    selection: selection
+    joinData: joinData
+  TestEgressParticle
+    joinData: joinData
+
+//-----------------------------------------------------------------------
 // Policy violation by egressing `sensitiveSelection` in `Selection`.
 //-----------------------------------------------------------------------
 @isolated

--- a/javatests/arcs/core/analysis/testdata/policy_test.arcs
+++ b/javatests/arcs/core/analysis/testdata/policy_test.arcs
@@ -240,21 +240,6 @@ recipe EgressUnredactedField
 //-----------------------------------------------------------------------
 // Policy violation by not marking an ingress store appropriately.
 //-----------------------------------------------------------------------
-@policy('TestPolicy')
-recipe UnmarkedProtectedStore
-  // This should have been marked as 'action' for it to be matched with
-  // the allowed usages in `TestPolicy`. Given that this is not marked at
-  // all, we assume that nothing can be done with the data on `action` handle.
-  action: create
-  selection: create 'selection'
-  joinData: create @ttl('30m')
-  JoinActionSelection_EgressUnrestrictedFields
-    action: action
-    selection: selection
-    joinData: joinData
-  TestEgressParticle
-    joinData: joinData
-
 @isolated
 particle IngestAction
   action: writes [Action]

--- a/javatests/arcs/core/policy/PolicyConstraintsTest.kt
+++ b/javatests/arcs/core/policy/PolicyConstraintsTest.kt
@@ -55,9 +55,9 @@ class PolicyConstraintsTest {
         assertThat(result.claims).containsExactly(
             "Foo",
             listOf(
-                PartialClaim(selectors("a"), labelPredicate("allowedForEgress_redaction1")),
-                PartialClaim(selectors("b"), labelPredicate("allowedForEgress_redaction2")),
-                PartialClaim(selectors("c"), labelPredicate("allowedForEgress_redaction3"))
+                SelectorClaim(selectors("a"), labelPredicate("allowedForEgress_redaction1")),
+                SelectorClaim(selectors("b"), labelPredicate("allowedForEgress_redaction2")),
+                SelectorClaim(selectors("c"), labelPredicate("allowedForEgress_redaction3"))
             )
         )
     }
@@ -71,7 +71,7 @@ class PolicyConstraintsTest {
         assertThat(result.claims).containsExactly(
             "Foo",
             listOf(
-                PartialClaim(selectors("a"), labelPredicate("allowedForEgress_redaction1"))
+                SelectorClaim(selectors("a"), labelPredicate("allowedForEgress_redaction1"))
             )
         )
     }
@@ -89,7 +89,7 @@ class PolicyConstraintsTest {
 
         val result = translatePolicy(policy)
 
-        assertThat(result.claims).containsExactly("Foo", emptyList<PartialClaim>())
+        assertThat(result.claims).containsExactly("Foo", emptyList<SelectorClaim>())
     }
 
     @Test
@@ -102,12 +102,12 @@ class PolicyConstraintsTest {
         assertThat(result.claims).containsExactly(
             "NestedFooBar",
             listOf(
-                PartialClaim(selectors("foo"), predicate),
-                PartialClaim(selectors("foo", "a"), predicate),
-                PartialClaim(selectors("foo", "b"), predicate),
-                PartialClaim(selectors("foo", "c"), predicate),
-                PartialClaim(selectors("bar"), predicate),
-                PartialClaim(selectors("bar", "a"), predicate)
+                SelectorClaim(selectors("foo"), predicate),
+                SelectorClaim(selectors("foo", "a"), predicate),
+                SelectorClaim(selectors("foo", "b"), predicate),
+                SelectorClaim(selectors("foo", "c"), predicate),
+                SelectorClaim(selectors("bar"), predicate),
+                SelectorClaim(selectors("bar", "a"), predicate)
             )
         )
     }

--- a/javatests/arcs/core/policy/proto/PolicyConstraintsProtoTest.kt
+++ b/javatests/arcs/core/policy/proto/PolicyConstraintsProtoTest.kt
@@ -1,9 +1,9 @@
 package arcs.core.policy.proto
 
 import arcs.core.data.AccessPath
-import arcs.core.data.Claim
 import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
+import arcs.core.policy.PartialClaim
 import arcs.core.policy.Policy
 import arcs.core.policy.PolicyConstraints
 import com.google.common.truth.Truth.assertThat
@@ -21,22 +21,22 @@ class PolicyConstraintsProtoTest {
                 egressType = "Logging"
             ),
             egressCheck = Predicate.Label(SemanticTag("public")),
-            storeClaims = mapOf(
-                "store_id_1" to listOf(
-                    Claim.Assume(
-                        AccessPath(AccessPath.Root.Store("store_id_1")),
-                        Predicate.Label(SemanticTag("public"))
+            claims = mapOf(
+                "schema_name_1" to listOf(
+                    PartialClaim(
+                        selectors = listOf(AccessPath.Selector.Field("a")),
+                        predicate = Predicate.Label(SemanticTag("public"))
                     )
                 ),
-                "store_id_2" to listOf(
-                    Claim.Assume(
-                        AccessPath(AccessPath.Root.Store("store_id_2")),
-                        Predicate.Label(SemanticTag("private"))
+                "schema_name_2" to listOf(
+                    PartialClaim(
+                        selectors = listOf(AccessPath.Selector.Field("b")),
+                        predicate = Predicate.Label(SemanticTag("private"))
                     )
                 )
             )
         )
 
-        assertThat(constraints.encode().decode(emptyMap())).isEqualTo(constraints)
+        assertThat(constraints.encode().decode()).isEqualTo(constraints)
     }
 }

--- a/javatests/arcs/core/policy/proto/PolicyConstraintsProtoTest.kt
+++ b/javatests/arcs/core/policy/proto/PolicyConstraintsProtoTest.kt
@@ -3,9 +3,9 @@ package arcs.core.policy.proto
 import arcs.core.data.AccessPath
 import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
-import arcs.core.policy.SelectorClaim
 import arcs.core.policy.Policy
 import arcs.core.policy.PolicyConstraints
+import arcs.core.policy.SelectorClaim
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/javatests/arcs/core/policy/proto/PolicyConstraintsProtoTest.kt
+++ b/javatests/arcs/core/policy/proto/PolicyConstraintsProtoTest.kt
@@ -3,7 +3,7 @@ package arcs.core.policy.proto
 import arcs.core.data.AccessPath
 import arcs.core.data.InformationFlowLabel.Predicate
 import arcs.core.data.InformationFlowLabel.SemanticTag
-import arcs.core.policy.PartialClaim
+import arcs.core.policy.SelectorClaim
 import arcs.core.policy.Policy
 import arcs.core.policy.PolicyConstraints
 import com.google.common.truth.Truth.assertThat
@@ -23,13 +23,13 @@ class PolicyConstraintsProtoTest {
             egressCheck = Predicate.Label(SemanticTag("public")),
             claims = mapOf(
                 "schema_name_1" to listOf(
-                    PartialClaim(
+                    SelectorClaim(
                         selectors = listOf(AccessPath.Selector.Field("a")),
                         predicate = Predicate.Label(SemanticTag("public"))
                     )
                 ),
                 "schema_name_2" to listOf(
-                    PartialClaim(
+                    SelectorClaim(
                         selectors = listOf(AccessPath.Selector.Field("b")),
                         predicate = Predicate.Label(SemanticTag("private"))
                     )


### PR DESCRIPTION
No longer needs to use the PolicyOptions object to identify ingress handles (via store IDs). Now the ingress points are computed by looking at the particle specs that are marked as having ingress. PolicyOptions will be deleted in a follow up PR.

Also updated PolicyConstraints to talk about schemas instead of store IDs, which meant updating the proto representation too.