### PR TITLE
Make `on` method suspending

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -35,7 +35,7 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
      * Registers a [ProxyCallback] with the store and returns a token which can be used to
      * unregister the callback using [off].
      */
-    abstract fun on(callback: ProxyCallback<Data, Op, ConsumerData>): Int
+    abstract suspend fun on(callback: ProxyCallback<Data, Op, ConsumerData>): Int
 
     /** Unregisters a callback associated with the given [callbackToken]. */
     abstract fun off(callbackToken: Int)

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -101,9 +101,10 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
     fun getLocalData(): Data = synchronized(this) { localModel.data }
 
-    override fun on(callback: ProxyCallback<Data, Op, T>): Int {
+    override suspend fun on(callback: ProxyCallback<Data, Op, T>): Int {
+        val callbackInvoke = callback::invoke
         synchronized(proxyManager) {
-            return proxyManager.register(callback::invoke)
+            return proxyManager.register(callbackInvoke)
         }
     }
 

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -13,7 +13,6 @@ package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
-import arcs.core.crdt.CrdtOperationAtTime
 import java.io.Closeable
 
 /** A message coming from the storage proxy into one of the [IStore] implementations. */
@@ -104,18 +103,4 @@ interface StorageEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> : C
      * Sends the storage layer a message from a [StorageProxy].
      */
     suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
-}
-
-/** Provider of a [StorageCommunicationEndpoint]s. */
-interface StorageEndpointProvider <Data : CrdtData, Op : CrdtOperationAtTime, ConsumerData> {
-    /**
-     * Returns a communications channel to an [ActiveStore] that reflects the provided
-     * [StoreOptions]. This is not necessarily an [ActiveStore] implementation, though a basic
-     * implementation may provide a simple wrapper around an in-process instance of [ActiveStore].
-     */
-    fun create(
-        callback: ProxyCallback<Data, Op, ConsumerData>
-    ): StorageEndpoint<Data, Op, ConsumerData>
-
-    val storageKey: StorageKey
 }

--- a/java/arcs/core/storage/RawEntityDereferencer.kt
+++ b/java/arcs/core/storage/RawEntityDereferencer.kt
@@ -20,9 +20,6 @@ import arcs.core.util.TaggedLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-typealias EntityStorageEndpointProvider =
-    StorageEndpointProvider<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>
-
 /**
  * [Dereferencer] to use when de-referencing a [Reference] to an [Entity].
  *
@@ -49,10 +46,9 @@ class RawEntityDereferencer(
             EntityType(schema)
         )
 
-        val store: EntityStorageEndpointProvider = storageEndpointManager.get(options)
-
         val deferred = CompletableDeferred<RawEntity?>()
-        return store.create(
+        return storageEndpointManager.get<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(
+            options,
             ProxyCallback { message ->
                 when (message) {
                     is ProxyMessage.ModelUpdate<*, *, *> -> {

--- a/java/arcs/core/storage/StorageEndpointManager.kt
+++ b/java/arcs/core/storage/StorageEndpointManager.kt
@@ -16,6 +16,7 @@ interface StorageEndpointManager {
      * implementation.
      */
     suspend fun <Data : CrdtData, Op : CrdtOperationAtTime, T> get(
-        storeOptions: StoreOptions
-    ): StorageEndpointProvider<Data, Op, T>
+        storeOptions: StoreOptions,
+        callback: ProxyCallback<Data, Op, T>
+    ): StorageEndpoint<Data, Op, T>
 }

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -109,7 +109,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         log.debug { "ServiceStore is idle" }
     }
 
-    override fun on(callback: ProxyCallback<Data, Op, ConsumerData>): Int {
+    override suspend fun on(callback: ProxyCallback<Data, Op, ConsumerData>): Int {
         val service = checkNotNull(storageService)
         return service.registerCallback(object : IStorageServiceCallback.Stub() {
             override fun onProxyMessage(proxyMessage: ByteArray) {

--- a/javatests/arcs/core/storage/FakeStorageEndpointManager.kt
+++ b/javatests/arcs/core/storage/FakeStorageEndpointManager.kt
@@ -1,0 +1,16 @@
+package arcs.core.storage
+
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperationAtTime
+
+class FakeStorageEndpointManager(
+    private val fakeEndpoint: StoreEndpointFake<*, *, *>
+) : StorageEndpointManager {
+    override suspend fun <Data : CrdtData, Op : CrdtOperationAtTime, T> get(
+        storeOptions: StoreOptions,
+        callback: ProxyCallback<Data, Op, T>
+    ): StorageEndpoint<Data, Op, T> {
+        @Suppress("UNCHECKED_CAST")
+        return fakeEndpoint as StorageEndpoint<Data, Op, T>
+    }
+}

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -63,11 +63,8 @@ class StorageProxyTest {
     @get:Rule
     val log = LogRule()
 
-    private lateinit var fakeStoreEndpoint: StoreEndpointFake<CrdtData, CrdtOperationAtTime, String>
-
-    @Mock
-    private lateinit var mockStorageEndpointProvider:
-        StorageEndpointProvider<CrdtData, CrdtOperationAtTime, String>
+    private val fakeStoreEndpoint = StoreEndpointFake<CrdtData, CrdtOperationAtTime, String>()
+    private val fakeStorageEndpointManager = FakeStorageEndpointManager(fakeStoreEndpoint)
 
     @Mock
     private lateinit var mockCrdtOperation: CrdtOperationAtTime
@@ -91,8 +88,6 @@ class StorageProxyTest {
     fun setup() {
         scheduler = Scheduler(Executors.newSingleThreadExecutor().asCoroutineDispatcher() + Job())
         MockitoAnnotations.initMocks(this)
-        fakeStoreEndpoint = StoreEndpointFake()
-        whenever(mockStorageEndpointProvider.create(any())).thenReturn(fakeStoreEndpoint)
         setupMockModel()
         whenever(mockCrdtOperation.clock).thenReturn(VersionMap())
     }
@@ -110,8 +105,12 @@ class StorageProxyTest {
         whenever(mockCrdtModel.consumerView).thenReturn("data")
     }
 
-    private fun mockProxy() = StorageProxy(
-        mockStorageEndpointProvider,
+    private suspend fun mockProxy() = StorageProxy.create(
+        StoreOptions(
+            storageKey = mockStorageKey,
+            type = mockType
+        ),
+        fakeStorageEndpointManager,
         mockCrdtModel,
         scheduler,
         mockTime
@@ -749,9 +748,12 @@ class StorageProxyTest {
                 }
             }
 
-        whenever(mockStorageEndpointProvider.storageKey).thenReturn(volatileStorageKey)
-        val proxy = StorageProxy(
-            mockStorageEndpointProvider,
+        val proxy = StorageProxy.create(
+            StoreOptions(
+                storageKey = volatileStorageKey,
+                type = mockType
+            ),
+            fakeStorageEndpointManager,
             mockCrdtModel,
             scheduler,
             mockTime,
@@ -806,10 +808,13 @@ class StorageProxyTest {
         val dbReferenceModeStorageKey =
             ReferenceModeStorageKey(dbBackingStorageKey, dbStorageKey)
 
-        whenever(mockStorageEndpointProvider.storageKey).thenReturn(dbReferenceModeStorageKey)
         val proxy =
-            StorageProxy(
-                mockStorageEndpointProvider,
+            StorageProxy.create(
+                StoreOptions(
+                    storageKey = dbReferenceModeStorageKey,
+                    type = mockType
+                ),
+                fakeStorageEndpointManager,
                 mockCrdtModel,
                 scheduler,
                 mockTime,


### PR DESCRIPTION
Having the `on` method suspend instead of block opens up the possibility
of restructuring the places that we use it to avoid deadlocks.

StorageProxy construction is fixed by making the store channel late
init, and introducing a suspending construction method that creates the
attached storage channel before returning the object.

It was also necessary to restructure `ReferenceModeStore` a bit so the
containerStore callback attachment happens in the suspendable
constructor method, as well.