### PR TITLE
[NOT FOR SUBMISSION] Read from different Arc test

### DIFF
--- a/java/arcs/core/host/AbstractArcHost.kt
+++ b/java/arcs/core/host/AbstractArcHost.kt
@@ -460,6 +460,12 @@ abstract class AbstractArcHost(
         // handles notify their underlying StorageProxy's that they will be synced at a later
         // time by the ParticleContext state machine.
         spec.handles.forEach { (handleName, handleConnection) ->
+            val storeSchema = (
+                handleConnection.handle.type as? EntitySchemaProviderType
+                          )?.entitySchema
+            println("CREATE HANDLE FOR ${spec.particleName}")
+            println("CREATE HANDLE $handleName ${handleConnection.storageKey}")
+            println("SCHEMA $storeSchema")
             createHandle(
                 context.handleManager,
                 handleName,

--- a/javatests/arcs/showcase/inline/ArcsStorage.kt
+++ b/javatests/arcs/showcase/inline/ArcsStorage.kt
@@ -2,6 +2,7 @@ package arcs.showcase.inline
 
 import arcs.showcase.ShowcaseEnvironment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 
@@ -17,26 +18,29 @@ class ArcsStorage(private val env: ShowcaseEnvironment) {
     }
 
     fun all0(): List<MyLevel0> = run {
-        env.getParticle<Reader0>(WriteRecipePlan).read()
+        env.getParticle<Reader0>(ExternalReaderPlan).read()
     }
 
     fun put0(item: MyLevel0) = run {
         env.getParticle<Writer0>(WriteRecipePlan).write(item)
+        delay(1000)
     }
 
     fun all1(): List<MyLevel1> = run {
-        env.getParticle<Reader1>(WriteRecipePlan).read()
+        env.getParticle<Reader1>(ExternalReaderPlan).read()
     }
 
     fun put1(item: MyLevel1) = run {
         env.getParticle<Writer1>(WriteRecipePlan).write(item)
+        delay(1000)
     }
 
     fun all2(): List<MyLevel2> = run {
-        env.getParticle<Reader2>(WriteRecipePlan).read()
+        env.getParticle<Reader2>(ExternalReaderPlan).read()
     }
 
     fun put2(item: MyLevel2) = run {
         env.getParticle<Writer2>(WriteRecipePlan).write(item)
+        delay(1000)
     }
 }

--- a/javatests/arcs/showcase/inline/BUILD
+++ b/javatests/arcs/showcase/inline/BUILD
@@ -14,6 +14,12 @@ arcs_kt_gen(
     srcs = ["schema.arcs"],
 )
 
+arcs_kt_gen(
+    name = "readschema_arcs_gen",
+    srcs = ["readschema.arcs"],
+    data = ["schema.arcs"]
+)
+
 arcs_kt_android_library(
     name = "particles",
     testonly = 1,
@@ -25,6 +31,7 @@ arcs_kt_android_library(
     ],
     deps = [
         ":schema_arcs_gen",
+        ":readschema_arcs_gen",
         "//java/arcs/android/sdk/host",
         "//java/arcs/android/storage/database",
         "//java/arcs/core/allocator",

--- a/javatests/arcs/showcase/inline/ReadWriteTest.kt
+++ b/javatests/arcs/showcase/inline/ReadWriteTest.kt
@@ -15,9 +15,6 @@ import org.junit.runner.RunWith
 class ReadWriteTest {
 
     @get:Rule
-    val log = LogRule()
-
-    @get:Rule
     val env = ShowcaseEnvironment(
         ::Reader0.toRegistration(),
         ::Writer0.toRegistration(),
@@ -49,5 +46,10 @@ class ReadWriteTest {
     fun writeAndReadBack2() {
         storage.put2(l2)
         assertThat(storage.all2()).containsExactly(l2)
+    }
+
+    @Test
+    fun externalParticleRead() {
+        storage.put0(l0)
     }
 }

--- a/javatests/arcs/showcase/inline/readschema.arcs
+++ b/javatests/arcs/showcase/inline/readschema.arcs
@@ -1,0 +1,28 @@
+import './schema.arcs'
+
+meta
+  namespace: arcs.showcase.inline
+
+particle Reader0 in 'arcs.showcase.inline.Reader0'
+  level0: reads [Level0]
+
+particle Reader1 in 'arcs.showcase.inline.Reader1'
+  level1: reads [Level1 {name, children}]
+
+particle Reader2 in 'arcs.showcase.inline.Reader2'
+  level2: reads [Level2 {name, children}]
+
+@arcId('readArc')
+recipe ExternalReader
+  level0: map 'level0'
+  level1: map 'level1'
+  level2: map 'level2'
+
+  Reader0
+    level0: level0
+
+  Reader1
+    level1: level1
+
+  Reader2
+    level2: level2

--- a/javatests/arcs/showcase/inline/schema.arcs
+++ b/javatests/arcs/showcase/inline/schema.arcs
@@ -3,6 +3,7 @@ meta
 
 schema Level0
   name: Text
+  name2: Text
 
 schema Level1
   name: Text
@@ -17,22 +18,13 @@ schema Level3
   children: [inline Level2]
 
 particle Writer0 in 'arcs.showcase.inline.Writer0'
-  level0: writes [Level0 {name}]
-
-particle Reader0 in 'arcs.showcase.inline.Reader0'
-  level0: reads [Level0 {name}]
+  level0: writes [Level0]
 
 particle Writer1 in 'arcs.showcase.inline.Writer1'
   level1: writes [Level1 {name, children}]
 
-particle Reader1 in 'arcs.showcase.inline.Reader1'
-  level1: reads [Level1 {name, children}]
-
 particle Writer2 in 'arcs.showcase.inline.Writer2'
   level2: writes [Level2 {name, children}]
-
-particle Reader2 in 'arcs.showcase.inline.Reader2'
-  level2: reads writes [Level2 {name, children}]
 
 @arcId('testArc')
 recipe WriteRecipe
@@ -43,17 +35,9 @@ recipe WriteRecipe
   Writer0
     level0: level0
 
-  Reader0
-    level0: level0
-
   Writer1
-    level1: level1
-
-  Reader1
     level1: level1
 
   Writer2
     level2: level2
 
-  Reader2
-    level2: level2


### PR DESCRIPTION
Split inline test so read happens from a different Arc.

Reproduces an issues we're seeing elsewhere.

If you modify the particles in schema.arcs so that the handles are
`reads writes` instead of only `writes` the tests being passing again.