### PR TITLE
Adjustments for nested 'from a in b'

### DIFF
--- a/java/arcs/core/data/expression/Evaluator.kt
+++ b/java/arcs/core/data/expression/Evaluator.kt
@@ -45,13 +45,13 @@ class ExpressionEvaluator(
 
     override fun <E : Expression.Scope, T> visit(expr: Expression.FieldExpression<E, T>): Any =
         (expr.qualifier.accept(this) as E).lookup(expr.field) ?: throw IllegalArgumentException(
-            "Field ${expr.field} not found"
+            "Field '${expr.field}' not found"
         )
 
     override fun <E> visit(expr: Expression.QueryParameterExpression<E>): Any {
         return parameterScope.lookup(expr.paramIdentifier) as? Any
             ?: throw IllegalArgumentException(
-                "Unbound parameter ${expr.paramIdentifier}"
+                "Unbound parameter '${expr.paramIdentifier}'"
             )
     }
 
@@ -67,27 +67,11 @@ class ExpressionEvaluator(
     override fun <T> visit(expr: Expression.ObjectLiteralExpression<T>): Any = expr.value as Any
 
     override fun <E, T> visit(expr: Expression.FromExpression<E, T>): Any {
-        var sequence = expr.expr.accept(this)
-
-        if (sequence is List<*>) {
-            sequence = sequence.asSequence()
-        }
-
-        require(sequence is Sequence<*>) {
-            "From source expression of type ${sequence::class} cannot be converted to a Sequence"
-        }
-
-        val fromSequence = sequence.map { value ->
-            currentScope.set(expr.iterationVar, value as Any)
-            value
-        }
-
-        return if (expr.qualifier != null) {
-            (expr.qualifier.accept(this) as Sequence<T>).flatMap {
-                fromSequence
+        return (expr.qualifier?.accept(this) as Sequence<T>? ?: sequenceOf(null)).flatMap {
+            asSequence<T>(expr.expr.accept(this)).map { value ->
+                currentScope.set(expr.iterationVar, value as Any)
+                value
             }
-        } else {
-            fromSequence
         }
     }
 
@@ -117,11 +101,21 @@ class ExpressionEvaluator(
     }
 }
 
+/** Coerces anything, including nulls and single values, to a sequence */
 private fun <T> toSequence(value: Any?) = when (value) {
-    null -> emptySequence<T>()
+    null -> emptySequence()
     is Sequence<*> -> value as Sequence<T>
     is Collection<*> -> value.asSequence() as Sequence<T>
-    else -> sequenceOf<T>(value as T)
+    else -> sequenceOf(value as T)
+}
+
+/** Transforms or casts any kind of collection (or a sequence) to a sequence */
+private fun <T> asSequence(value: Any?) = when (value) {
+    is Sequence<*> -> value as Sequence<T>
+    is Collection<*> -> value.asSequence() as Sequence<T>
+    else -> throw java.lang.IllegalArgumentException(
+        "Value '$value' cannot be converted to a sequence"
+    )
 }
 
 /** Global functions are invoked by [FunctionExpression] during evaluation. */

--- a/javatests/arcs/core/data/expression/ExpressionTest.kt
+++ b/javatests/arcs/core/data/expression/ExpressionTest.kt
@@ -37,9 +37,9 @@ class ExpressionTest {
             "blah" to 10,
             "baz" to mapOf("x" to 24).asScope(),
             "foos" to listOf(
-                mapOf("val" to 0).asScope(),
-                mapOf("val" to 10).asScope(),
-                mapOf("val" to 20).asScope()
+                mapOf("val" to 0, "words" to listOf("Lorem", "ipsum")).asScope(),
+                mapOf("val" to 10, "words" to listOf<String>()).asScope(),
+                mapOf("val" to 20, "words" to listOf("dolor", "sit", "amet")).asScope()
             ),
             "numbers" to numbers
         )
@@ -196,8 +196,21 @@ class ExpressionTest {
         // select p + foo.val
         val fromExpr = (from<Number>("p") on currentScope["numbers"].asSequence())
             .from<Number, Scope>("foo") on currentScope["foos"].asSequence() select
-            currentScope["p"].asNumber() + currentScope["foo"].asScope().get<Scope, Number>("val")
+            currentScope["p"].asNumber() + currentScope["foo"].asScope()["val"]
         assertThat(evalExpression(fromExpr, currentScope).toList()).containsExactlyElementsIn(1..30)
+    }
+
+    @Test
+    fun evaluate_paxel_from_inner() {
+        // from foo in foos
+        // from word in foo.words
+        // select word
+        val fromExpr = (from<Scope>("foo") on currentScope["foos"].asSequence())
+            .from<Scope, String>("word") on currentScope["foo"].asScope()["words"] select
+            currentScope["word"]
+        assertThat(evalExpression(fromExpr, currentScope).toList()).containsExactly(
+            "Lorem", "ipsum", "dolor", "sit", "amet"
+        )
     }
 
     @Test


### PR DESCRIPTION
Makes the evaluation of the expression (from which a scope variable is selected) lazy, so that it is re-evaluated correctly for nested `from foo in foos from bar in foo.bars` work.