### PR TITLE
Demotes the missing policy definition error to a warning.

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -930,10 +930,10 @@ ${e.message}
     if (recipeItem.verbs) {
       recipe.verbs = recipeItem.verbs;
     }
-    Manifest._buildRecipe(manifest, recipe, recipeItem.items);
+    Manifest._buildRecipe(manifest, recipe, recipeItem.items, recipeItem.location);
   }
 
-  private static _buildRecipe(manifest: Manifest, recipe: Recipe, recipeItems: AstNode.RecipeItem[]) {
+  private static _buildRecipe(manifest: Manifest, recipe: Recipe, recipeItems: AstNode.RecipeItem[], location: AstNode.SourceLocation) {
     const items = {
       require: recipeItems.filter(item => item.kind === 'require') as AstNode.RecipeRequire[],
       handles: recipeItems.filter(item => item.kind === 'handle') as AstNode.RecipeHandle[],
@@ -1342,7 +1342,7 @@ ${e.message}
     if (items.require) {
       for (const item of items.require) {
         const requireSection = recipe.newRequireSection();
-        Manifest._buildRecipe(manifest, requireSection, item.items);
+        Manifest._buildRecipe(manifest, requireSection, item.items, item.location);
       }
     }
 
@@ -1350,9 +1350,12 @@ ${e.message}
     if (policyName != null) {
       const policy = manifest.allPolicies.find(p => p.name === policyName);
       if (policy == null) {
-        throw new Error(`No policy named '${policyName}' was found in the manifest.`);
+        const warning = new ManifestWarning(location, `No policy named '${policyName}' was found in the manifest.`);
+        warning.key = 'unknownPolicyName';
+        manifest.errors.push(warning);
+      } else {
+        recipe.policy = policy;
       }
-      recipe.policy = policy;
     }
   }
 

--- a/src/runtime/recipe/recipe.ts
+++ b/src/runtime/recipe/recipe.ts
@@ -345,9 +345,6 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
     this._policy = policy;
   }
   get policy(): Policy | null {
-    if (this.policyName != null) {
-      assert(this._policy != null, `Expected policy with name '${this.policyName}' but policy was null.`);
-    }
     return this._policy;
   }
 

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -4699,11 +4699,17 @@ recipe
   });
 
   it('fails when the @policy annotation mentions an unknown policy name', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    const manifest = await Manifest.parse(`
       @policy('ThisPolicyDoesNotExist')
       recipe
         foo: create
-    `), `No policy named 'ThisPolicyDoesNotExist' was found in the manifest.`);
+    `);
+
+    assert.lengthOf(manifest.errors, 1);
+    const error = manifest.errors[0];
+    assert.strictEqual(error.severity, ErrorSeverity.Warning);
+    assert.strictEqual(error.toString(), `Error: No policy named 'ThisPolicyDoesNotExist' was found in the manifest.`);
+    assert.isNull(manifest.recipes[0].policy);
   });
 
   it('fails when the @policy annotation is missing its argument', async () => {


### PR DESCRIPTION
Previously, when you referred to a policy via the `@policy` annotation on a recipe, the policy had to be well-defined otherwise it would throw an error:

```
@policy('ThisPolicyMustExist')
recipe Foo
```

Now, if the policy is missing, this is only a warning, not an error.

Sometimes it is hard to know exactly where your policy is (or which version of a policy should be used) at the place you write your recipe. This allows developers to defer that decision until later (e.g. in a custom rule to bundle all manifests together).

Note that policy tests will still require that the policy exists, so developers ignoring this warning will need to disable policy tests.