### PR TITLE
Add restrictType to Handle Interface in recipe-lib.ts

### DIFF
--- a/src/runtime/recipe/lib-recipe.ts
+++ b/src/runtime/recipe/lib-recipe.ts
@@ -126,6 +126,7 @@ export interface Handle {
   joinDataFromHandle(handle: Handle): void;
 
   findConnectionByDirection(direction: Direction): HandleConnection;
+  restrictType(restrictedType: Type): void;
 }
 
 export interface Slot {


### PR DESCRIPTION
To fix lint/build errors, add restrict type to the interface for Handles provided in recipe-lib.ts

Missed as part of #6025

cc: @shans 