### PR TITLE
Make ProxyCallbackManager a more general CallbackManager

### DIFF
--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -20,7 +20,7 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.DirectStore.State.Name.AwaitingDriverModel
 import arcs.core.storage.DirectStore.State.Name.AwaitingResponse
 import arcs.core.storage.DirectStore.State.Name.Idle
-import arcs.core.storage.util.RandomProxyCallbackManager
+import arcs.core.storage.util.randomCallbackManager
 import arcs.core.util.Random
 import arcs.core.util.TaggedLog
 import kotlin.coroutines.coroutineContext
@@ -79,7 +79,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
     private val stateChannel =
         ConflatedBroadcastChannel<State<Data>>(State.Idle(idleDeferred, driver))
     private val stateFlow = stateChannel.asFlow()
-    private val proxyManager = RandomProxyCallbackManager<Data, Op, T>(
+    private val proxyManager = randomCallbackManager<ProxyMessage<Data, Op, T>>(
         "direct",
         Random
     )
@@ -103,7 +103,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
     override fun on(callback: ProxyCallback<Data, Op, T>): Int {
         synchronized(proxyManager) {
-            return proxyManager.register(callback)
+            return proxyManager.register(callback::invoke)
         }
     }
 

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -42,8 +42,8 @@ import arcs.core.storage.referencemode.toBridgingOps
 import arcs.core.storage.referencemode.toReferenceModeMessage
 import arcs.core.storage.util.HoldQueue
 import arcs.core.storage.util.OperationQueue
-import arcs.core.storage.util.RandomProxyCallbackManager
 import arcs.core.storage.util.SimpleQueue
+import arcs.core.storage.util.randomCallbackManager
 import arcs.core.type.Type
 import arcs.core.util.Random
 import arcs.core.util.Result
@@ -112,7 +112,7 @@ class ReferenceModeStore private constructor(
      * Registered callbacks to Storage Proxies.
      */
     private val callbacks =
-        RandomProxyCallbackManager<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>(
+        randomCallbackManager<ProxyMessage<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>>(
             "reference",
             Random
         )
@@ -183,7 +183,7 @@ class ReferenceModeStore private constructor(
 
     override fun on(
         callback: ProxyCallback<RefModeStoreData, RefModeStoreOp, RefModeStoreOutput>
-    ): Int = callbacks.register(callback)
+    ): Int = callbacks.register(callback::invoke)
 
     override fun off(callbackToken: Int) {
         callbacks.unregister(callbackToken)

--- a/java/arcs/core/storage/util/BUILD
+++ b/java/arcs/core/storage/util/BUILD
@@ -13,9 +13,6 @@ arcs_kt_library(
     deps = [
         "//java/arcs/core/common",  # buildcleaner: keep
         "//java/arcs/core/crdt",
-        "//java/arcs/core/storage:proxy",
-        "//java/arcs/core/storage:reference",
-        "//java/arcs/core/storage/referencemode",
         "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",
     ],

--- a/javatests/arcs/core/storage/util/RandomProxyCallbackManagerTest.kt
+++ b/javatests/arcs/core/storage/util/RandomProxyCallbackManagerTest.kt
@@ -13,6 +13,7 @@ package arcs.core.storage.util
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
+import arcs.core.storage.ProxyCallback
 import com.google.common.truth.Truth.assertThat
 import kotlin.random.Random
 import org.junit.Test
@@ -24,7 +25,10 @@ class RandomProxyCallbackManagerTest {
     @Test
     fun generatesNewTokens_untilUnusedOne_isFound() {
         val random = FakeRandom()
-        val manager = RandomProxyCallbackManager<CrdtData, CrdtOperation, Unit>("test", random)
+        val manager = randomCallbackManager<ProxyCallback<CrdtData, CrdtOperation, Unit>>(
+            "test",
+            random
+        )
         val used = setOf(
             "0::test".hashCode(),
             "1::test".hashCode(),


### PR DESCRIPTION
Nothing about the implementation actually depends on the callback
parameters being a proxy message, so let's make the callback parameter
type more generic.

Opens up the possibility of re-using this callback manager for any sort
of callback, not just ProxyCallbacks.