### PR TITLE
A few type-parameter simplifications in Paxel.

### DIFF
--- a/java/arcs/core/data/expression/Builders.kt
+++ b/java/arcs/core/data/expression/Builders.kt
@@ -135,17 +135,17 @@ infix fun Expression<Number>.lte(other: Expression<Number>) = Expression.BinaryE
 )
 
 /** Constructs a [Expression.BinaryExpression] with [Expression.BinaryOp.Equals]. */
-infix fun Expression<out Any>.eq(other: Expression<out Any>) = Expression.BinaryExpression(
+infix fun Expression<Any>.eq(other: Expression<Any>) = Expression.BinaryExpression(
     Expression.BinaryOp.Equals,
-    this as Expression<Any>,
-    other as Expression<Any>
+    this,
+    other
 )
 
 /** Constructs a [Expression.BinaryExpression] with [Expression.BinaryOp.NotEquals]. */
-infix fun Expression<out Any>.neq(other: Expression<out Any>) = Expression.BinaryExpression(
+infix fun Expression<Any>.neq(other: Expression<Any>) = Expression.BinaryExpression(
     Expression.BinaryOp.NotEquals,
-    this as Expression<Any>,
-    other as Expression<Any>
+    this,
+    other
 )
 
 /** Constructs a [Expression.FieldExpression] given a [Scope] and [field]. */
@@ -206,35 +206,35 @@ fun <T> Map<String, T>.asScope(scopeName: String = "<object>") = MapScope(
 fun <T> query(queryArgName: String) = Expression.QueryParameterExpression<T>(queryArgName)
 
 /** Helper used to build [FromExpression]. */
-data class FromBuilder<T, Q>(val iterName: String, val qualifier: Expression<Sequence<Q>>?)
+data class FromBuilder(val iterName: String, val qualifier: Expression<Sequence<Unit>>?)
 
 /** Build a [FromExpression] whose [Sequence] iterates using a scope variable named [iterName]. */
-fun <T> from(iterName: String) = FromBuilder<T, T>(iterName, null)
+fun from(iterName: String) = FromBuilder(iterName, null)
 
 /** Build a nested [FromExpression] whose [Sequence] iterates a scope variable named [iterName]. */
-fun <Q, T> Expression<Sequence<Q>>.from(iterName: String) = FromBuilder<T, Q>(iterName, this)
+infix fun Expression<Sequence<Unit>>.from(iterName: String) = FromBuilder(iterName, this)
 
 /** Designates the expression which holds the [Sequence] the from expression iterates on. */
-infix fun <T, Q> FromBuilder<T, Q>.on(sequence: Expression<Sequence<T>>) =
-    Expression.FromExpression<Q, T>(this.qualifier, sequence, this.iterName)
+infix fun FromBuilder.on(sequence: Expression<Sequence<Any>>) =
+    Expression.FromExpression(this.qualifier, sequence, this.iterName)
 
 /** Constructs a [WhereExpression]. */
-infix fun <T> Expression<Sequence<T>>.where(expr: Expression<Boolean>) =
+infix fun Expression<Sequence<Unit>>.where(expr: Expression<Boolean>) =
     Expression.WhereExpression(this, expr)
 
 /** Constructs a [SelectExpression]. */
-infix fun <E, T> Expression<Sequence<E>>.select(expr: Expression<T>) =
+infix fun <T> Expression<Sequence<Unit>>.select(expr: Expression<T>) =
     Expression.SelectExpression(this, expr)
 
 /** Helper to construct [NewExpression]. */
-data class NewBuilder<E, T>(val schemaNames: Set<String>) {
+data class NewBuilder(val schemaNames: Set<String>) {
     operator fun invoke(
         block: () -> List<Pair<String, Expression<*>>>
-    ): Expression<T> = Expression.NewExpression(schemaNames, block())
+    ): Expression<Scope> = Expression.NewExpression(schemaNames, block())
 }
 
 /** Constructs a [NewBuilder] for the given [schemaName]. */
-fun <E, T> new(vararg schemaNames: String) = NewBuilder<E, T>(schemaNames.toSet())
+fun new(vararg schemaNames: String) = NewBuilder(schemaNames.toSet())
 
 /** Constructs a [FunctionExpression] to invoke [Max]. */
 fun max(expr: Expression<*>) = FunctionExpression<Number>(Max, listOf(expr))

--- a/java/arcs/core/data/expression/Expression.kt
+++ b/java/arcs/core/data/expression/Expression.kt
@@ -21,7 +21,7 @@ import java.math.BigInteger
  *
  * @param T the resulting type of the expression.
  */
-sealed class Expression<T> {
+sealed class Expression<out T> {
 
     /**
      * Implementors denote sub-properties that may be looked up. This is not necessarily limited
@@ -72,19 +72,19 @@ sealed class Expression<T> {
         fun <T> visit(expr: ObjectLiteralExpression<T>): Result
 
         /** Called when [FromExpression] encountered. */
-        fun <E, T> visit(expr: FromExpression<E, T>): Result
+        fun visit(expr: FromExpression): Result
 
         /** Called when [WhereExpression] encountered. */
-        fun <T> visit(expr: WhereExpression<T>): Result
+        fun visit(expr: WhereExpression): Result
 
         /** Called when [SelectExpression] encountered. */
-        fun <E, T> visit(expr: SelectExpression<E, T>): Result
+        fun <T> visit(expr: SelectExpression<T>): Result
 
         /** Called when [FunctionExpression] encountered. */
         fun <T> visit(expr: FunctionExpression<T>): Result
 
         /** Called when [NewExpression] encountered. */
-        fun <T> visit(expr: NewExpression<T>): Result
+        fun visit(expr: NewExpression): Result
     }
 
     /** Accepts a visitor and invokes the appropriate [Visitor.visit] method. */
@@ -348,23 +348,20 @@ sealed class Expression<T> {
     }
 
     /** Subtypes represent a [Expression]s that operate over the result of the [qualifier]. */
-    interface QualifiedExpression<T> {
-        val qualifier: Expression<Sequence<T>>?
+    interface QualifiedExpression {
+        val qualifier: Expression<Sequence<Unit>>?
     }
 
     /**
      * Represents an iteration over a [Sequence] in the current scope under the identifier [source],
-     * placing each member of the sequence in a scope under [iterationVar] and evaluating
-     * [iterationExpr], returning a new sequence.
-     *
-     * @param E the type of the [qualifier] expression if any
-     * @param T the type of elements in the resulting [Sequence]
+     * placing each member of the sequence in a scope under [iterationVar] and returning
+     * a new sequence.
      */
-    data class FromExpression<E, T>(
-        override val qualifier: Expression<Sequence<E>>?,
-        val expr: Expression<Sequence<T>>,
+    data class FromExpression(
+        override val qualifier: Expression<Sequence<Unit>>?,
+        val source: Expression<Sequence<Any>>,
         val iterationVar: String
-    ) : QualifiedExpression<E>, Expression<Sequence<T>>() {
+    ) : QualifiedExpression, Expression<Sequence<Unit>>() {
         override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
         override fun toString() = this.stringify()
     }
@@ -374,10 +371,10 @@ sealed class Expression<T> {
      *
      * @param T the type of elements in the [qualfier] [Sequence].
      */
-    data class WhereExpression<T>(
-        override val qualifier: Expression<Sequence<T>>,
+    data class WhereExpression(
+        override val qualifier: Expression<Sequence<Unit>>,
         val expr: Expression<Boolean>
-    ) : QualifiedExpression<T>, Expression<Sequence<T>>() {
+    ) : QualifiedExpression, Expression<Sequence<Unit>>() {
         override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
         override fun toString() = this.stringify()
     }
@@ -385,13 +382,12 @@ sealed class Expression<T> {
     /**
      * Represents an expression that outputs a value.
      *
-     * @param E the type of elements in the [qualfier] [Sequence]
      * @param T the type of the new elements in the sequence
      */
-    data class SelectExpression<E, T>(
-        override val qualifier: Expression<Sequence<E>>,
+    data class SelectExpression<T>(
+        override val qualifier: Expression<Sequence<Unit>>,
         val expr: Expression<T>
-    ) : QualifiedExpression<E>, Expression<Sequence<T>>() {
+    ) : QualifiedExpression, Expression<Sequence<T>>() {
         override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
         override fun toString() = this.stringify()
     }
@@ -399,13 +395,11 @@ sealed class Expression<T> {
     /**
      * Represents an expression that constructs a new value corresponding to the given
      * [schemaName] with a field for each declared (name, expression) in [fields].
-     *
-     * @param T the type of the new elements in the [Sequence]
      */
-    data class NewExpression<T>(
+    data class NewExpression(
         val schemaName: Set<String>,
         val fields: List<Pair<String, Expression<*>>>
-    ) : Expression<T>() {
+    ) : Expression<Scope>() {
         override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
         override fun toString() = this.stringify()
     }

--- a/java/arcs/core/data/expression/Serializer.kt
+++ b/java/arcs/core/data/expression/Serializer.kt
@@ -80,17 +80,17 @@ class ExpressionSerializer() : Expression.Visitor<JsonValue<*>> {
     override fun <T> visit(expr: Expression.ObjectLiteralExpression<T>) =
         throw IllegalArgumentException("Can't serialize an ObjectLiteralExpression")
 
-    override fun <T, R> visit(expr: Expression.FromExpression<T, R>) =
+    override fun visit(expr: Expression.FromExpression) =
         JsonObject(
             mapOf(
                 "op" to JsonString("from"),
-                "source" to expr.expr.accept(this),
+                "source" to expr.source.accept(this),
                 "var" to JsonString(expr.iterationVar),
                 "qualifier" to (expr.qualifier?.accept(this) ?: JsonNull)
             )
         )
 
-    override fun <T> visit(expr: Expression.WhereExpression<T>) =
+    override fun visit(expr: Expression.WhereExpression) =
         JsonObject(
             mapOf(
                 "op" to JsonString("where"),
@@ -99,7 +99,7 @@ class ExpressionSerializer() : Expression.Visitor<JsonValue<*>> {
             )
         )
 
-    override fun <E, T> visit(expr: Expression.SelectExpression<E, T>) =
+    override fun <T> visit(expr: Expression.SelectExpression<T>) =
         JsonObject(
             mapOf(
                 "op" to JsonString("select"),
@@ -108,7 +108,7 @@ class ExpressionSerializer() : Expression.Visitor<JsonValue<*>> {
             )
         )
 
-    override fun <T> visit(expr: Expression.NewExpression<T>) =
+    override fun visit(expr: Expression.NewExpression) =
         JsonObject(
             mapOf(
                 "op" to JsonString("new"),
@@ -165,27 +165,27 @@ class ExpressionDeserializer : JsonVisitor<Expression<*>> {
             type == "this" -> Expression.CurrentScopeExpression<Expression.Scope>()
             type == "?" -> Expression.QueryParameterExpression<Any>(value["identifier"].string()!!)
             type == "from" ->
-                Expression.FromExpression<Any, Any>(
+                Expression.FromExpression(
                     if (value["qualifier"] == JsonNull) {
                         null
                     } else {
-                        visit(value["qualifier"].obj()!!) as Expression<Sequence<Any>>
+                        visit(value["qualifier"].obj()!!) as Expression<Sequence<Unit>>
                     },
                     visit(value["source"].obj()!!) as Expression<Sequence<Any>>,
                     value["var"].string()!!
                 )
             type == "where" ->
                 Expression.WhereExpression(
-                    visit(value["qualifier"].obj()!!) as Expression<Sequence<Any>>,
+                    visit(value["qualifier"].obj()!!) as Expression<Sequence<Unit>>,
                     visit(value["expr"]) as Expression<Boolean>
                 )
             type == "select" ->
                 Expression.SelectExpression(
-                    visit(value["qualifier"].obj()!!) as Expression<Sequence<Any>>,
+                    visit(value["qualifier"].obj()!!) as Expression<Sequence<Unit>>,
                     visit(value["expr"]) as Expression<Sequence<Any>>
                 )
             type == "new" ->
-                Expression.NewExpression<Any>(
+                Expression.NewExpression(
                     value["schemaName"].array()!!.value.map { it.string()!! }.toSet(),
                     value["expr"].obj()!!.value.map { (name, expr) ->
                         name to visit(expr)

--- a/java/arcs/core/data/expression/Stringifier.kt
+++ b/java/arcs/core/data/expression/Stringifier.kt
@@ -47,17 +47,17 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
     override fun <T> visit(expr: Expression.ObjectLiteralExpression<T>) =
         (expr.value as? Expression.Scope)?.scopeName ?: "<object>"
 
-    override fun <T, R> visit(expr: Expression.FromExpression<T, R>): String =
+    override fun visit(expr: Expression.FromExpression): String =
         (expr.qualifier?.accept(this) ?: "") +
-            "\nfrom ${expr.iterationVar} in ${expr.expr.accept(this)}\n"
+            "\nfrom ${expr.iterationVar} in ${expr.source.accept(this)}\n"
 
-    override fun <T> visit(expr: Expression.WhereExpression<T>): String =
+    override fun visit(expr: Expression.WhereExpression): String =
         expr.qualifier.accept(this) + "\nwhere " + expr.expr.accept(this) + "\n"
 
-    override fun <E, T> visit(expr: Expression.SelectExpression<E, T>): String =
+    override fun <T> visit(expr: Expression.SelectExpression<T>): String =
         expr.qualifier.accept(this) + "\nselect " + expr.expr.accept(this) + "\n"
 
-    override fun <T> visit(expr: Expression.NewExpression<T>): String =
+    override fun visit(expr: Expression.NewExpression): String =
         "new " + expr.schemaName.joinToString(" ") + expr.fields.joinToString(
             ", \n",
             "{\n",

--- a/javatests/arcs/core/data/expression/EvaluatorParticleTest.kt
+++ b/javatests/arcs/core/data/expression/EvaluatorParticleTest.kt
@@ -41,24 +41,21 @@ class EvaluatorParticleTest {
         //   from x in inputNumbers select new Value {
         //     value: x.value * scalar.magnitude
         //   }
-        val scaledNumbersExpression = from<Number>("x") on
-            seq("inputNumbers") select
-            new<Number, Scope>("Value")() {
+        val scaledNumbersExpression = from("x") on seq("inputNumbers") select
+            new("Value")() {
                 listOf(
-                    "value" to scope("x")
-                        .get<Scope, Expression<*>>("value").asNumber() *
+                    "value" to scope("x").get<Scope, Number>("value") *
                         scope("scalar")["magnitude"]
                 )
             }
 
         // average: writes Average {average: Number} =
         //   Average(from x in inputNumbers select x.value)
-        val averageExpression = new<Number, Scope>("Average")() {
+        val averageExpression = new("Average")() {
             listOf(
                 "average" to average(
-                    from<Number>("x") on seq("inputNumbers")
-                        select (scope("x")
-                        .get<Scope, Number>("value"))
+                    from("x") on seq("inputNumbers")
+                        select (scope("x").get<Scope, Number>("value"))
                 )
             )
         }

--- a/javatests/arcs/core/data/expression/ExpressionTest.kt
+++ b/javatests/arcs/core/data/expression/ExpressionTest.kt
@@ -183,7 +183,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_from() {
-        val fromExpr = from<Number>("p") on lookup("numbers")
+        val fromExpr = from("p") on lookup("numbers") select num("p")
         assertThat(
             evalExpression(fromExpr, currentScope).toList()
         ).isEqualTo(numbers)
@@ -194,9 +194,8 @@ class ExpressionTest {
         // from p in numbers
         // from foo in foos
         // select p + foo.val
-        val fromExpr = (from<Number>("p") on lookup("numbers"))
-            .from<Number, Scope>("foo") on lookup("foos") select
-            num("p") + scope("foo")["val"]
+        val fromExpr = from("p") on lookup("numbers") from("foo") on
+            lookup("foos") select (num("p") + scope("foo")["val"])
         assertThat(evalExpression(fromExpr, currentScope).toList()).containsExactlyElementsIn(1..30)
     }
 
@@ -205,8 +204,7 @@ class ExpressionTest {
         // from foo in foos
         // from word in foo.words
         // select word
-        val fromExpr = (from<Scope>("foo") on lookup("foos"))
-            .from<Scope, String>("word") on scope("foo")["words"] select
+        val fromExpr = from("foo") on lookup("foos") from("word") on scope("foo")["words"] select
             text("word")
         assertThat(evalExpression(fromExpr, currentScope).toList()).containsExactly(
             "Lorem", "ipsum", "dolor", "sit", "amet"
@@ -215,7 +213,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_select() {
-        val selectExpr = from<Number>("p") on lookup("numbers") select 1.asExpr()
+        val selectExpr = from("p") on lookup("numbers") select 1.asExpr()
         assertThat(
             evalExpression(selectExpr, currentScope).toList()
         ).isEqualTo(numbers.map { 1 })
@@ -223,8 +221,8 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_where() {
-        val whereExpr = from<Number>("p") on lookup("numbers") where
-            (num("p") eq 5.asExpr())
+        val whereExpr = from("p") on lookup("numbers") where
+            (num("p") eq 5.asExpr()) select num("p")
         assertThat(
             evalExpression(whereExpr, currentScope).toList()
         ).isEqualTo(listOf(5))
@@ -232,7 +230,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_max() {
-        val selectMaxExpr = from<Number>("p") on lookup("numbers") select
+        val selectMaxExpr = from("p") on lookup("numbers") select
             max(seq<Number>("numbers"))
 
         assertThat(
@@ -242,7 +240,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_count() {
-        val selectCountExpr = from<Number>("p") on lookup("numbers") select
+        val selectCountExpr = from("p") on lookup("numbers") select
             count(seq<Number>("numbers"))
 
         assertThat(
@@ -255,7 +253,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_min() {
-        val selectMinExpr = from<Number>("p") on lookup("numbers") select
+        val selectMinExpr = from("p") on lookup("numbers") select
             min(seq<Number>("numbers"))
 
         assertThat(
@@ -265,7 +263,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_average() {
-        val selectAvgExpr = from<Number>("p") on lookup("numbers") select
+        val selectAvgExpr = from("p") on lookup("numbers") select
             average(seq<Number>("numbers"))
 
         assertThat(
@@ -276,7 +274,7 @@ class ExpressionTest {
     @Test
     fun evaluate_paxel_average_onComplexExpression() {
         val selectAvgExpr = average(
-            from<Number>("p") on lookup("numbers")
+            from("p") on lookup("numbers")
             select num("p") + 10.asExpr()
         )
         assertThat(
@@ -295,10 +293,10 @@ class ExpressionTest {
 
     @Test
     fun evaluate_paxel_union() {
-        val lessThan8 = from<Number>("p") on lookup("numbers") where
-            (num("p") lt 8.asExpr())
-        val greaterThan6 = from<Number>("p") on lookup("numbers") where
-            (num("p") gt 6.asExpr())
+        val lessThan8 = from("p") on lookup("numbers") where
+            (num("p") lt 8.asExpr()) select num("p")
+        val greaterThan6 = from("p") on lookup("numbers") where
+            (num("p") gt 6.asExpr()) select num("p")
         val unionExpr = union(lessThan8, greaterThan6)
 
         assertThat(
@@ -316,8 +314,8 @@ class ExpressionTest {
         //   y: p + 2
         //   z: COUNT(numbers)
         // }
-        val paxelExpr = from<Number>("p") on lookup("numbers") where
-            (num("p") lt 5.asExpr()) select new<Number, Scope>("Example")() {
+        val paxelExpr = from("p") on lookup("numbers") where
+            (num("p") lt 5.asExpr()) select new("Example")() {
             listOf(
                 "x" to num("p") + 1.asExpr(),
                 "y" to num("p") + 2.asExpr(),

--- a/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
+++ b/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
@@ -19,11 +19,11 @@ import arcs.core.data.expression.div
 import arcs.core.data.expression.eq
 import arcs.core.data.expression.from
 import arcs.core.data.expression.get
-import arcs.core.data.expression.lookup
 import arcs.core.data.expression.new
 import arcs.core.data.expression.on
 import arcs.core.data.expression.scope
 import arcs.core.data.expression.select
+import arcs.core.data.expression.seq
 import arcs.core.data.expression.where
 import arcs.core.host.toRegistration
 import arcs.core.testutil.handles.dispatchFetchAll
@@ -109,11 +109,10 @@ class ExpressionShowcaseTest {
         //    statePopulationRatio: county.population / state.population
         //  }
         val calculateStats =
-            ((from<Scope>("state") on lookup("states"))
-                .from<Scope, Scope>("county") on lookup("counties")) where (
+            from("state") on seq<Scope>("states") from("county") on seq<Scope>("counties") where (
                 scope("county").get<Scope, String>("stateCode") eq
-                scope("state").get<Scope, String>("code")) select
-            new<Scope, Scope>("CountyStats")() {
+                scope("state").get<Scope, String>("code")
+            ) select new("CountyStats")() {
                 listOf(
                     "name" to scope("county").get<Scope, String>("name"),
                     "state" to scope("state").get<Scope, String>("name"),


### PR DESCRIPTION
Simplifications in type parameters in Paxel:
* FROM and WHERE become `Expression<Sequence<Unit>>` - they don't yield results until SELECT is called.
* NEW becomes Expression<Scope>, as it's always used for creating new Entities, which are represented as Scopes.

Also some related changes:
* `Expression<T>` is now `Expression<out T>`
* Nested from can now be an infix function
