### PR TITLE
A few simplifications to Paxel

### DIFF
--- a/java/arcs/core/data/expression/Builders.kt
+++ b/java/arcs/core/data/expression/Builders.kt
@@ -148,38 +148,25 @@ infix fun Expression<Any>.neq(other: Expression<Any>) = Expression.BinaryExpress
     other
 )
 
-/** Constructs a [Expression.FieldExpression] given a [Scope] and [field]. */
-operator fun <E : Scope, T> E.get(field: String) = Expression.FieldExpression<E, T>(
-    when (this) {
-        is CurrentScope<*> -> Expression.CurrentScopeExpression()
-        is MapScope<*> -> Expression.ObjectLiteralExpression(this as E)
-        else -> this as Expression<E>
-    }, field)
-
 /** Constructs a [Expression.FieldExpression] given an [Expression] and [field]. */
-operator fun <E : Scope, T> Expression<E>.get(field: String) =
-    Expression.FieldExpression<E, T>(this, field)
+operator fun <T> Expression<Scope>.get(field: String) =
+    Expression.FieldExpression<T>(this, field)
 
 /** Constructs a [Expression.FieldExpression] from a field lookup in a current scope. */
 fun <T> lookup(field: String) =
-    Expression.FieldExpression<CurrentScope<T>, T>(Expression.CurrentScopeExpression(), field)
-
-fun num(field: String) = lookup<Number>(field)
-fun scope(field: String) = lookup<Scope>(field)
-fun text(field: String) = lookup<String>(field)
-fun <T> seq(field: String) = lookup<Sequence<T>>(field)
+    Expression.FieldExpression<T>(null, field)
 
 /** Cast a Field lookup expression to return a Number. */
-fun <E : Scope, T> Expression.FieldExpression<E, T>.asNumber() =
-    this as Expression.FieldExpression<E, Number>
-
-/** Cast a Field lookup expression to return a Sequence. */
-fun <R> Expression.FieldExpression<CurrentScope<Any>, Any>.asSequence() =
-    this as Expression.FieldExpression<Scope, Sequence<R>>
+fun num(field: String) = lookup<Number>(field)
 
 /** Cast a Field lookup expression to return another [Scope]. */
-fun <E : Scope, T> Expression.FieldExpression<E, T>.asScope() =
-    this as Expression.FieldExpression<E, Scope>
+fun scope(field: String) = lookup<Scope>(field)
+
+/** Cast a Field lookup expression to return a String. */
+fun text(field: String) = lookup<String>(field)
+
+/** Cast a Field lookup expression to return a Sequence. */
+fun <T> seq(field: String) = lookup<Sequence<T>>(field)
 
 /** Constructs a reference to a current scope object for test purposes */
 class CurrentScope<V>(map: MutableMap<String, V>) : MapScope<V>("<this>", map)
@@ -229,8 +216,8 @@ infix fun <T> Expression<Sequence<Unit>>.select(expr: Expression<T>) =
 /** Helper to construct [NewExpression]. */
 data class NewBuilder(val schemaNames: Set<String>) {
     operator fun invoke(
-        block: () -> List<Pair<String, Expression<*>>>
-    ): Expression<Scope> = Expression.NewExpression(schemaNames, block())
+        vararg fields: Pair<String, Expression<*>>
+    ): Expression<Scope> = Expression.NewExpression(schemaNames, fields.asList())
 }
 
 /** Constructs a [NewBuilder] for the given [schemaName]. */

--- a/java/arcs/core/data/expression/Serializer.kt
+++ b/java/arcs/core/data/expression/Serializer.kt
@@ -47,19 +47,12 @@ class ExpressionSerializer() : Expression.Visitor<JsonValue<*>> {
             )
         )
 
-    override fun <E : Expression.Scope, T> visit(expr: Expression.FieldExpression<E, T>) =
+    override fun <T> visit(expr: Expression.FieldExpression<T>) =
         JsonObject(
             mapOf(
                 "op" to JsonString("."),
-                "qualifier" to expr.qualifier.accept(this),
+                "qualifier" to (expr.qualifier?.accept(this) ?: JsonNull),
                 "field" to JsonString(expr.field)
-            )
-        )
-
-    override fun <E : Expression.Scope> visit(expr: Expression.CurrentScopeExpression<E>) =
-        JsonObject(
-            mapOf(
-                "op" to JsonString("this")
             )
         )
 
@@ -76,9 +69,6 @@ class ExpressionSerializer() : Expression.Visitor<JsonValue<*>> {
     override fun visit(expr: Expression.TextLiteralExpression) = JsonString(expr.value)
 
     override fun visit(expr: Expression.BooleanLiteralExpression) = JsonBoolean(expr.value)
-
-    override fun <T> visit(expr: Expression.ObjectLiteralExpression<T>) =
-        throw IllegalArgumentException("Can't serialize an ObjectLiteralExpression")
 
     override fun visit(expr: Expression.FromExpression) =
         JsonObject(
@@ -145,8 +135,13 @@ class ExpressionDeserializer : JsonVisitor<Expression<*>> {
         val type = value["op"].string()!!
 
         return when {
-            type == "." -> Expression.FieldExpression<Expression.Scope, Any>(
-                visit(value["qualifier"]) as Expression<Expression.Scope>, value["field"].string()!!
+            type == "." -> Expression.FieldExpression<Any>(
+                if (value["qualifier"] == JsonNull) {
+                    null
+                } else {
+                    visit(value["qualifier"]) as Expression<Expression.Scope>
+                },
+                value["field"].string()!!
             )
             BinaryOp.fromToken(type) != null -> {
                 BinaryExpression(
@@ -162,7 +157,6 @@ class ExpressionDeserializer : JsonVisitor<Expression<*>> {
                 )
             }
             type == "number" -> Expression.NumberLiteralExpression(fromNumber(value))
-            type == "this" -> Expression.CurrentScopeExpression<Expression.Scope>()
             type == "?" -> Expression.QueryParameterExpression<Any>(value["identifier"].string()!!)
             type == "from" ->
                 Expression.FromExpression(

--- a/java/arcs/core/data/expression/Stringifier.kt
+++ b/java/arcs/core/data/expression/Stringifier.kt
@@ -30,10 +30,12 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
     override fun <L, R, T> visit(expr: Expression.BinaryExpression<L, R, T>) =
         maybeParen(expr.left) + " ${expr.op.token} " + maybeParen(expr.right)
 
-    override fun <E : Expression.Scope, T> visit(expr: Expression.FieldExpression<E, T>) =
-        expr.qualifier.accept(this) + ".${expr.field}"
-
-    override fun <T : Expression.Scope> visit(expr: Expression.CurrentScopeExpression<T>) = "this"
+    override fun <T> visit(expr: Expression.FieldExpression<T>) =
+        if (expr.qualifier != null) {
+            "${expr.qualifier.accept(this)}.${expr.field}"
+        } else {
+            expr.field
+        }
 
     override fun <T> visit(expr: Expression.QueryParameterExpression<T>) =
         "?${expr.paramIdentifier}"
@@ -43,9 +45,6 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
     override fun visit(expr: Expression.TextLiteralExpression) = "\"${expr.value}\""
 
     override fun visit(expr: Expression.BooleanLiteralExpression) = expr.value.toString()
-
-    override fun <T> visit(expr: Expression.ObjectLiteralExpression<T>) =
-        (expr.value as? Expression.Scope)?.scopeName ?: "<object>"
 
     override fun visit(expr: Expression.FromExpression): String =
         (expr.qualifier?.accept(this) ?: "") +

--- a/java/arcs/core/util/Json.kt
+++ b/java/arcs/core/util/Json.kt
@@ -90,7 +90,9 @@ sealed class JsonValue<T>() {
     }
 
     /** Used to represent custom (potentially non-standard) Json values. */
-    open class JsonAny<T>(override val value: T) : JsonValue<T>()
+    open class JsonAny<T>(override val value: T) : JsonValue<T>() {
+        override fun toString() = value.toString()
+    }
 
     /** Used to to represent a Json array .*/
     data class JsonArray(

--- a/javatests/arcs/core/data/expression/EvaluatorParticleTest.kt
+++ b/javatests/arcs/core/data/expression/EvaluatorParticleTest.kt
@@ -14,7 +14,6 @@ package arcs.core.data.expression
 import arcs.core.data.Plan
 import arcs.core.data.expression.AbstractNumberSetMultiplier.Scalar
 import arcs.core.data.expression.AbstractNumberSetMultiplier.Value
-import arcs.core.data.expression.Expression.Scope
 import arcs.core.testutil.handles.dispatchFetch
 import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
@@ -42,23 +41,19 @@ class EvaluatorParticleTest {
         //     value: x.value * scalar.magnitude
         //   }
         val scaledNumbersExpression = from("x") on seq("inputNumbers") select
-            new("Value")() {
-                listOf(
-                    "value" to scope("x").get<Scope, Number>("value") *
-                        scope("scalar")["magnitude"]
-                )
-            }
+            new("Value")(
+                "value" to scope("x").get<Number>("value") *
+                    scope("scalar")["magnitude"]
+            )
 
         // average: writes Average {average: Number} =
         //   Average(from x in inputNumbers select x.value)
-        val averageExpression = new("Average")() {
-            listOf(
-                "average" to average(
-                    from("x") on seq("inputNumbers")
-                        select (scope("x").get<Scope, Number>("value"))
-                )
+        val averageExpression = new("Average")(
+            "average" to average(
+                from("x") on seq("inputNumbers")
+                    select (scope("x").get<Number>("value"))
             )
-        }
+        )
 
         return Plan.Particle.handlesLens.mod(particle) {
             mapOf(

--- a/javatests/arcs/core/data/expression/ExpressionTest.kt
+++ b/javatests/arcs/core/data/expression/ExpressionTest.kt
@@ -74,10 +74,8 @@ class ExpressionTest {
     @Test
     fun evaluate_fieldOps() {
         // field ops
-        assertThat(evalNum<Number>(mapOf("foo" to 42).asScope()["foo"])).isEqualTo(42)
         assertThat(evalNum(num("blah"))).isEqualTo(10)
-        val baz = scope("baz")
-        assertThat(evalNum<Number>(baz["x"])).isEqualTo(24)
+        assertThat(evalNum<Number>(scope("baz").get<Number>("x"))).isEqualTo(24)
     }
 
     @Test
@@ -172,13 +170,12 @@ class ExpressionTest {
     @Test
     fun evaluate_complexExpression() {
         // Test complex expression
-        // (2 + (3 * 4) + scope.foo + ?arg - 1) / 2
-        val obj = mapOf("foo" to 42).asScope("handle")
-        val expr = (2.0.asExpr() + (3.asExpr() * 4.asExpr()) + obj["foo"] + query(
+        // (2 + (3 * 4) + blah + ?arg - 1) / 2
+        val expr = (2.0.asExpr() + (3.asExpr() * 4.asExpr()) + num("blah") + query(
             "arg"
         ) - 1.asExpr()) / 2.asExpr()
 
-        assertThat(evalExpression(expr, currentScope, "arg" to 1)).isEqualTo(28)
+        assertThat(evalExpression(expr, currentScope, "arg" to 1)).isEqualTo(12)
     }
 
     @Test
@@ -315,13 +312,11 @@ class ExpressionTest {
         //   z: COUNT(numbers)
         // }
         val paxelExpr = from("p") on lookup("numbers") where
-            (num("p") lt 5.asExpr()) select new("Example")() {
-            listOf(
+            (num("p") lt 5.asExpr()) select new("Example")(
                 "x" to num("p") + 1.asExpr(),
                 "y" to num("p") + 2.asExpr(),
                 "z" to count(seq<Number>("numbers"))
             )
-        }
 
         assertThat(
             evalExpression(paxelExpr, currentScope).toList().map {
@@ -337,8 +332,7 @@ class ExpressionTest {
 
     @Test
     fun evaluate_ExpressionWithScopeLookupError_throws() {
-        val obj = mapOf("foo" to 42).asScope("handle")
-        val expr = 1.asExpr() + obj["bar"]
+        val expr = 1.asExpr() + lookup("noSuchThing")
         assertFailsWith<IllegalArgumentException> {
             evalNum(expr)
         }
@@ -356,10 +350,8 @@ class ExpressionTest {
     fun stringify() {
         // Test Math binary ops, field lookups, and parameter lookups
         // (2 + (3 * 4) + scope.foo + ?arg - 1) / 2
-        val obj = mapOf("foo" to 42).asScope("handle")
-        val expr = (2.0.asExpr() + (3.asExpr() * 4.asExpr()) + obj["foo"] + query(
-            "arg"
-        ) - 1.asExpr()) / 2.asExpr()
+        val expr = (2.0.asExpr() + (3.asExpr() * 4.asExpr()) +
+            scope("handle").get<Number>("foo") + query("arg") - 1.asExpr()) / 2.asExpr()
         assertThat(expr.toString()).isEqualTo("((((2.0 + (3 * 4)) + handle.foo) + ?arg) - 1) / 2")
     }
 
@@ -367,9 +359,8 @@ class ExpressionTest {
     @Suppress("UNCHECKED_CAST")
     fun serialization_roundTrip() {
         val q = query<Scope>("arg")
-        val field = Expression.FieldExpression<Scope, Number>(q, "bar")
-        val baz = scope("baz")
-        val x: Expression<Number> = baz["x"]
+        val field = Expression.FieldExpression<Number>(q, "bar")
+        val x: Expression<Number> = scope("baz")["x"]
         val expr = (x + 2.0.asExpr() + (3f.asExpr() * 4L.asExpr()) + field - 1.toByte().asExpr()) /
             2.toBigInteger().asExpr()
         val json = expr.serialize()

--- a/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
+++ b/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
@@ -109,24 +109,23 @@ class ExpressionShowcaseTest {
         //    statePopulationRatio: county.population / state.population
         //  }
         val calculateStats =
-            from("state") on seq<Scope>("states") from("county") on seq<Scope>("counties") where (
-                scope("county").get<Scope, String>("stateCode") eq
-                scope("state").get<Scope, String>("code")
-            ) select new("CountyStats")() {
-                listOf(
-                    "name" to scope("county").get<Scope, String>("name"),
-                    "state" to scope("state").get<Scope, String>("name"),
-                    "density" to
-                        scope("county").get<Scope, Number>("population") /
-                        scope("county")["areaSqMi"],
-                    "stateAreaRatio" to
-                        scope("county").get<Scope, Number>("areaSqMi") /
-                        scope("state")["areaSqMi"],
-                    "statePopulationRatio" to
-                        scope("county").get<Scope, Number>("population") /
-                        scope("state")["population"]
-                )
-            }
+            from("state") on seq<Scope>("states") from("county") on
+                seq<Scope>("counties") where (
+                scope("county").get<String>("stateCode") eq
+                scope("state").get<String>("code")
+            ) select new("CountyStats")(
+                "name" to scope("county").get<String>("name"),
+                "state" to scope("state").get<String>("name"),
+                "density" to
+                    scope("county").get<Number>("population") /
+                    scope("county")["areaSqMi"],
+                "stateAreaRatio" to
+                    scope("county").get<Number>("areaSqMi") /
+                    scope("state")["areaSqMi"],
+                "statePopulationRatio" to
+                    scope("county").get<Number>("population") /
+                    scope("state")["population"]
+            )
 
         // Adds the above expression to the CountiesStatsCalculator.output connection.
         val planWithExpression = Plan.particleLens.mod(StatsCalculationPlan) { particles ->


### PR DESCRIPTION
List:
* Removes ObjectLiteralExpression - it's not needed anymore
* Removes CurrentScopeExpression - can be signified with null on FieldExpression
* Fixes the first type argument of FieldExpression to be `Scope`, as we always look up on scopes and subclasses don't need to be used in typing of expressions.
* Changes the NewExpression builder to avoid extra `listOf()`