### PR TITLE
Parse from/where/select/new

### DIFF
--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -350,7 +350,7 @@ export interface ParticleHandleConnection extends BaseNode {
   name: string;
   tags: TagList;
   annotations: AnnotationRef[];
-  expression: Expression;
+  expression: PaxelExpressionNode;
 }
 
 export type ParticleItem = ParticleModality | ParticleSlotConnection | Description | ParticleHandleConnection;
@@ -798,8 +798,6 @@ export interface SchemaAlias extends BaseNode {
   alias: string;
 }
 
-export type Expression = ExpressionEntity;
-
 export enum PaxelFunctionName {
   Now = 'now',
   Min = 'min',
@@ -891,7 +889,7 @@ export interface SelectExpressionNode extends QualifiedExpression, BaseNode {
   expression: PaxelExpressionNode;
 }
 
-export interface NewExpressionNode extends QualifiedExpression, BaseNode {
+export interface NewExpressionNode extends BaseNode {
   kind: 'paxel-new';
   schemaNames: string[];
   fields: ExpressionEntityField[];

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -679,7 +679,7 @@ NameWithColon
   }
 
 ParticleHandleConnectionBody
-  = name:NameWithColon? direction:(Direction '?'?)? whiteSpace type:ParticleHandleConnectionType annotations:SpaceAnnotationRefList? maybeTags:SpaceTagList? expression:('=' multiLineSpace Expression)?
+  = name:NameWithColon? direction:(Direction '?'?)? whiteSpace type:ParticleHandleConnectionType annotations:SpaceAnnotationRefList? maybeTags:SpaceTagList? expression:('=' multiLineSpace PaxelExpression)?
   {
     return toAstNode<AstNode.ParticleHandleConnection>({
       kind: 'particle-argument',
@@ -1614,10 +1614,56 @@ NestedSchemaType = 'inline' whiteSpace? schema:(SchemaInline / TypeName)
     });
   }
 
-Expression
-  = ExpressionEntity 
+QualifiedExpression
+  = FromExpression / WhereExpression / SelectExpression
 
-ExpressionEntity "Expression instantiating a new Arcs entity, e.g. new Foo {x: bar.x}"
+ExpressionWithQualifier
+  = qualifier:QualifiedExpression rest:(multiLineSpace rest:QualifiedExpression)* {
+    const result = [qualifier, ...rest.map(x => x[1])];
+    for (let i = result.length - 1; i > 0; i--) {
+      result[i].qualifier = result[i-1];
+    }
+    return result.pop();
+  }
+
+PaxelExpression
+  = NewExpression / ExpressionWithQualifier
+
+PaxelExpressionWithRefinement
+  = PaxelExpression / RefinementExpression
+
+SourceExpression "a scope lookup or a sub-expression,e.g. from p in (paxel expression)"
+  = ExpressionScopeLookup / '(' whiteSpace? expr:PaxelExpression whiteSpace? ')' {
+    return expr;
+  }
+  
+FromExpression "Expression for iterating over a sequence stored in a scope, e.g. from p in inputHandle"
+  = 'from' whiteSpace iterVar:fieldName whiteSpace 'in' whiteSpace source:SourceExpression {
+    return toAstNode<AstNode.FromExpressionNode>({
+       kind: 'paxel-from',
+       iterationVar: iterVar,
+       qualifier: null,
+       source
+    });
+  }
+
+WhereExpression "Expression for filtering a sequence, e.g. where p < 10"
+  = 'where' whiteSpace condition:RefinementExpression {
+    return toAstNode<AstNode.WhereExpressionNode>({
+       kind: 'paxel-where',
+       condition
+    });
+  }
+
+SelectExpression "Expression for mapping a sequence to new values, e.g. select p + 1"
+  = 'select' whiteSpace expression:PaxelExpressionWithRefinement {
+    return toAstNode<AstNode.SelectExpressionNode>({
+      kind: 'paxel-select',
+      expression
+    });
+  }
+
+NewExpression "Expression instantiating a new Arcs entity, e.g. new Foo {x: bar.x}"
   = 'new' whiteSpace names:((upperIdent / '*') whiteSpace?)* '{' multiLineSpace fields:ExpressionEntityFields? ','? multiLineSpace '}' {
      return toAstNode<AstNode.ExpressionEntity>({
         kind: 'expression-entity',
@@ -1641,11 +1687,11 @@ ExpressionEntityField
   }
 
 ExpressionScopeLookup "a dotted scope chain, starting at a root param, e.g. param.schemaFieldName.schemaFieldName"
-  = scope:RefinementExpression? lookup:('.' fieldName) {
+  = scope:(RefinementExpression '.')? lookup:fieldName {
     return toAstNode<AstNode.FieldExpressionNode>({
       kind: 'paxel-field',
-      scopeExpression: scope,
-      field: toAstNode<AstNode.FieldNode>({kind: 'field-name-node', value: lookup[1]})
+      scopeExpression: scope && scope[0] || null,
+      field: toAstNode<AstNode.FieldNode>({kind: 'field-name-node', value: lookup})
     });
   }
 

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1623,7 +1623,15 @@ ExpressionWithQualifier
     for (let i = result.length - 1; i > 0; i--) {
       result[i].qualifier = result[i-1];
     }
-    return result.pop();
+    if (qualifier.kind !== 'paxel-from') {
+      error('Paxel expressions must begin with \'from\'');
+    }
+
+    const select = result.pop();
+    if (select.kind !== 'paxel-select') {
+      error('Paxel expressions must end with \'select\'');
+    }
+    return select;
   }
 
 PaxelExpression

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -789,28 +789,28 @@ describe('manifest parser', () => {
       parse(`
       particle Converter
         foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x
+        bar: writes Bar {y: Number} = from p in foo.x select p
       `);
     });
     it('parses from expression with nested source', () => {
       parse(`
       particle Converter
         foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in (from q in foo.x)
+        bar: writes Bar {y: Number} = from p in (from q in foo.x select q) select p
       `);
     });
     it('parses nested from expression with nested source', () => {
       parse(`
       particle Converter
         foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in (from q in blah) from q in foo.x
+        bar: writes Bar {y: Number} = from p in (from q in blah select q) from q in foo.x select p
       `);
     });
     it('parses from/where expression', () => {
       parse(`
       particle Converter
         foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x where p + 1 < 10
+        bar: writes Bar {y: Number} = from p in foo.x where p + 1 < 10 select p
       `);
     });
     it('parses from/select expression', () => {
@@ -826,6 +826,20 @@ describe('manifest parser', () => {
         foo: reads Foo {x: Number}
         bar: writes Bar {y: Number} = from p in foo.x where p < 10 select new Bar {y: foo.x}
       `);
+    });
+    it('fails expression without starting from', () => {
+      assert.throws(() => parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = where p < 10 select new Bar {y: foo.x}
+      `), 'Paxel expressions must begin with \'from\'');
+    });
+    it('fails expression without ending select', () => {
+      assert.throws(() => parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x where p < 10
+      `), 'Paxel expressions must end with \'select\'');
     });
   });
 

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -785,6 +785,48 @@ describe('manifest parser', () => {
         bar: writes Bar {y: Number} = new Bar {y: foo.x}
       `);
     });
+    it('parses from expression', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x
+      `);
+    });
+    it('parses from expression with nested source', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in (from q in foo.x)
+      `);
+    });
+    it('parses nested from expression with nested source', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in (from q in blah) from q in foo.x
+      `);
+    });
+    it('parses from/where expression', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x where p + 1 < 10
+      `);
+    });
+    it('parses from/select expression', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x select p + 1
+      `);
+    });
+    it('parses from/select expression with new', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x where p < 10 select new Bar {y: foo.x}
+      `);
+    });
   });
 
   describe('inline data stores', () => {


### PR DESCRIPTION
Caveat: current using 'p.x' doesn't work an a refinement expression, so 'where p.x < foo' won't work. After this is landed, I need to add in the scope/type propagation logic so that refiner.ts is aware what the scope types are, then I can add in the scope lookup syntax.
