### PR TITLE
Added `init` block to register schemas on creation.

### DIFF
--- a/java/arcs/core/data/Schema.kt
+++ b/java/arcs/core/data/Schema.kt
@@ -37,6 +37,12 @@ data class Schema(
     val refinementExpression: Expression<Boolean> = true.asExpr(),
     val queryExpression: Expression<Boolean> = true.asExpr()
 ) {
+
+    /** Ensure instance is registered on construction. */
+    init {
+        SchemaRegistry.register(this)
+    }
+
     val name: SchemaName?
         get() = names.firstOrNull()
 


### PR DESCRIPTION
Attempt to address schema registry bug. 

@jasonwyatt @satakshir @jblebrun 