### PR TITLE
Fixing `arcs_kt_gen` dependency system for G3

### DIFF
--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -742,13 +742,15 @@ def arcs_kt_gen(
         d + "_manifest"
         for d in manifest_only(deps, inverse = True)
         if (d.find(":") != -1 and not d.endswith("_manifest"))
-    ]
+    ] + manifest_only(deps)
+
+    data_deps = [d for d in data if not d.endswith("_manifest")] + manifest_only(data)
 
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
         manifest_proto = False,
-        deps = manifest_only(deps) + data + manifest_deps,
+        deps = data_deps + manifest_deps,
     )
 
     schema = arcs_kt_schema(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -738,10 +738,15 @@ def arcs_kt_gen(
     schema_name = name + "_schema"
     plan_name = name + "_plan"
 
+    # Here, we want to collect all manifest dependencies. Since the ideal arguments for `deps` are other `arcs_kt_gen`
+    # targets, this expression gathers all `arcs_manifest` subtargets as dependencies (i.e. `:<dep_target>_manifest`).
+    # The comprehension filters for all non-*.arcs files that are a build target (i.e. have a `:`), precluding targets
+    # that already end with `_manifest` (i.e. a work-around might have already been applied, this can be removed later).
+    # Sometimes, users will add *.arcs files as a dependency, and that's captured here, too.
     manifest_deps = [
         d + "_manifest"
         for d in manifest_only(deps, inverse = True)
-        if (d.find(":") != -1 and not d.endswith("_manifest"))
+        if (":" in d and not d.endswith("_manifest"))
     ] + manifest_only(deps)
 
     arcs_manifest(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -738,11 +738,17 @@ def arcs_kt_gen(
     schema_name = name + "_schema"
     plan_name = name + "_plan"
 
+    manifest_deps = [
+        d + "_manifest"
+        for d in manifest_only(deps, inverse = True)
+        if (d.find(":") != -1 and not d.endswith("_manifest"))
+    ]
+
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
         manifest_proto = False,
-        deps = manifest_only(deps) + data,
+        deps = manifest_only(deps) + data + manifest_deps,
     )
 
     schema = arcs_kt_schema(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -744,6 +744,7 @@ def arcs_kt_gen(
         if (d.find(":") != -1 and not d.endswith("_manifest"))
     ] + manifest_only(deps)
 
+    # TODO(b/162603499) This filter can be removed or modified once current workarounds have been patched.
     data_deps = [d for d in data if not d.endswith("_manifest")] + manifest_only(data)
 
     arcs_manifest(

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -744,14 +744,11 @@ def arcs_kt_gen(
         if (d.find(":") != -1 and not d.endswith("_manifest"))
     ] + manifest_only(deps)
 
-    # TODO(b/162603499) This filter can be removed or modified once current workarounds have been patched.
-    data_deps = [d for d in data if not d.endswith("_manifest")] + manifest_only(data)
-
     arcs_manifest(
         name = manifest_name,
         srcs = srcs,
         manifest_proto = False,
-        deps = data_deps + manifest_deps,
+        deps = data + manifest_deps,
     )
 
     schema = arcs_kt_schema(


### PR DESCRIPTION
This PR is a pre-requisite for #6039 
- Pulling in the `_manifest` suffix dep into the macro.
- Adding filters / workarounds (to `deps` and `data`) to not break current rules in G3.
- Once G3 rules are modified, a lot of these changes can be modified or removed. 

Evidence that these rules do not break G3: cl/329401762

CC: @csilvestrini 