### PR TITLE
Add support for callbacks on DirectStoreMuxer

### DIFF
--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -14,11 +14,14 @@ package arcs.core.storage
 import androidx.annotation.VisibleForTesting
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.storage.ProxyMessage.ModelUpdate
 import arcs.core.storage.ProxyMessage.Operations
 import arcs.core.storage.ProxyMessage.SyncRequest
+import arcs.core.storage.util.randomCallbackManager
 import arcs.core.type.Type
 import arcs.core.util.LruCacheMap
+import arcs.core.util.Random
 import arcs.core.util.TaggedLog
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,14 +32,22 @@ import kotlinx.coroutines.sync.withLock
  *
  * This is what *backs* Entities.
  */
-class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
+class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     val storageKey: StorageKey,
     val backingType: Type,
-    val callbackFactory: (String) -> ProxyCallback<Data, Op, T>,
     private val options: StoreOptions? = null
 ) {
     private val storeMutex = Mutex()
     private val log = TaggedLog { "DirectStoreMuxer" }
+
+    /**
+     * Store a set of callbacks that will be fired for any of the underlying stores in this
+     * [DirectStoreMuxer].
+     */
+    private val callbackManager = randomCallbackManager<MuxedProxyMessage<Data, Op, T>>(
+        "direct-store-muxer",
+        Random
+    )
 
     // TODO(b/158262634): Make this CacheMap Weak.
     /* internal */ val stores = LruCacheMap<String, StoreRecord<Data, Op, T>>(
@@ -57,6 +68,22 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
                 log.info { "failed to close the store" }
             }
         }
+    }
+
+    /**
+     * Register a callback with the [DirectStoreMuxer] that will receive callbacks for all
+     * [DirectStore] instnaces that are currently active. The message will be wrapped in a
+     * [MuxedProxyMessage] with [muxId] representing the [entityId] of the entity.
+     */
+    fun on(callback: MuxedProxyCallback<Data, Op, T>) {
+        callbackManager.register(callback::invoke)
+    }
+
+    /**
+     * Remove a previously-registered [MuxedProxyCallback] identified by the provided [token].
+     */
+    fun off(token: Int) {
+        callbackManager.unregister(token)
     }
 
     /**
@@ -111,7 +138,9 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperation, T>(
             )
         )
 
-        val id = store.on(callbackFactory(referenceId))
+        val id = store.on(ProxyCallback {
+            callbackManager.send(MuxedProxyMessage(referenceId, it))
+        })
 
         // Return a new Record and add it to our local stores, keyed by muxId.
         return StoreRecord(id, store)

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -13,6 +13,7 @@ package arcs.core.storage
 
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtOperationAtTime
 import java.io.Closeable
 
 /** A message coming from the storage proxy into one of the [IStore] implementations. */
@@ -90,6 +91,18 @@ fun <Data : CrdtData, Op : CrdtOperation, ConsumerData> ProxyCallback(
         message: ProxyMessage<Data, Op, ConsumerData>
     ) = callback(message)
 }
+
+/**
+ * A combination of a [ProxyMessage] and a [muxId], which is typically the reference ID that
+ * uniquely identifies the entity store that has generated the message.
+ */
+data class MuxedProxyMessage<Data : CrdtData, Op : CrdtOperationAtTime, T>(
+    val muxId: String,
+    val message: ProxyMessage<Data, Op, T>
+)
+
+/** A convenience for a [CallbackManager] callback that uses a [MuxedProxyMessage] parameter. */
+typealias MuxedProxyCallback<Data, Op, T> = suspend (MuxedProxyMessage<Data, Op, T>) -> Unit
 
 /** Interface common to an [ActiveStore] and the PEC, used by the Storage Proxy. */
 interface StorageEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> : Closeable {

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -154,15 +154,14 @@ class ReferenceModeStore private constructor(
     val backingStore = DirectStoreMuxer<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(
         storageKey = backingKey,
         backingType = backingType,
-        callbackFactory = { muxId ->
-            ProxyCallback { message ->
-                receiveQueue.enqueue {
-                    handleBackingStoreMessage(message, muxId)
-                }
-            }
-        },
         options = options
-    )
+    ).also {
+        it.on { muxedMessage ->
+            receiveQueue.enqueue {
+                handleBackingStoreMessage(muxedMessage.message, muxedMessage.muxId)
+            }
+        }
+    }
 
     init {
         @Suppress("UNCHECKED_CAST")

--- a/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
+++ b/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
@@ -40,15 +40,15 @@ class DirectStoreMuxerTest {
         )
 
         var callbacks = 0
-        val callback = ProxyCallback<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity> {
+
+        val directStoreMuxer = DirectStoreMuxer<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(
+            storageKey = storageKey,
+            backingType = EntityType(schema)
+        )
+
+        directStoreMuxer.on {
             callbacks++
         }
-
-        val directStoreMuxer = DirectStoreMuxer(
-            storageKey = storageKey,
-            backingType = EntityType(schema),
-            callbackFactory = { callback }
-        )
 
         val vm1 = VersionMap("first" to 1)
         val value = CrdtSingleton(

--- a/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
@@ -17,6 +17,7 @@ import arcs.core.crdt.CrdtCount.Operation.MultiIncrement
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtModel
 import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.data.CountType
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.driver.RamDiskDriverProvider
@@ -59,17 +60,17 @@ class RamDiskDirectStoreMuxerIntegrationTest {
         var job = Job()
 
         val storageKey = RamDiskStorageKey("unique")
-        val store = DirectStoreMuxer<CrdtData, CrdtOperation, Any?>(
+        val store = DirectStoreMuxer<CrdtData, CrdtOperationAtTime, Any?>(
             storageKey = storageKey,
-            backingType = CountType(),
-            callbackFactory = { eventId ->
-                ProxyCallback { m ->
-                    message.value = m as ProxyMessage<CrdtCount.Data, CrdtCount.Operation, Int>
-                    muxId.value = eventId
-                    job.complete()
-                }
+            backingType = CountType()
+        ).also {
+            it.on { muxedProxyMessage ->
+                message.value = muxedProxyMessage.message
+                    as ProxyMessage<CrdtCount.Data, CrdtCount.Operation, Int>
+                muxId.value = muxedProxyMessage.muxId
+                job.complete()
             }
-        )
+        }
 
         val count1 = CrdtCount()
         count1.applyOperation(Increment("me", version = 0 to 1))


### PR DESCRIPTION
[DirectStoreMuxer] now implements [on] and [off] methods that register a
callback that will be triggered for any changes in any entities
currently being managed by the muxer.

[ReferenceModeStore] is refactored to adapt to this change: it now
registeres a single [MuxedProxyCallback] with the DSM, instead of
providing a calback factory to be set on each store.