### PR TITLE
Increase delay in PerformanceStatisticsTest to prevent flakes

### DIFF
--- a/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
@@ -83,7 +83,7 @@ class PerformanceStatisticsTest {
             it.increment("foo")
         }
 
-        delay(100) // let the mutex in the time function run.
+        delay(1000) // let the mutex in the time function run.
 
         val snapshot = stats.snapshot()
         assertThat(snapshot.runtimeStatistics.measurements).isEqualTo(1)


### PR DESCRIPTION
Test was 0.5% flaky with a 100ms delay. Increasing to 1000ms improves success rate to 100%.