### PR TITLE
Adds LET clause for qualified Paxel expressions + various minor fixes

### DIFF
--- a/java/arcs/core/data/expression/Builders.kt
+++ b/java/arcs/core/data/expression/Builders.kt
@@ -209,6 +209,17 @@ infix fun FromBuilder.on(sequence: Expression<Sequence<Any>>) =
 infix fun Expression<Sequence<Unit>>.where(expr: Expression<Boolean>) =
     Expression.WhereExpression(this, expr)
 
+/** Helper used to build [LetExpression]. */
+data class LetBuilder(val variableName: String, val qualifier: Expression<Sequence<Unit>>)
+
+/** Build a let expression nested inside a qualified expression. */
+infix fun Expression<Sequence<Unit>>.let(variableName: String) =
+    LetBuilder(variableName, this)
+
+/** Assigns an expression to be evaluated as a value to be introduced into the scope. */
+infix fun LetBuilder.be(expression: Expression<Any>) =
+    Expression.LetExpression(this.qualifier, expression, this.variableName)
+
 /** Constructs a [SelectExpression]. */
 infix fun <T> Expression<Sequence<Unit>>.select(expr: Expression<T>) =
     Expression.SelectExpression(this, expr)

--- a/java/arcs/core/data/expression/Evaluator.kt
+++ b/java/arcs/core/data/expression/Evaluator.kt
@@ -74,6 +74,12 @@ class ExpressionEvaluator(
         }
     }
 
+    override fun visit(expr: Expression.LetExpression): Any {
+        return (expr.qualifier.accept(this) as Sequence<*>).map {
+            currentScope.set(expr.variableName, expr.variableExpr.accept(this))
+        }
+    }
+
     override fun <T> visit(expr: Expression.SelectExpression<T>): Any {
         return (expr.qualifier.accept(this) as Sequence<*>).map {
             expr.expr.accept(this) as T

--- a/java/arcs/core/data/expression/Expression.kt
+++ b/java/arcs/core/data/expression/Expression.kt
@@ -74,6 +74,9 @@ sealed class Expression<out T> {
         /** Called when [SelectExpression] encountered. */
         fun <T> visit(expr: SelectExpression<T>): Result
 
+        /** Called when [LetExpression] encountered. */
+        fun visit(expr: LetExpression): Result
+
         /** Called when [FunctionExpression] encountered. */
         fun <T> visit(expr: FunctionExpression<T>): Result
 
@@ -336,14 +339,28 @@ sealed class Expression<out T> {
 
     /**
      * Represents a filter expression that returns true or false.
-     *
-     * @param T the type of elements in the [qualfier] [Sequence].
      */
     data class WhereExpression(
         override val qualifier: Expression<Sequence<Unit>>,
         val expr: Expression<Boolean>
     ) : QualifiedExpression, Expression<Sequence<Unit>>() {
         override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
+        @Suppress("UNCHECKED_CAST")
+        override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
+            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Unit>>) }
+                ?: this
+        override fun toString() = this.stringify()
+    }
+
+    /**
+     * Represents introducing a new identifier into the scope.
+     */
+    data class LetExpression(
+        override val qualifier: Expression<Sequence<Unit>>,
+        val variableExpr: Expression<*>,
+        val variableName: String
+    ) : QualifiedExpression, Expression<Sequence<Unit>>() {
+        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
         @Suppress("UNCHECKED_CAST")
         override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
             qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Unit>>) }

--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -187,6 +187,18 @@ object PaxelParser {
             )
         }
 
+    private val letVar = -token("let") + (ows + ident + ows)
+    private val letSource = -token("=") + (ows + sourceExpression)
+
+    private val letExpression: Parser<QualifiedExpression> =
+        (letVar + letSource).map {
+            (varName, src) -> Expression.LetExpression(
+                src as Expression<Sequence<kotlin.Unit>>,
+                src as Expression<Any>,
+                varName
+            )
+        }
+
     private val schemaNames = (ident + many(whitespace + ident)).map { (ident, rest) ->
         setOf(ident) + rest.toSet()
     }
@@ -217,7 +229,7 @@ object PaxelParser {
         }
 
     private val qualifiedExpression: Parser<QualifiedExpression> =
-        fromExpression / whereExpression / selectExpression
+        fromExpression / whereExpression / letExpression / selectExpression
 
     private val expressionWithQualifier =
         (qualifiedExpression + many(ows + qualifiedExpression)).map { (first, rest) ->

--- a/java/arcs/core/data/expression/Stringifier.kt
+++ b/java/arcs/core/data/expression/Stringifier.kt
@@ -47,19 +47,23 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
     override fun visit(expr: Expression.BooleanLiteralExpression) = expr.value.toString()
 
     override fun visit(expr: Expression.FromExpression): String =
-        (expr.qualifier?.accept(this) ?: "") +
-            "\nfrom ${expr.iterationVar} in ${expr.source.accept(this)}\n"
+        (expr.qualifier?.accept(this)?.plus("\n") ?: "") +
+            "from ${expr.iterationVar} in ${expr.source.accept(this)}"
 
     override fun visit(expr: Expression.WhereExpression): String =
-        expr.qualifier.accept(this) + "\nwhere " + expr.expr.accept(this) + "\n"
+        expr.qualifier.accept(this) + "\nwhere " + expr.expr.accept(this)
+
+    override fun visit(expr: Expression.LetExpression): String =
+        expr.qualifier.accept(this) + "\n" +
+        "let ${expr.variableName} = (${expr.variableExpr.accept(this)})"
 
     override fun <T> visit(expr: Expression.SelectExpression<T>): String =
         expr.qualifier.accept(this) + "\nselect " + expr.expr.accept(this) + "\n"
 
     override fun visit(expr: Expression.NewExpression): String =
         "new " + expr.schemaName.joinToString(" ") + expr.fields.joinToString(
-            ", \n",
-            "{\n",
+            ",\n  ",
+            " {\n  ",
             "\n}", transform = { (name, fieldExpr) ->
                 "$name: " + fieldExpr.accept(this)
             }
@@ -67,8 +71,8 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
 
     override fun <T> visit(expr: Expression.FunctionExpression<T>): String =
         expr.function.name + expr.arguments.joinToString(
-            ", \n",
-            "(\n",
+            ",\n  ",
+            "(\n  ",
             "\n)", transform = { argExpr ->
                 argExpr.accept(this)
             }

--- a/javatests/arcs/core/data/expression/ParserTest.kt
+++ b/javatests/arcs/core/data/expression/ParserTest.kt
@@ -183,6 +183,7 @@ class ParserTest {
     fun parsePaxel() {
         PaxelParser.parse("from p in q select p")
         PaxelParser.parse("from p in q where p < 1 select p")
+        PaxelParser.parse("from p in q where p < 1 let x = (p + 1) select x - 1")
         PaxelParser.parse("from p in q where p < 1 select new Foo { x: 1 }")
         PaxelParser.parse("new Foo { x: 1 }")
     }


### PR DESCRIPTION
This implements LET expressions inside qualified expressions. Using LET outside qualified expressions is not yet possible and would require making all Paxel expressions qualified, which is a bigger refactoring for a later PR.