### PR TITLE
Sends Paxel expression string from TS Parser to Kotlin

### DIFF
--- a/java/arcs/core/data/HandleConnectionSpec.kt
+++ b/java/arcs/core/data/HandleConnectionSpec.kt
@@ -11,11 +11,12 @@
 
 package arcs.core.data
 
+import arcs.core.data.expression.Expression
 import arcs.core.type.Type
 
 data class HandleConnectionSpec(
     val name: String,
     val direction: HandleMode,
     val type: Type,
-    val expression: String? = null
+    val expression: Expression<*>? = null
 )

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -11,7 +11,6 @@
 
 package arcs.core.data
 
-import arcs.core.data.expression.deserializeExpression
 import arcs.core.storage.StorageKeyParser
 import arcs.core.type.Type
 
@@ -87,7 +86,7 @@ fun Recipe.Particle.HandleConnection.toPlanHandleConnection() = Plan.HandleConne
     mode = spec.direction,
     type = type,
     annotations = handle.annotations,
-    expression = spec.expression?.ifEmpty { null }?.deserializeExpression()
+    expression = spec.expression
 )
 
 /** Translates a [Recipe.Handle] into a [StorageKey] */

--- a/java/arcs/core/data/expression/Serializer.kt
+++ b/java/arcs/core/data/expression/Serializer.kt
@@ -95,7 +95,7 @@ class ExpressionSerializer() : Expression.Visitor<JsonValue<*>> {
                 "op" to JsonString("let"),
                 "expr" to expr.variableExpr.accept(this),
                 "var" to JsonString(expr.variableName),
-                "qualifier" to (expr.qualifier?.accept(this) ?: JsonNull)
+                "qualifier" to (expr.qualifier.accept(this))
             )
         )
 

--- a/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
+++ b/java/arcs/core/data/proto/ParticleSpecProtoDecoder.kt
@@ -15,6 +15,7 @@ import arcs.core.data.Check
 import arcs.core.data.HandleConnectionSpec
 import arcs.core.data.HandleMode
 import arcs.core.data.ParticleSpec
+import arcs.core.data.expression.PaxelParser
 
 typealias DirectionProto = HandleConnectionSpecProto.Direction
 
@@ -35,7 +36,7 @@ fun HandleConnectionSpecProto.decode() = HandleConnectionSpec(
     name = name,
     direction = direction.decode(),
     type = type.decode(),
-    expression = expression.ifEmpty { null }
+    expression = if (expression.isEmpty()) { null } else { PaxelParser.parse(expression) }
 )
 
 /** Converts a [ParticleSpecProto] to the corresponding [ParticleSpec] instance. */

--- a/javatests/arcs/core/data/RecipeTest.kt
+++ b/javatests/arcs/core/data/RecipeTest.kt
@@ -12,7 +12,6 @@ package arcs.core.data
 
 import arcs.core.data.Recipe.Handle.Fate
 import arcs.core.data.expression.asExpr
-import arcs.core.data.expression.serialize
 import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
@@ -138,7 +137,7 @@ class RecipeTest {
                     "data",
                     HandleMode.Read,
                     personCollectionType,
-                    true.asExpr().serialize()
+                    true.asExpr()
                 )
             ).associateBy { it.name }
         )

--- a/javatests/arcs/core/data/proto/BUILD
+++ b/javatests/arcs/core/data/proto/BUILD
@@ -14,6 +14,7 @@ arcs_kt_jvm_test_suite(
     deps = [
         "//java/arcs/core/data",
         "//java/arcs/core/data:schema_fields",
+        "//java/arcs/core/data/expression",
         "//java/arcs/core/data/proto:annotation_java_proto",
         "//java/arcs/core/data/proto:manifest_java_proto",
         "//java/arcs/core/data/proto:proto_for_test",

--- a/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
+++ b/javatests/arcs/core/data/proto/ParticleSpecProtoDecoderTest.kt
@@ -15,6 +15,7 @@ import arcs.core.data.ParticleSpec
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
+import arcs.core.data.expression.Expression
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.TextFormat
 import kotlin.test.assertFailsWith
@@ -101,13 +102,13 @@ class ParticleSpecProtoDecoderTest {
     @Test
     fun decodesHandleConnectionSpecProto_withExpression() {
         val handleConnectionSpecProto = getHandleConnectionSpecProto(
-            "data", "READS", "Thing", "expression-literal"
+            "data", "READS", "Thing", "new Thing {x: foo.y}"
         )
         val connectionSpec = decodeHandleConnectionSpecProto(handleConnectionSpecProto)
         assertThat(connectionSpec.name).isEqualTo("data")
         assertThat(connectionSpec.direction).isEqualTo(HandleMode.Read)
         assertThat(connectionSpec.type).isEqualTo(EntityType(schema))
-        assertThat(connectionSpec.expression).isEqualTo("expression-literal")
+        assertThat(connectionSpec.expression).isInstanceOf(Expression.NewExpression::class.java)
     }
 
     @Test

--- a/javatests/arcs/showcase/expression/expression.arcs
+++ b/javatests/arcs/showcase/expression/expression.arcs
@@ -35,8 +35,14 @@ recipe DataIngestion
 particle CountiesStatsCalculator
   states: reads [State {name, code, areaSqMi, population}]
   counties: reads [County {name, stateCode, areaSqMi, population}]
-  output: writes [CountyStats {name, state, density, stateAreaRatio,statePopulationRatio}] // =
-  // TODO(b/163033197): uncomment once Paxel can be parsed from the manifest.
+  output: writes [CountyStats {name, state, density, stateAreaRatio,statePopulationRatio}] =
+    from state in states
+    from county in counties
+    select new CountyStats {
+      name: county.name,
+      state: state.name
+    }
+  // TODO(b/163033197): uncomment once it can be parsed from the manifest.
   //  from state in states
   //  from county in counties
   //  where county.stateCode == state.code

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -679,7 +679,7 @@ NameWithColon
   }
 
 ParticleHandleConnectionBody
-  = name:NameWithColon? direction:(Direction '?'?)? whiteSpace type:ParticleHandleConnectionType annotations:SpaceAnnotationRefList? maybeTags:SpaceTagList? expression:('=' multiLineSpace PaxelExpression)?
+  = name:NameWithColon? direction:(Direction '?'?)? whiteSpace type:ParticleHandleConnectionType annotations:SpaceAnnotationRefList? maybeTags:SpaceTagList? expression:(whiteSpace? '=' multiLineSpace PaxelExpression)?
   {
     return toAstNode<AstNode.ParticleHandleConnection>({
       kind: 'particle-argument',
@@ -690,7 +690,7 @@ ParticleHandleConnectionBody
       name: name || (maybeTags && maybeTags[0]) || expected(`either a name or tags to be supplied ${name} ${maybeTags}`),
       tags: maybeTags || [],
       annotations: annotations || [],
-      expression: expression && expression[2]
+      expression: expression && expression[3]
     });
   }
 
@@ -1635,7 +1635,11 @@ ExpressionWithQualifier
   }
 
 PaxelExpression
-  = NewExpression / ExpressionWithQualifier
+  = expr:(NewExpression / ExpressionWithQualifier) {
+    // Attaches entire expression text to the top level paxel expression node.
+    expr.unparsedPaxelExpression = text();
+    return expr;
+  }
 
 PaxelExpressionWithRefinement
   = PaxelExpression / RefinementExpression

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -865,8 +865,7 @@ ${e.message}
         arg.annotations = Manifest._buildAnnotationRefs(manifest, arg.annotations);
 
         // TODO: Validate that the type of the expression matches the declared type.
-        // TODO: Transform the expression AST into a cross-platform text format.
-        arg.expression = arg.expression && arg.expression.kind;
+        arg.expression = arg.expression && arg.expression.unparsedPaxelExpression;
       }
     };
     if (particleItem.implFile && particleItem.args.some(arg => !!arg.expression)) {

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -802,57 +802,57 @@ describe('manifest parser', () => {
     it('parses from expression', () => {
       parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x select p
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in foo.x select p
       `);
     });
     it('parses from expression with nested source', () => {
       parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in (from q in foo.x select q) select p
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in (from q in foo.x select q) select p
       `);
     });
     it('parses nested from expression with nested source', () => {
       parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in (from q in blah select q) from q in foo.x select p
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in (from q in blah select q) from q in foo.x select p
       `);
     });
     it('parses from/where expression', () => {
       parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x where p + 1 < 10 select p
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in foo.x where p + 1 < 10 select p
       `);
     });
     it('parses from/select expression', () => {
       parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x select p + 1
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in foo.x select p + 1
       `);
     });
     it('parses from/select expression with new', () => {
       parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x where p < 10 select new Bar {y: foo.x}
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in foo.x where p < 10 select new Bar {y: foo.x}
       `);
     });
     it('fails expression without starting from', () => {
       assert.throws(() => parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = where p < 10 select new Bar {y: foo.x}
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = where p < 10 select new Bar {y: foo.x}
       `), 'Paxel expressions must begin with \'from\'');
     });
     it('fails expression without ending select', () => {
       assert.throws(() => parse(`
       particle Converter
-        foo: reads Foo {x: Number}
-        bar: writes Bar {y: Number} = from p in foo.x where p < 10
+        foo: reads [Foo {x: Number}]
+        bar: writes [Bar {y: Number}] = from p in foo.x where p < 10
       `), 'Paxel expressions must end with \'select\'');
     });
   });

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -5093,7 +5093,6 @@ A particle with implementation cannot use result expressions.
     assert.isNull(readConnection.expression);
 
     const writeConnection = particle.connections.find(hc => hc.direction === 'writes');
-    // TODO: A stop-gap for now, we need to serialize the expression AST.
-    assert.equal(writeConnection.expression, 'expression-entity');
+    assert.equal(writeConnection.expression, 'new Bar {y: foo.x}');
   });
 });

--- a/src/tools/kotlin-generation-utils.ts
+++ b/src/tools/kotlin-generation-utils.ts
@@ -140,8 +140,11 @@ export function leftPad(input: string, indent: number, skipFirst: boolean = fals
     .join('\n');
 }
 
-/** Format a Kotlin string. */
+/** Quote a string. */
 export function quote(s: string) { return `"${s}"`; }
+
+/** Quote a multi-line string. */
+export function multiLineQuote(s: string) { return `"""${s}"""`; }
 
 /** Produces import statement if target is not within the same package. */
 export function tryImport(importName: string, packageName: string): string {

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -9,7 +9,7 @@
  */
 import {Recipe, Handle, Particle, HandleConnection} from '../runtime/recipe/lib-recipe.js';
 import {Type} from '../types/lib-types.js';
-import {KotlinGenerationUtils, quote, tryImport} from './kotlin-generation-utils.js';
+import {KotlinGenerationUtils, quote, multiLineQuote, tryImport} from './kotlin-generation-utils.js';
 import {generateConnectionType, generateHandleType} from './kotlin-type-generator.js';
 import {Direction} from '../runtime/arcs-types/enums.js';
 import {annotationsToKotlin} from './annotations-utils.js';
@@ -111,8 +111,7 @@ export class PlanGenerator {
     const annotations = annotationsToKotlin(connection.handle.annotations);
     const args = [handle, mode, type, annotations];
     if (connection.spec.expression) {
-      // This is a temporary stop gap, until we develop Expression AST in TypeScript.
-      args.push('42.asExpr()');
+      args.push(ktUtils.applyFun('PaxelParser.parse', [multiLineQuote(connection.spec.expression)]));
     }
 
     return ktUtils.applyFun('HandleConnection', args, {startIndent: 24});

--- a/src/tools/tests/goldens/plan-generator-handleConnections.cgtest
+++ b/src/tools/tests/goldens/plan-generator-handleConnections.cgtest
@@ -137,3 +137,34 @@ HandleConnection(
     emptyList()
 )
 -----[end]-----
+
+-----[name]-----
+parses Paxel expression on handle connections
+-----[input]-----
+particle Foo
+  person: reads Person {name: Text}
+  friend: writes Friend {nickname: Text} =
+    new Friend {nickname: person.name}
+
+recipe R
+  a: create
+  b: create
+  Foo
+    person: a
+    friend: b
+-----[results]-----
+HandleConnection(
+    R_Handle0,
+    HandleMode.Write,
+    arcs.core.data.SingletonType(arcs.core.data.EntityType(Foo_Friend.SCHEMA)),
+    emptyList(),
+    PaxelParser.parse("""new Friend {nickname: person.name}""")
+)
+-----[next]-----
+HandleConnection(
+    R_Handle1,
+    HandleMode.Read,
+    arcs.core.data.SingletonType(arcs.core.data.EntityType(Foo_Person.SCHEMA)),
+    emptyList()
+)
+-----[end]-----

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -206,7 +206,7 @@ describe('manifest2proto', () => {
             fields: {a: {primitive: 'TEXT'}},
             hash: 'eb8597be8b72862d5580f567ab563cefe192508d',
           }}},
-          expression: 'expression-entity' // This is a temporary stop-gap.
+          expression: 'new X {a: bar.b}'
         }],
         name: 'FooBar',
       }]


### PR DESCRIPTION
Captures the full Paxel expression in the top-level Paxel node as text and passes this to Kotlin in recipe2plan, manifest2proto and parses back on the Kotlin side.

Also, a small bugfix to the parser, where a whitespace was required to parse paxel with collection types, but not singletons - weird.

TODO: Make the Peg Parser parse the Showcase expression.