### PR TITLE
Uses PaxelParser in Paxel Showcase and EvaluatorParticle Test.

### DIFF
--- a/javatests/arcs/core/data/expression/Particles.arcs
+++ b/javatests/arcs/core/data/expression/Particles.arcs
@@ -9,7 +9,9 @@ particle NumberSetMultiplier
   //   value: x.value * scalar.magnitude
   // }
   average: writes Average {average: Number}
-  // = Average(from x in inputNumbers select x.value)
+  // = new Average {
+  // average: average(from x in inputNumbers select x.value)
+  // }
 
 recipe Multiplier
   inputNumbers: create

--- a/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
+++ b/javatests/arcs/showcase/expression/ExpressionShowcaseTest.kt
@@ -14,17 +14,7 @@ package arcs.showcase.expression
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.core.data.Plan
 import arcs.core.data.expression.EvaluatorParticle
-import arcs.core.data.expression.Expression.Scope
-import arcs.core.data.expression.div
-import arcs.core.data.expression.eq
-import arcs.core.data.expression.from
-import arcs.core.data.expression.get
-import arcs.core.data.expression.new
-import arcs.core.data.expression.on
-import arcs.core.data.expression.scope
-import arcs.core.data.expression.select
-import arcs.core.data.expression.seq
-import arcs.core.data.expression.where
+import arcs.core.data.expression.PaxelParser
 import arcs.core.host.toRegistration
 import arcs.core.testutil.handles.dispatchFetchAll
 import arcs.core.testutil.handles.dispatchStore
@@ -98,35 +88,6 @@ class ExpressionShowcaseTest {
         )
 
         // TODO(b/163033197): Remove once we can parse expressions from the Manifest
-        //  from state in states
-        //  from county in counties
-        //  where county.stateCode == state.code
-        //  select new County {
-        //    name: county.name,
-        //    state: state.name,
-        //    density: county.population / county.areaSqMi,
-        //    stateAreaRatio: county.areaSqMi / state.areaSqMi,
-        //    statePopulationRatio: county.population / state.population
-        //  }
-        val calculateStats =
-            from("state") on seq<Scope>("states") from("county") on
-                seq<Scope>("counties") where (
-                scope("county").get<String>("stateCode") eq
-                scope("state").get<String>("code")
-            ) select new("CountyStats")(
-                "name" to scope("county").get<String>("name"),
-                "state" to scope("state").get<String>("name"),
-                "density" to
-                    scope("county").get<Number>("population") /
-                    scope("county")["areaSqMi"],
-                "stateAreaRatio" to
-                    scope("county").get<Number>("areaSqMi") /
-                    scope("state")["areaSqMi"],
-                "statePopulationRatio" to
-                    scope("county").get<Number>("population") /
-                    scope("state")["population"]
-            )
-
         // Adds the above expression to the CountiesStatsCalculator.output connection.
         val planWithExpression = Plan.particleLens.mod(StatsCalculationPlan) { particles ->
             particles.map { particle ->
@@ -136,7 +97,18 @@ class ExpressionShowcaseTest {
                     Plan.Particle.handlesLens.mod(updated) { handles ->
                         handles.mapValues { (name, connection) ->
                             if (name == "output") {
-                                connection.copy(expression = calculateStats)
+                                connection.copy(expression = PaxelParser.parse("""
+                                    |from state in states
+                                    |from county in counties
+                                    |where county.stateCode == state.code
+                                    |select new County {
+                                    |  name: county.name,
+                                    |  state: state.name,
+                                    |  density: county.population / county.areaSqMi,
+                                    |  stateAreaRatio: county.areaSqMi / state.areaSqMi,
+                                    |  statePopulationRatio: county.population / state.population
+                                    |}
+                                """.trimMargin()))
                             } else {
                                 connection
                             }

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -841,6 +841,19 @@ describe('manifest parser', () => {
         bar: writes Bar {y: Number} = from p in foo.x where p < 10 select new Bar {y: foo.x}
       `);
     });
+    it('parses multi-line paxel expression', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} =
+          from p in foo.x
+          where p < 10
+          select new Bar {
+            y: foo.x
+          }
+        baz: reads Baz {z: Number}
+      `);
+    });
     it('fails expression without starting from', () => {
       assert.throws(() => parse(`
       particle Converter


### PR DESCRIPTION
This brings us one step closer to E2E integration, as PaxelParser will also be used in the final codepath.

I have also added a test case for parsing a multi-line paxel in the parser test, as I started on making it work but it already works!