### PR TITLE
Improvements to `runOnAllDatabases`: run all jobs & test

### DIFF
--- a/java/arcs/core/common/CompositeException.kt
+++ b/java/arcs/core/common/CompositeException.kt
@@ -1,0 +1,60 @@
+package arcs.core.common
+
+import java.io.PrintWriter
+import java.io.StringWriter
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
+
+/**
+ * This class wraps one or more exceptions that occur when running a set of operations on all
+ * databases owned by a manager.
+ *
+ * When the exception is thrown, the output will include the stack traces for all of the wrapped
+ * errors.
+ */
+class CompositeException(
+    val exceptions: List<Throwable>
+) : Exception() {
+    override fun toString(): String {
+        val stringWriter = StringWriter()
+        PrintWriter(stringWriter).run {
+            print("CompositeException: (${exceptions.size} failed ops)\n")
+            exceptions.forEach {
+                it.printStackTrace(this)
+            }
+            print("Invoked from:")
+        }
+        return stringWriter.toString()
+    }
+}
+
+/**
+ * A helper to wait for a group of [Deferred] objects to complete, collect any exceptions taht
+ * occurred, and wrap the results in a composite exception, if there were any.
+ */
+@ExperimentalCoroutinesApi
+suspend fun Collection<Deferred<*>>.toCompositeExceptionOrNull() =
+    onEach { it.join() }
+        .mapNotNull { it.getCompletionExceptionOrNull() }
+        .takeIf { it.isNotEmpty() }
+        ?.let { CompositeException(it) }
+
+/**
+ * Run a collection of jobs generated from the provided source parameters of type [T]. If any of
+ * the jobs throw an exception, they'll be aggregated into a [CompositeException] which will be
+ * thrown once all jobs complete
+ */
+@ExperimentalCoroutinesApi
+suspend inline fun <T> Collection<T>.collectExceptions(
+    crossinline block: suspend (T) -> Unit
+) {
+    supervisorScope {
+        map {
+            async {
+                block(it)
+            }
+        }.toCompositeExceptionOrNull()?.let { throw(it) }
+    }
+}

--- a/java/arcs/core/storage/database/BUILD
+++ b/java/arcs/core/storage/database/BUILD
@@ -11,6 +11,7 @@ arcs_kt_library(
     name = "database",
     srcs = glob(["*.kt"]),
     deps = [
+        "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
         "//java/arcs/core/data:rawentity",

--- a/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
+++ b/java/arcs/jvm/storage/database/testutil/FakeDatabaseManager.kt
@@ -20,7 +20,6 @@ import arcs.core.storage.database.DatabaseIdentifier
 import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.database.DatabasePerformanceStatistics
 import arcs.core.storage.database.DatabaseRegistration
-import arcs.core.storage.database.DatabaseRegistry
 import arcs.core.storage.database.MutableDatabaseRegistry
 import arcs.core.util.guardedBy
 import arcs.core.util.performance.PerformanceStatistics
@@ -47,7 +46,7 @@ class FakeDatabaseManager : DatabaseManager {
 
     private val _manifest = FakeDatabaseRegistry()
     private val clients = arrayListOf<DatabaseClient>()
-    override val registry: DatabaseRegistry = _manifest
+    override val registry: FakeDatabaseRegistry = _manifest
 
     fun addClients(vararg clients: DatabaseClient) = this.clients.addAll(clients)
 
@@ -213,7 +212,9 @@ class FakeDatabaseRegistry : MutableDatabaseRegistry {
             entries.remove(it)
             return it.copy(lastAccessed = now).also { entry -> entries.add(entry) }
         }
-        return DatabaseRegistration(databaseName, isPersistent, now, now)
+        return DatabaseRegistration(databaseName, isPersistent, now, now).also {
+            entries.add(it)
+        }
     }
 
     @Synchronized

--- a/javatests/arcs/core/storage/database/BUILD
+++ b/javatests/arcs/core/storage/database/BUILD
@@ -1,0 +1,24 @@
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
+
+licenses(["notice"])
+
+package(default_visibility = ["//java/arcs:allowed-packages"])
+
+arcs_kt_jvm_test_suite(
+    name = "database",
+    package = "arcs.core.storage.database",
+    deps = [
+        "//java/arcs/core/common",
+        "//java/arcs/core/data",
+        "//java/arcs/core/storage/database",
+        "//java/arcs/core/testutil",
+        "//java/arcs/jvm/storage/database/testutil",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)

--- a/javatests/arcs/core/storage/database/DatabaseManagerTest.kt
+++ b/javatests/arcs/core/storage/database/DatabaseManagerTest.kt
@@ -1,0 +1,100 @@
+package arcs.core.storage.database
+
+import arcs.core.common.CompositeException
+import arcs.core.testutil.assertSuspendingThrows
+import arcs.jvm.storage.database.testutil.FakeDatabaseManager
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class DatabaseManagerTest {
+    private val databaseManager = FakeDatabaseManager()
+
+    private val dbNames = (1..100).map { "db$it" }
+
+    @Before
+    fun setup() {
+        databaseManager.registry.run {
+            dbNames.forEach {
+                register(it, true)
+            }
+        }
+    }
+
+    @Test
+    fun runOnAllDatabasesWaitsForAll() = runBlockingTest {
+        val visited = mutableListOf<String>()
+        databaseManager.runOnAllDatabases { name, _ ->
+            delay(1)
+            visited.add(name)
+        }
+        assertThat(visited).containsExactlyElementsIn(dbNames)
+    }
+
+    @Test
+    fun runOnAllDatabasesPropagatesException() = runBlockingTest {
+        val visited = mutableListOf<String>()
+
+        val throwFor = setOf("db12", "db42", "db66", "db88")
+        val exception = assertSuspendingThrows(CompositeException::class) {
+            databaseManager.runOnAllDatabases { name, _ ->
+                if (name in throwFor) {
+                    throw FakeException(name)
+                }
+                delay(1)
+                visited.add(name)
+            }
+        }
+        val expectExceptions = throwFor.map { FakeException(it) }
+        assertThat(exception.exceptions).containsExactlyElementsIn(expectExceptions)
+        assertThat(visited).containsExactlyElementsIn(dbNames - throwFor)
+    }
+
+    // We use [runBlocking] here instead of [runBlockingTest] since we want to create a separate
+    // scope that doesn't trigger cancellation of the wrapping scope.
+    @Test
+    fun runOnAllDatabasesFailureCancelsCallerScope() = runBlocking<Unit> {
+        // The goal of this test is to show that when we use runOnAllDatabases,
+        // 1) All database jobs will complete, even if an exception is thrown.
+        // 2) The *calling scope* of runOnAllDatabases will still be cancelled.
+        //
+        // In other words, we want to give all of the jobs a chance to run, but we still want
+        // normal failure behavior if one or more failures occur.
+
+        // Here we create a new scope that's separate from the one driving this test.
+        // That way, if an exception is thrown, it won't cancel our test, and we can
+        // inspect the state of the job.
+        val otherJob = Job()
+        val otherScope = CoroutineScope(otherJob)
+
+        val throwFor = setOf("db12", "db42", "db66", "db88")
+
+        // We launch a job in that separate scope.
+        otherScope.launch {
+            databaseManager.runOnAllDatabases { name, _ ->
+                if (name in throwFor) {
+                    throw FakeException(name)
+                }
+            }
+        }
+
+        // Here we wait for it to complete
+        otherJob.join()
+
+        // We expect it to be cancelled, not completed, since an exception was thrown.
+        assertThat(otherJob.isCancelled)
+    }
+
+    data class FakeException(val name: String) : Exception()
+}


### PR DESCRIPTION
This changes the behavior of `runOnAllDatabases` so that it runs all
jobs regardless of the failure of any other. Failures are returned as a
composite exception.

Questions are often raised about the behavior of `coroutineScope`. This
PR introduces a test for the `runOnAllDatabases` method to verify that
`coroutineScope` is actually behaving in the way we want.

Since the method isn't specific to Android database manager, this PR
also moves it to become an extension method on `DatabaseManager`.

Since the pattern may be useful in other contexts, I created
`CompositeException` and some generalized helpers that perform this
pattern.

I tried running the test with `coroutineScope` replaced with
`CoroutineScope(coroutineContext).launch` just to verify that the added
tests fail in that case.