### PR TITLE
Remove `runBlocking` from the `sendProxyMessage` service call.

### DIFF
--- a/java/arcs/core/common/BUILD
+++ b/java/arcs/core/common/BUILD
@@ -12,6 +12,7 @@ arcs_kt_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//java/arcs/core/util",
+        "//third_party/kotlin/kotlinx_atomicfu",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/core/common/CounterFlow.kt
+++ b/java/arcs/core/common/CounterFlow.kt
@@ -1,0 +1,33 @@
+package arcs.core.common
+
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Provides a counter with increment/decrement functionality whose value can be observed via a
+ * Flow<Int>.
+ *
+ * The counter value will be conflated: if a large number of changes occur at once, collectors of
+ * the flow may not receive all of them, but are guaranteed to receive the most recent one.
+ */
+class CounterFlow(initialValue: Int = 0) {
+    private val count = atomic(initialValue)
+    private val stateFlow = MutableStateFlow<Int>(initialValue)
+
+    /**
+     * Returns a [Flow<Int>] that emits counter changes. Not every change is guaranteed to be emitted, but
+     * you're always guaranteed to receive the last one.
+     */
+    val flow: Flow<Int> = stateFlow
+
+    /**
+     * Increments the counter. The change will be emitted on any active collections of [flow].
+     */
+    fun increment() { stateFlow.value = count.incrementAndGet() }
+
+    /**
+     * Decrements the counter. The change will be emitted on any active collections of [flow].
+     */
+    fun decrement() { stateFlow.value = count.decrementAndGet() }
+}

--- a/javatests/arcs/android/storage/service/BindingContextTest.kt
+++ b/javatests/arcs/android/storage/service/BindingContextTest.kt
@@ -89,7 +89,7 @@ class BindingContextTest {
         val bindingContext = buildContext()
         val callback = DeferredProxyCallback()
 
-        val token = suspendForRegistrationCallback {
+        suspendForRegistrationCallback {
             bindingContext.registerCallback(callback, it)
         }
 
@@ -161,6 +161,11 @@ class BindingContextTest {
 
         suspendForResultCallback {
             bindingContext.sendProxyMessage(message.toProto().toByteArray(), it)
+        }
+
+        // sendProxyMessage does not wait for the op to complete.
+        suspendForResultCallback { resultCallback ->
+            bindingContext.idle(10000, resultCallback)
         }
 
         assertThat(receivedKey).isEqualTo(storageKey)

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -1120,7 +1120,6 @@ open class HandleManagerTestBase {
             log("Monitor Handle: $it")
         }
         val monitorSawEntities = monitorHandle.onUpdateDeferred {
-            log("First batch of entities - so far: $it")
             it.size() == 2
         }
         writeEntityHandle.dispatchStore(entity1, entity2)

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
@@ -98,9 +98,16 @@ class StorageServiceTest {
             val proxyMessage = ProxyMessage.Operations<CrdtCount.Data, CrdtCount.Operation, Int>(
                 listOf(op), id = 1
             )
+
             suspendForResultCallback {
                 context.sendProxyMessage(proxyMessage.toProto().toByteArray(), it)
             }
+
+            suspendForResultCallback {
+                context.idle(10000, it)
+            }
+
+            true
         }
         assertThat(success).isTrue()
 
@@ -108,6 +115,7 @@ class StorageServiceTest {
         // Pass the nextStartedService to the resurrectionHelper. If it was a resurrection intent,
         // the helper's callback will be triggered, adding to `receivedUpdates`.
         val shadowApp = shadowOf(app)
+
         resurrectionHelper.onStartCommand(shadowApp.nextStartedService)
         assertThat(receivedUpdates).hasSize(1)
         assertThat(receivedUpdates[0]).containsExactly(storeOptions.storageKey)


### PR DESCRIPTION
Includes the following fixes:
* Update StorageService.idle object to wait for in-flight API calls to
  complete before idling on the store.
* To support in-flight call tracking, add a `CounterFlow` helper that
  wraps an atomic counter and a `StateFlow`, and provides a simple
  interface to increment/decrement the counter, and to get a flow of its
  values.
* In order to maintain ordering of operations we introduce a mutex to
  wrap execution of API actions. This should eventually be replaced
  with a proper queue solution.
* Add a needed idle in `BindingContextText.causesSendToCallback` and
  `sendingProxyMessage_resultsInResurrection` tests.