### PR TITLE
Remove boolean return value from `onProxyMessage`

### DIFF
--- a/java/arcs/android/storage/service/BindingContext.kt
+++ b/java/arcs/android/storage/service/BindingContext.kt
@@ -150,9 +150,8 @@ class BindingContext(
                     val actualMessage = proxyMessage.decodeProxyMessage()
 
                     (store() as ActiveStore<CrdtData, CrdtOperation, Any?>).let { store ->
-                        if (store.onProxyMessage(actualMessage)) {
-                            onProxyMessage(store.storageKey, actualMessage)
-                        }
+                        store.onProxyMessage(actualMessage)
+                        onProxyMessage(store.storageKey, actualMessage)
                     }
                 }
             }

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -41,7 +41,7 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
     abstract fun off(callbackToken: Int)
 
     /** Handles a message from the storage proxy. */
-    abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
+    abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>)
 
     /** Performs any operations that are needed to release resources held by this [ActiveStore]. */
     open fun close() = Unit

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -149,13 +149,12 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
      */
     override suspend fun onProxyMessage(
         message: ProxyMessage<Data, Op, T>
-    ): Boolean {
-        return when (message) {
+    ) {
+        when (message) {
             is ProxyMessage.SyncRequest -> {
                 callbackManager.getCallback(message.id)?.invoke(
                     ProxyMessage.ModelUpdate(getLocalData(), message.id)
                 )
-                true
             }
             is ProxyMessage.Operations -> {
                 val failure = synchronized(this) {
@@ -166,7 +165,6 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                     callbackManager.getCallback(message.id)?.invoke(
                         ProxyMessage.SyncRequest(message.id)
                     )
-                    false
                 } else {
                     if (message.operations.isNotEmpty()) {
                         val change = CrdtChange.Operations<Data, Op>(
@@ -184,7 +182,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                             )
                         }
                     }
-                    true
+                    Unit
                 }
             }
             is ProxyMessage.ModelUpdate -> {
@@ -201,7 +199,6 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
                         channel = message.id
                     )
                 }
-                true
             }
         }.also {
             log.verbose { "Model after proxy message: ${localModel.data}" }

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -117,16 +117,16 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     suspend fun onProxyMessage(
         message: ProxyMessage<Data, Op, T>,
         referenceId: String
-    ): Boolean {
+    ) {
         val (id, store) = store(referenceId)
         val deMuxedMessage: ProxyMessage<Data, Op, T> = when (message) {
             is SyncRequest -> SyncRequest(id)
             is ModelUpdate -> ModelUpdate(message.model, id)
             is Operations -> if (message.operations.isNotEmpty()) {
                 Operations(message.operations, id)
-            } else return true
+            } else return
         }
-        return store.onProxyMessage(deMuxedMessage)
+        store.onProxyMessage(deMuxedMessage)
     }
 
     /* internal */ suspend fun setupStore(referenceId: String): StoreRecord<Data, Op, T> {

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -115,5 +115,5 @@ interface StorageEndpoint<Data : CrdtData, Op : CrdtOperation, ConsumerData> : C
     /**
      * Sends the storage layer a message from a [StorageProxy].
      */
-    suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean
+    suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>)
 }

--- a/java/arcs/sdk/android/storage/ServiceStore.kt
+++ b/java/arcs/sdk/android/storage/ServiceStore.kt
@@ -130,7 +130,7 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         service.unregisterCallback(callbackToken)
     }
 
-    override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>): Boolean {
+    override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>) {
         val service = checkNotNull(storageService)
         val result = DeferredResult(coroutineContext)
         // Trick: make an indirect access to the message to keep kotlin flow
@@ -138,11 +138,10 @@ class ServiceStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
         outgoingMessages.incrementAndGet()
         service.sendProxyMessage(message.toProto().toByteArray(), result)
         // Just return false if the message couldn't be applied.
-        return try {
+        try {
             result.await()
         } catch (e: CrdtException) {
             log.debug(e) { "CrdtException occurred in onProxyMessage" }
-            false
         } finally {
             outgoingMessages.decrementAndGet()
         }

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -129,11 +129,9 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
         logRule("Sending ModelUpdate")
 
-        assertThat(
             activeStore.onProxyMessage(
                 ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
             )
-        ).isTrue()
 
         activeStore.idle()
 
@@ -193,14 +191,12 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         val bobEntity = createPersonEntityCrdt()
 
         // Apply to RefMode store.
-        assertThat(
-            activeStore.onProxyMessage(
-                ProxyMessage.Operations(
-                    listOf(RefModeStoreOp.SetAdd("me", VersionMap("me" to 1), bob)),
-                    id = 1
-                )
+        activeStore.onProxyMessage(
+            ProxyMessage.Operations(
+                listOf(RefModeStoreOp.SetAdd("me", VersionMap("me" to 1), bob)),
+                id = 1
             )
-        ).isTrue()
+        )
 
         // Apply to expected collection representation
         assertThat(personCollection.applyOperation(operation)).isTrue()
@@ -286,18 +282,14 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
         // Add Bob to collection.
         val addOp = RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
         // Bob was added to the backing store.
         val storedBob = activeStore.backingStore.getLocalData("an-id")
         assertThat(storedBob.toRawEntity("an-id")).isEqualTo(bob)
 
         // Remove Bob from the collection.
         val deleteOp = RefModeStoreOp.SetRemove(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
 
         // Check the backing store Bob has been cleared.
         val storedBob2 = activeStore.backingStore.getLocalData("an-id")
@@ -335,17 +327,13 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
         // Set singleton to Bob.
         val updateOp = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
         // Bob was added to the backing store.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("an-id")
 
         // Remove Bob from the collection.
         val clearOp = RefModeStoreOp.SingletonClear(actor, VersionMap(actor to 1))
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(clearOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(clearOp), id = 1))
 
         // Check memory copy has been freed.
         assertThat(activeStore.backingStore.stores.keys).isEmpty()
@@ -360,17 +348,14 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
         // Set singleton to Bob.
         val updateOp = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
+
         // Bob was added to the backing store.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("b-id")
 
         // Set singleton to Alice.
         val updateOp2 = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 2), alice)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp2), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp2), id = 1))
 
         // Check Bob's memory copy has been freed.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("a-id")
@@ -396,9 +381,8 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
 
         // Add Bob to collection.
         val addOp = RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
+
         activeStore.idle()
 
         // Check Bob from backing store.

--- a/javatests/arcs/android/storage/service/BindingContextTest.kt
+++ b/javatests/arcs/android/storage/service/BindingContextTest.kt
@@ -134,7 +134,7 @@ class BindingContextTest {
             ),
             id = null
         )
-        assertThat(store().onProxyMessage(message)).isTrue()
+        store().onProxyMessage(message)
 
         assertThat(callback.isCompleted).isEqualTo(false)
     }

--- a/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
@@ -78,12 +78,8 @@ class RamDiskDirectStoreMuxerIntegrationTest {
         val count2 = CrdtCount()
         count2.applyOperation(MultiIncrement("them", version = 0 to 10, delta = 15))
 
-        assertThat(
-            store.onProxyMessage(ProxyMessage.ModelUpdate(count1.data, null), "thing0")
-        ).isTrue()
-        assertThat(
-            store.onProxyMessage(ProxyMessage.ModelUpdate(count2.data, null), "thing1")
-        ).isTrue()
+        store.onProxyMessage(ProxyMessage.ModelUpdate(count1.data, null), "thing0")
+        store.onProxyMessage(ProxyMessage.ModelUpdate(count2.data, null), "thing1")
 
         store.idle()
 

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -94,11 +94,9 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
         logRule("Sending ModelUpdate")
 
-        assertThat(
-            activeStore.onProxyMessage(
-                ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
-            )
-        ).isTrue()
+        activeStore.onProxyMessage(
+            ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
+        )
 
         logRule("ModelUpdate sent")
 
@@ -196,14 +194,12 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         val bobEntity = createPersonEntityCrdt()
 
         // Apply to RefMode store.
-        assertThat(
-            activeStore.onProxyMessage(
-                ProxyMessage.Operations(
-                    listOf(RefModeStoreOp.SetAdd("me", VersionMap("me" to 1), bob)),
-                    id = 1
-                )
+        activeStore.onProxyMessage(
+            ProxyMessage.Operations(
+                listOf(RefModeStoreOp.SetAdd("me", VersionMap("me" to 1), bob)),
+                id = 1
             )
-        ).isTrue()
+        )
 
         // Apply to expected collection representation
         assertThat(personCollection.applyOperation(operation)).isTrue()
@@ -265,18 +261,15 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
         // Add Bob to collection.
         val addOp = RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
+
         // Bob was added to the backing store.
         val storedBob = activeStore.backingStore.getLocalData("an-id")
         assertThat(storedBob.toRawEntity("an-id")).isEqualTo(bob)
 
         // Remove Bob from the collection.
         val deleteOp = RefModeStoreOp.SetRemove(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
 
         // Check the backing store Bob has been cleared.
         val storedBob2 = activeStore.backingStore.getLocalData("an-id")
@@ -304,17 +297,14 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
         // Set singleton to Bob.
         val updateOp = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
+
         // Bob was added to the backing store.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("an-id")
 
         // Remove Bob from the collection.
         val clearOp = RefModeStoreOp.SingletonClear(actor, VersionMap(actor to 1))
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(clearOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(clearOp), id = 1))
 
         // Check memory copy has been freed.
         assertThat(activeStore.backingStore.stores.keys).isEmpty()
@@ -329,17 +319,14 @@ class ReferenceModeStoreDatabaseIntegrationTest {
 
         // Set singleton to Bob.
         val updateOp = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
+
         // Bob was added to the backing store.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("b-id")
 
         // Set singleton to Alice.
         val updateOp2 = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 2), alice)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp2), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp2), id = 1))
 
         // Check Bob's memory copy has been freed.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("a-id")

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -124,11 +124,9 @@ class ReferenceModeStoreTest {
             CrdtSet.Operation.Add("me", VersionMap("me" to 1), entity)
         )
 
-        assertThat(
-            activeStore.onProxyMessage(
-                ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
-            )
-        ).isTrue()
+        activeStore.onProxyMessage(
+            ProxyMessage.ModelUpdate(RefModeStoreData.Set(collection.data), 1)
+        )
 
         val actor = activeStore.crdtKey
 
@@ -182,14 +180,12 @@ class ReferenceModeStoreTest {
         val bobEntity = createPersonEntityCrdt()
 
         // Apply to RefMode store.
-        assertThat(
-            activeStore.onProxyMessage(
-                ProxyMessage.Operations(
-                    listOf(RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)),
-                    id = 1
-                )
+        activeStore.onProxyMessage(
+            ProxyMessage.Operations(
+                listOf(RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)),
+                id = 1
             )
-        ).isTrue()
+        )
 
         // Apply to expected collection representation
         assertThat(personCollection.applyOperation(operation)).isTrue()
@@ -242,18 +238,15 @@ class ReferenceModeStoreTest {
 
         // Add Bob to collection.
         val addOp = RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
+
         // Bob was added to the backing store.
         val storedBob = activeStore.backingStore.getLocalData("an-id")
         assertThat(storedBob.toRawEntity("an-id")).isEqualTo(bob)
 
         // Remove Bob from the collection.
         val deleteOp = RefModeStoreOp.SetRemove(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
 
         // Check the backing store Bob has been cleared.
         val storedBob2 = activeStore.backingStore.getLocalData("an-id")
@@ -270,11 +263,11 @@ class ReferenceModeStoreTest {
         // Add a couple of people.
         val alice = createPersonEntity("id1", "alice", 10)
         val addOp1 = listOf(RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), alice))
-        assertThat(activeStore.onProxyMessage(ProxyMessage.Operations(addOp1, id = 1))).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(addOp1, id = 1))
 
         val bob = createPersonEntity("id2", "bob", 20)
         val addOp2 = listOf(RefModeStoreOp.SetAdd(actor, VersionMap(actor to 2), bob))
-        assertThat(activeStore.onProxyMessage(ProxyMessage.Operations(addOp2, id = 2))).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(addOp2, id = 2))
 
         // Verify that they've been stored.
         val storedRefs = activeStore.containerStore.getLocalData() as CrdtSet.Data<Reference>
@@ -288,7 +281,7 @@ class ReferenceModeStoreTest {
 
         // Clear!
         val clearOp = listOf(RefModeStoreOp.SetClear(actor, VersionMap(actor to 2)))
-        assertThat(activeStore.onProxyMessage(ProxyMessage.Operations(clearOp, null))).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(clearOp, null))
 
         val clearedRefs = activeStore.containerStore.getLocalData() as CrdtSet.Data<Reference>
         assertThat(clearedRefs.values.keys).isEmpty()
@@ -310,17 +303,14 @@ class ReferenceModeStoreTest {
 
         // Set singleton to Bob.
         val updateOp = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
+
         // Bob was added to the backing store.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("an-id")
 
         // Remove Bob from the collection.
         val clearOp = RefModeStoreOp.SingletonClear(actor, VersionMap(actor to 1))
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(clearOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(clearOp), id = 1))
 
         // Check memory copy has been freed.
         assertThat(activeStore.backingStore.stores.keys).isEmpty()
@@ -337,17 +327,14 @@ class ReferenceModeStoreTest {
 
         // Set singleton to Bob.
         val updateOp = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 1), bob)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp), id = 1))
+
         // Bob was added to the backing store.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("b-id")
 
         // Set singleton to Alice.
         val updateOp2 = RefModeStoreOp.SingletonUpdate(actor, VersionMap(actor to 2), alice)
-        assertThat(
-            activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp2), id = 1))
-        ).isTrue()
+        activeStore.onProxyMessage(ProxyMessage.Operations(listOf(updateOp2), id = 1))
 
         // Check Bob's memory copy has been freed.
         assertThat(activeStore.backingStore.stores.keys).containsExactly("a-id")
@@ -518,11 +505,9 @@ class ReferenceModeStoreTest {
         val driver = activeStore.containerStore.driver as MockDriver<CrdtSet.Data<Reference>>
         driver.fail = true // make sending return false
 
-        assertThat(
-            activeStore.onProxyMessage(
-                ProxyMessage.ModelUpdate(RefModeStoreData.Set(bobCollection.data), id = 1)
-            )
-        ).isTrue()
+        activeStore.onProxyMessage(
+            ProxyMessage.ModelUpdate(RefModeStoreData.Set(bobCollection.data), id = 1)
+        )
         assertThat(driver.sentData).isNotEmpty() // send should've been called.
 
         driver.fail = false // make sending work.

--- a/javatests/arcs/core/storage/ReferenceTest.kt
+++ b/javatests/arcs/core/storage/ReferenceTest.kt
@@ -79,7 +79,7 @@ class ReferenceTest {
                 Person("Watson", 6).toRawEntity()
             )
         )
-        assertThat(store.onProxyMessage(ProxyMessage.Operations(addPeople, 1))).isTrue()
+        store.onProxyMessage(ProxyMessage.Operations(addPeople, 1))
 
         log("Setting up direct store to collection of references")
         val collectionOptions =
@@ -96,8 +96,7 @@ class ReferenceTest {
         val me = directCollection.on(ProxyCallback {
             if (it is ProxyMessage.ModelUpdate<*, *, *>) job.complete()
         })
-        assertThat(directCollection.onProxyMessage(ProxyMessage.SyncRequest(me)))
-            .isTrue()
+        directCollection.onProxyMessage(ProxyMessage.SyncRequest(me))
         directCollection.idle()
         job.join()
 

--- a/javatests/arcs/core/storage/StoreEndpointFake.kt
+++ b/javatests/arcs/core/storage/StoreEndpointFake.kt
@@ -21,12 +21,9 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
     private var target: Target<Data, Op, T>? = null
     var closed = false
 
-    // Tests can change this field to alter the value returned by `onProxyMessage`.
-    var onProxyMessageReturn = true
-
     override suspend fun idle() = Unit
 
-    override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>): Boolean {
+    override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>) {
         targetMutex.withLock {
             proxyMessages = proxyMessages + message
             log.info { "onProxyMessage($message) - current value: $proxyMessages" }
@@ -37,7 +34,7 @@ class StoreEndpointFake<Data : CrdtData, Op : CrdtOperation, T> :
             }
         }
 
-        return onProxyMessageReturn
+        return
     }
 
     suspend fun getProxyMessages(): List<ProxyMessage<Data, Op, T>> = targetMutex.withLock {

--- a/javatests/arcs/core/storage/StoreTest.kt
+++ b/javatests/arcs/core/storage/StoreTest.kt
@@ -82,8 +82,7 @@ class StoreTest {
         val count = CrdtCount()
         count.applyOperation(Increment("me", 0 to 1))
 
-        assertThat(store.onProxyMessage(ProxyMessage.ModelUpdate(count.data, 1)))
-            .isTrue()
+        store.onProxyMessage(ProxyMessage.ModelUpdate(count.data, 1))
 
         assertThat(driver.lastData).isEqualTo(count.data)
     }
@@ -97,7 +96,7 @@ class StoreTest {
         val count = CrdtCount()
         val op = Increment("me", 0 to 1)
 
-        assertThat(store.onProxyMessage(ProxyMessage.Operations(listOf(op), 1))).isTrue()
+        store.onProxyMessage(ProxyMessage.Operations(listOf(op), 1))
 
         count.applyOperation(op)
 
@@ -265,11 +264,10 @@ class StoreTest {
         val remoteCount = CrdtCount()
         remoteCount.applyOperation(Increment("them", 0 to 1))
 
-        val result = activeStore.onProxyMessage(ProxyMessage.ModelUpdate(count.data, 1))
+        activeStore.onProxyMessage(ProxyMessage.ModelUpdate(count.data, 1))
         println("Received result.")
 
         firstCallComplete.await()
-        assertThat(result).isTrue()
 
         println("Setting up for round two")
         // Reset, this time we'll capture the model it receives.


### PR DESCRIPTION
Nothing meaningfully acts on this return value, and we should not
actually need it. The typescript implementation doesn't include it.

We'd already gone part of the way down this road in removing the value
for the StorageService APIs, this removes it from the `ActiveStore`
onProxyMessage definition.

The one place the value seems to be used meaningfully is in
ReferenceModeStore, when interacting with the DirectStores of the
DirectStoreMuxer. But all that happens there is throwing an exception.
That behavior isn't needed, and no tests even verified it.