### PR TITLE
Test refinement scoping for field names and ensure source locations are attached

### DIFF
--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1248,7 +1248,7 @@ RecipeConnection
     const anyTarget = toAstNode<AstNode.NameConnectionTarget>({
       kind: 'connection-target',
       targetType: 'localName',
-      name: undefined,
+      name: null,
       param: '*',
       tags: [],
     });

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -106,7 +106,7 @@ class ManifestVisitor {
   }
 
   // Parents are visited before children, but an implementation can force
-  // children to be visted by calling `visitChildren()`.
+  // children to be visited by calling `visitChildren()`.
   visit(node: AstNode.BaseNode, visitChildren: Runnable) {
   }
 }
@@ -633,7 +633,11 @@ ${e.message}
             const typeData = {};
             for (let {name, type} of node.fields) {
               if (type && type.refinement) {
-                type.refinement = Refinement.fromAst(type.refinement, {[name]: type.type});
+                try {
+                  type.refinement = Refinement.fromAst(type.refinement, {[name]: type.type});
+                } catch (e) {
+                    throw new ManifestError(node.location, e.message);
+                }
               }
               for (const schema of schemas) {
                 if (!type) {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -822,6 +822,36 @@ ${particleStr1}
         }
       };
 
+      it('checks refinement expressions with out of scope variables', Flags.withFieldRefinementsAllowed(async () => {
+        assertThrowsAsync(async () => {
+          await parseManifest(`
+            particle Writer
+              output: writes Something {num: Number [ foo > 5 ] }
+            particle Reader
+              input: reads Something {num: Number [ foo > 3 ] }
+            recipe Foo
+              Writer
+                output: writes data
+              Reader
+                input: reads data
+          `);
+        }, 'Unresolved field name \'foo\' in the refinement expression');
+      }));
+      it('checks refinement expressions with out of scope field names', Flags.withFieldRefinementsAllowed(async () => {
+        assertThrowsAsync(async () => {
+          await parseManifest(`
+            particle Writer
+              output: writes Something {num: Number [ other_num > 5 ], other_num: Number }
+            particle Reader
+              input: reads Something {num: Number [ other_num > 3 ], other_num: Number }
+            recipe Foo
+              Writer
+                output: writes data
+              Reader
+                input: reads data
+          `);
+        }, 'Unresolved field name \'other_num\' in the refinement expression.');
+      }));
       it('checks refinement expressions', Flags.withFieldRefinementsAllowed(async () => {
         const manifest = await parseManifest(`
           particle Writer


### PR DESCRIPTION
Just adding tests and a tiny fix for a refinement issue where errors were reported without their source location.