### PR TITLE
Make ts imports consistent in the github code base.

### DIFF
--- a/src/tools/dev_server/hot-reload-server.ts
+++ b/src/tools/dev_server/hot-reload-server.ts
@@ -9,7 +9,7 @@
  */
 
 import WebSocket from 'ws';
-import * as fs from 'fs';
+import fs from 'fs';
 
 /**
  * Hot Reload Server is opening a WebSocket connection for Arcs Explorer to support hot code reload feature.

--- a/src/tools/language-server/util.ts
+++ b/src/tools/language-server/util.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as url from 'url';
+import url from 'url';
 import fs from 'fs';
 
 export interface LanguageServiceOptions {

--- a/src/tools/vscode-language-client/src/workspace.ts
+++ b/src/tools/vscode-language-client/src/workspace.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import * as path from 'path';
+import path from 'path';
 import {
   Disposable,
   ExtensionContext,


### PR DESCRIPTION
This is necessary to keep copybara transformations simpler. The convention that I am trying to follow is that github codebase has the `import fs from 'fs';` form and the google codebase has the `import * as fs from 'fs';` form.