### PR TITLE
parse functionCall(args).field in TS

### DIFF
--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -903,7 +903,7 @@ export interface FieldExpressionNode extends BaseNode {
 
 export interface FunctionExpressionNode extends BaseNode {
   kind: 'paxel-function';
-  function: PaxelFunction;
+  function: string;
   arguments: PaxelExpressionNode[];
 }
 

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1868,8 +1868,8 @@ FunctionCall
 PrimaryExpression
   = '(' whiteSpace? expr:PaxelExpressionWithRefinement whiteSpace? ')'
   {
-    if (!isPaxelMode() && expr.kind.indexOf('paxel-') != -1) {
-      error('Paxel expressions are not allowed in refinements.')
+    if (!isPaxelMode() && expr.kind.indexOf('paxel-') !== -1) {
+      error('Paxel expressions are not allowed in refinements.');
     }
     return expr;
   }

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1720,7 +1720,7 @@ ExpressionEntityFields
   }
 
 ExpressionEntityField
-  = fieldName:fieldName whiteSpace? ':' whiteSpace? expression:RefinementExpression {
+  = fieldName:fieldName whiteSpace? ':' whiteSpace? expression:PaxelExpressionWithRefinement {
     return toAstNode<AstNode.ExpressionEntityField>({
         kind: 'expression-entity-field',
         name: fieldName,
@@ -1866,8 +1866,11 @@ FunctionCall
   }
 
 PrimaryExpression
-  = '(' whiteSpace? expr:RefinementExpression whiteSpace? ')'
+  = '(' whiteSpace? expr:PaxelExpressionWithRefinement whiteSpace? ')'
   {
+    if (!isPaxelMode() && expr.kind.indexOf('paxel-') != -1) {
+      error('Paxel expressions are not allowed in refinements.')
+    }
     return expr;
   }
   / op:(('not' whiteSpace) / ('-' whiteSpace?)) expr:PrimaryExpression

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -680,6 +680,12 @@ describe('manifest parser', () => {
           input: reads Something {value: Text } [ average() > 0 ]
         `);
     }, `Paxel function calls other to now() are permitted only in paxel expressions`);
+    assert.throws(() => {
+      parse(`
+        particle Foo
+          input: reads Something {value: Text } [ (from p in q select p) > 0 ]
+        `);
+    }, `Paxel expressions are not allowed in refinements`);
   });
   it('parses nested referenced inline schemas', () => {
     parse(`
@@ -885,6 +891,20 @@ describe('manifest parser', () => {
       particle Converter
         foo: reads Foo {x: Number}
         bar: writes Bar {y: Number} = from p in foo.x select new Bar {y: p.num / 2}
+      `);
+    });
+    it('allows paxel expressions in new nested entity selection', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x select new Bar {y: (from p in foo.z select first(p))/2}
+      `);
+    });
+    it('allows paxel expressions in new entity selection', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x select new Bar {y: from p in foo.z select first(p)}
       `);
     });
     it('allows function calls as qualifiers', () => {

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -668,6 +668,18 @@ describe('manifest parser', () => {
           input: reads Something {value: Text } [ value.x / 2 ]
         `);
     }, `Scope lookups are not permitted`);
+    assert.throws(() => {
+      parse(`
+        particle Foo
+          input: reads Something {value: Text } [ now(x) > 0 ]
+        `);
+    }, `Functions may have arguments only in paxel expressions`);
+    assert.throws(() => {
+      parse(`
+        particle Foo
+          input: reads Something {value: Text } [ average() > 0 ]
+        `);
+    }, `Paxel function calls other to now() are permitted only in paxel expressions`);
   });
   it('parses nested referenced inline schemas', () => {
     parse(`
@@ -873,6 +885,20 @@ describe('manifest parser', () => {
       particle Converter
         foo: reads Foo {x: Number}
         bar: writes Bar {y: Number} = from p in foo.x select new Bar {y: p.num / 2}
+      `);
+    });
+    it('allows function calls as qualifiers', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x select new Bar {y: first(foo).x}
+      `);
+    });
+    it('allows complex qualifiers in where condition', () => {
+      parse(`
+      particle Converter
+        foo: reads Foo {x: Number}
+        bar: writes Bar {y: Number} = from p in foo.x where first(foo).x < p.y select new Bar {y: foo.x}
       `);
     });
     it('fails expression without starting from', () => {


### PR DESCRIPTION
Now handles foo.bar.baz, foo(args).baz, and args can be any paxel expression, e.g. first(from p in blah select p).x
