### PR TITLE
Cleans up EvaluatorParticleTest

### DIFF
--- a/javatests/arcs/core/data/expression/EvaluatorParticleTest.kt
+++ b/javatests/arcs/core/data/expression/EvaluatorParticleTest.kt
@@ -11,7 +11,6 @@
 
 package arcs.core.data.expression
 
-import arcs.core.data.Plan
 import arcs.core.data.expression.AbstractNumberSetMultiplier.Scalar
 import arcs.core.data.expression.AbstractNumberSetMultiplier.Value
 import arcs.core.testutil.handles.dispatchFetch
@@ -31,28 +30,7 @@ class EvaluatorParticleTest {
 
     @get:Rule
     val harness = NumberSetMultiplierTestHarness {
-        EvaluatorParticle(addExpression(MultiplierPlan.particles.first()))
-    }
-
-    // This is temporary while we don't yet pass Expression AST all the way from the parser.
-    private fun addExpression(particle: Plan.Particle) = Plan.Particle.handlesLens.mod(particle) {
-        mapOf(
-            "inputNumbers" to requireNotNull(particle.handles["inputNumbers"]),
-            "scalar" to requireNotNull(particle.handles["scalar"]),
-            "scaledNumbers" to requireNotNull(particle.handles["scaledNumbers"]).copy(
-                expression = PaxelParser.parse("""
-                    |from x in inputNumbers select new Value {
-                    |  value: x.value * scalar.magnitude
-                    |}""".trimMargin())
-            ),
-            "average" to requireNotNull(particle.handles["average"]).copy(
-                expression = PaxelParser.parse("""
-                   |new Average {
-                   |  average: average(from x in inputNumbers select x.value)
-                   |}""".trimMargin()
-                )
-            )
-        )
+        EvaluatorParticle(MultiplierPlan.particles.first())
     }
 
     @Test

--- a/javatests/arcs/core/data/expression/ParserTest.kt
+++ b/javatests/arcs/core/data/expression/ParserTest.kt
@@ -189,7 +189,12 @@ class ParserTest {
         PaxelParser.parse("from p in q where p < 1 select new Foo { x: union(q,q) }")
         PaxelParser.parse("from p in q where p < 1 select new Foo { x: first(q) }")
         PaxelParser.parse("from p in q where p < 1 select new Foo { x: first(q).x }")
-        PaxelParser.parse("from p in q where p < 1 select new Foo { x: first(from x in p select x).x }")
+        PaxelParser.parse("""
+            |from p in q
+            |where p < 1 
+            |select new Foo {
+            |  x: first(from x in p select x).x 
+            |}""".trimMargin())
     }
 
     @Test

--- a/javatests/arcs/core/data/expression/Particles.arcs
+++ b/javatests/arcs/core/data/expression/Particles.arcs
@@ -4,14 +4,14 @@ meta
 particle NumberSetMultiplier
   inputNumbers: reads [Value {value: Number}]
   scalar: reads Scalar {magnitude: Number}
-  scaledNumbers: writes [Value {value: Number}]
-  // = from x in inputNumbers select new Value {
-  //   value: x.value * scalar.magnitude
-  // }
-  average: writes Average {average: Number}
-  // = new Average {
-  // average: average(from x in inputNumbers select x.value)
-  // }
+  scaledNumbers: writes [Value {value: Number}] =
+    from x in inputNumbers select new Value {
+      value: x.value * scalar.magnitude
+    }
+  average: writes Average {average: Number} =
+    new Average {
+      average: average(from x in inputNumbers select x.value)
+    }
 
 recipe Multiplier
   inputNumbers: create


### PR DESCRIPTION
Everything that's needed is supported now in the TS Parser, so we can parse the expressions directly from the Arcs manifest.