### PR TITLE
Prohibit importing internal files from other modules in our custom loader

### DIFF
--- a/src/crdt/tests/crdt-collection-test.ts
+++ b/src/crdt/tests/crdt-collection-test.ts
@@ -8,9 +8,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {assert} from '../../../platform/chai-web.js';
-import {ChangeType, VersionMap, isEmptyChange} from '../crdt.js';
-import {CollectionOpTypes, CRDTCollection, CollectionOperation, simplifyFastForwardOp} from '../crdt-collection.js';
+import {assert} from '../../platform/chai-web.js';
+import {ChangeType, VersionMap, CollectionOpTypes, CRDTCollection, CollectionOperation} from '../lib-crdt.js';
+import {isEmptyChange} from '../internal/crdt.js';
+import {simplifyFastForwardOp} from '../internal/crdt-collection.js';
 
 /** Creates an Add operation. */
 function addOp(id: string, actor: string, clock: VersionMap): CollectionOperation<{id: string}> {

--- a/src/crdt/tests/crdt-count-test.ts
+++ b/src/crdt/tests/crdt-count-test.ts
@@ -8,9 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {assert} from '../../../platform/chai-web.js';
-import {CountOpTypes, CRDTCount} from '../crdt-count.js';
-import {CRDTError, ChangeType} from '../crdt.js';
+import {assert} from '../../platform/chai-web.js';
+import {CountOpTypes, CRDTCount, CRDTError, ChangeType} from '../lib-crdt.js';
 
 describe('CRDTCount', () => {
 

--- a/src/crdt/tests/crdt-entity-test.ts
+++ b/src/crdt/tests/crdt-entity-test.ts
@@ -8,11 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {assert} from '../../../platform/chai-web.js';
-import {Referenceable} from '../crdt.js';
-import {CRDTEntity, EntityOpTypes} from '../crdt-entity.js';
-import {CRDTSingleton} from '../crdt-singleton.js';
-import {CRDTCollection} from '../crdt-collection.js';
+import {assert} from '../../platform/chai-web.js';
+import {Referenceable, CRDTEntity, EntityOpTypes, CRDTSingleton, CRDTCollection} from '../lib-crdt.js';
 
 describe('CRDTEntity', () => {
   it('has reasonable defaults for singletons and sets', () => {

--- a/src/crdt/tests/crdt-singleton-test.ts
+++ b/src/crdt/tests/crdt-singleton-test.ts
@@ -8,9 +8,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {assert} from '../../../platform/chai-web.js';
-import {ChangeType} from '../crdt.js';
-import {CRDTSingleton, SingletonOpTypes} from '../crdt-singleton.js';
+import {assert} from '../../platform/chai-web.js';
+import {ChangeType, CRDTSingleton, SingletonOpTypes} from '../lib-crdt.js';
 
 describe('CRDTSingleton', () => {
   it('can set values from a single actor', () => {

--- a/tools/custom-loader.mjs
+++ b/tools/custom-loader.mjs
@@ -22,7 +22,8 @@ export function resolve(specifier, parent, resolve) {
     // If the parent is '<path>/src/module/tests/file.js', the root is '<path>/src/module';
     // otherwise the root is just the parent dir itself.
     const root = (path.basename(parentDir) === 'tests') ? path.dirname(parentDir) : parentDir;
-    const target = path.resolve(parentDir, specifier);
+    const target = path.resolve(parentDir, specifier)
+                       .replace(new RegExp(String.fromCharCode(92, 92), 'g'), '/');
 
     // Temporary logging to help debug Windows builds...
     console.log('parent     =', parent);

--- a/tools/custom-loader.mjs
+++ b/tools/custom-loader.mjs
@@ -15,8 +15,8 @@ export function resolve(specifier, parent, resolve) {
   }
 
   // Prohibit importing from another module's internal directory.
-  if (parent && parent.startsWith('file:///') && specifier.includes('/internal/')) {
-    const parentFile = parent.substr(7);  // 7 == len('file://')
+  if (parent && parent.startsWith('file://') && specifier.includes('/internal/')) {
+    const parentFile = parent.substr(parent.match('^file:///[A-Z]:/') ? 8 : 7);
     const parentDir = path.dirname(parentFile);
 
     // If the parent is '<path>/src/module/tests/file.js', the root is '<path>/src/module';
@@ -33,7 +33,7 @@ export function resolve(specifier, parent, resolve) {
     console.log('target     =', target);
     console.log();
 
-    if (!target.startsWith(root)) {
+    if (1) { //!target.startsWith(root)) {
       throw new Error(`cannot access internal file '${target}' from location '${parentFile}'`);
     }
   }

--- a/tools/custom-loader.mjs
+++ b/tools/custom-loader.mjs
@@ -23,6 +23,16 @@ export function resolve(specifier, parent, resolve) {
     // otherwise the root is just the parent dir itself.
     const root = (path.basename(parentDir) === 'tests') ? path.dirname(parentDir) : parentDir;
     const target = path.resolve(parentDir, specifier);
+
+    // Temporary logging to help debug Windows builds...
+    console.log('parent     =', parent);
+    console.log('specifier  =', specifier);
+    console.log('parentFile =', parentFile);
+    console.log('parentDir  =', parentDir);
+    console.log('root       =', root);
+    console.log('target     =', target);
+    console.log();
+
     if (!target.startsWith(root)) {
       throw new Error(`cannot access internal file '${target}' from location '${parentFile}'`);
     }

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -391,7 +391,7 @@ function buildPath(path: string, preprocess: () => void): () => boolean {
       return false;
     }
 
-    if (!link(findProjectFiles('src', null, /\.js$/))) {
+    if (!link(findProjectFiles('src', /webpack\.config\.js$/, /\.js$/))) {
       console.error('build::link failed');
       return false;
     }
@@ -517,9 +517,7 @@ function lint(args: string[]): boolean {
   });
 
   const result = saneSpawnSyncWithOutput(
-    'grep',
-    ['--include', '\\*.ts', '-R', '"\\(describe\\|it\\)\\.only"', './src'],
-    {logCmd: true}
+    'grep', ['--include', '\\*.ts', '-R', '"\\(describe\\|it\\)\\.only"', './src']
   );
   if (result.stdout !== '') {
     console.error(result.stdout);
@@ -638,13 +636,16 @@ function spawnWasSuccessful(result: RawSpawnResult, opts: SpawnOptions = {}): bo
   if (result.status === 0 && !result.error) {
     return true;
   }
-  for (const x of [result.stdout, result.stderr]) {
-    if (x && !opts.dontWarnOnFailure) {
-      console.warn(x.toString().trim());
+  if (!opts.dontWarnOnFailure) {
+    for (const x of [result.stdout, result.stderr]) {
+      const str = x.toString().trim();
+      if (str) {
+        console.warn(str);
+      }
     }
-  }
-  if (result.error && !opts.dontWarnOnFailure) {
-    console.warn(result.error);
+    if (result.error) {
+      console.warn(result.error);
+    }
   }
   return false;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,7 @@
     "noErrorTruncation": true
   },
   "exclude": [
-    "build/**/*",
-    "cloud/**/*",
-    "./src/tools/language-server/**/*",
-    "./src/tools/vscode-language-client/**/*"
+    "src/tools/language-server/**/*",
+    "src/tools/vscode-language-client/**/*"
   ]
 }


### PR DESCRIPTION
Also some small tidy-ups:
- Cleaner output for sigh; don't hardlink webpack.config.js files in the build dir
- Removed unnecessary excludes in tsconfig.json
- Use lib-crdt imports where appropriate for crdt test files.