### PR TITLE
Allow Paxel let expression in the peg parser

### DIFF
--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -860,8 +860,8 @@ export const PAXEL_FUNCTIONS: PaxelFunction[] = [
   makePaxelCollectionTypeFunction(PaxelFunctionName.First, 1)
 ];
 
-export type PaxelExpressionNode = FromExpressionNode | WhereExpressionNode | SelectExpressionNode | NewExpressionNode |
-  FunctionExpressionNode | RefinementExpressionNode;
+export type PaxelExpressionNode = FromExpressionNode | WhereExpressionNode | LetExpressionNode |
+  SelectExpressionNode | NewExpressionNode | FunctionExpressionNode | RefinementExpressionNode;
 
 export interface ExpressionEntity extends BaseNode {
   kind: 'expression-entity';
@@ -882,6 +882,12 @@ export interface FromExpressionNode extends QualifiedExpression, BaseNode {
 export interface WhereExpressionNode extends QualifiedExpression, BaseNode {
   kind: 'paxel-where';
   condition: PaxelExpressionNode;
+}
+
+export interface LetExpressionNode extends QualifiedExpression, BaseNode {
+  kind: 'paxel-let';
+  varName: string;
+  expression: PaxelExpressionNode;
 }
 
 export interface SelectExpressionNode extends QualifiedExpression, BaseNode {

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1645,7 +1645,7 @@ NestedSchemaType = 'inline' whiteSpace? schema:(SchemaInline / TypeName)
   }
 
 QualifiedExpression
-  = FromExpression / WhereExpression / SelectExpression
+  = FromExpression / WhereExpression / LetExpression / SelectExpression
 
 ExpressionWithQualifier
   = qualifier:QualifiedExpression rest:(multiLineSpace rest:QualifiedExpression)* {
@@ -1653,6 +1653,13 @@ ExpressionWithQualifier
     for (let i = result.length - 1; i > 0; i--) {
       result[i].qualifier = result[i-1];
     }
+
+    for (let i = result.length - 2; i > 0; i--) {
+      if (result[i].kind === 'paxel-select') {
+        error('Paxel expressions cannot have non-trailing \'select\'');
+      }
+    }
+
     if (qualifier.kind !== 'paxel-from') {
       error('Paxel expressions must begin with \'from\'');
     }
@@ -1694,6 +1701,15 @@ WhereExpression "Expression for filtering a sequence, e.g. where p < 10"
     return toAstNode<AstNode.WhereExpressionNode>({
        kind: 'paxel-where',
        condition
+    });
+  }
+
+LetExpression "Expression for introducing a new identifier, e.g. let x = 10"
+  = 'let' whiteSpace varName:fieldName whiteSpace '=' whiteSpace expression:PaxelExpressionWithRefinement {
+    return toAstNode<AstNode.LetExpressionNode>({
+      kind: 'paxel-let',
+      varName: varName,
+      expression
     });
   }
 


### PR DESCRIPTION
As an extra - don't allow `select` in the middle of the expression.