### PR TITLE
Introduce a way of creating foreign references (references not pointi…

### DIFF
--- a/java/arcs/core/entity/EntityDereferencerFactory.kt
+++ b/java/arcs/core/entity/EntityDereferencerFactory.kt
@@ -9,6 +9,7 @@ import arcs.core.storage.Dereferencer
 import arcs.core.storage.RawEntityDereferencer
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageEndpointManager
+import arcs.core.storage.keys.ForeignStorageKey
 
 /** A [Dereferencer.Factory] for [Reference] and [RawEntity] classes. */
 class EntityDereferencerFactory(
@@ -30,7 +31,13 @@ class EntityDereferencerFactory(
     override fun injectDereferencers(schema: Schema, value: Any?) {
         if (value == null) return
         when (value) {
-            is Reference -> value.dereferencer = create(schema)
+            is Reference -> {
+                if (value.storageKey is ForeignStorageKey) {
+                    value.dereferencer = ForeignEntityDereferencer(schema)
+                } else {
+                    value.dereferencer = create(schema)
+                }
+            }
             is RawEntity -> injectDereferencersIntoRawEntity(schema, value)
             is Set<*> -> value.forEach { injectDereferencers(schema, it) }
             is ReferencableList<*> -> value.value.forEach { injectDereferencers(schema, it) }
@@ -64,5 +71,23 @@ class EntityDereferencerFactory(
             }
             injectDereferencers(fieldSchema, fieldValue)
         }
+    }
+}
+
+/**
+ * A [Dereferencer] for foreign [Reference]s. A foreign reference is a reference to something not
+ * stored in Arcs. This Dereferencer checks with the [ForeignReferenceChecker] whether the given ID
+ * is valid, if so it return an empty RawEntity with that ID, otherwise it returns null.
+ */
+class ForeignEntityDereferencer(val schema: Schema) : Dereferencer<RawEntity> {
+    override suspend fun dereference(reference: Reference): RawEntity? {
+        check(reference.storageKey is ForeignStorageKey) {
+            "ForeignEntityDereferencer can only be used for foreign references."
+        }
+        val entityId = reference.id
+        if (ForeignReferenceChecker.check(schema, entityId)) {
+            return RawEntity(id = entityId)
+        }
+        return null
     }
 }

--- a/java/arcs/core/entity/ForeignReferenceChecker.kt
+++ b/java/arcs/core/entity/ForeignReferenceChecker.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.entity
+
+import arcs.core.data.Schema
+import arcs.core.storage.Reference as StorageReference
+import arcs.core.storage.keys.ForeignStorageKey
+
+/**
+ * Singleton object used to register hooks that can check the validity of external references. A
+ * check is associate with a namespace, represented by an empty Arcs schema. It checks a given id in
+ * this namespace for external validity.
+ */
+object ForeignReferenceChecker {
+    private val validityChecks = mutableMapOf<Schema, (String) -> Boolean>()
+
+    // Registers the checker for the given spec, which acts as the namespace.
+    fun registerExternalEntityType(
+        spec: EntitySpec<out Entity>,
+        checker: (String) -> Boolean
+    ) = synchronized(this) {
+        checkNoFields(spec.SCHEMA)
+        validityChecks[spec.SCHEMA] = checker
+    }
+
+    // Checks the given value using the checker for the given namespace.
+    fun check(namespace: Schema, value: String): Boolean = synchronized(this) {
+        return checkNotNull(validityChecks[namespace]) {
+            "Foreign type not registered: $namespace."
+        }.invoke(value)
+    }
+
+    private fun checkNoFields(schema: Schema) {
+        check(schema.fields.singletons.isEmpty() && schema.fields.collections.isEmpty()) {
+            "Only empty schemas can be used for foreign references."
+        }
+    }
+}
+
+/**
+ * Create a foreign [Reference] of type [T] with the given [id], checking for validity of that [id].
+ *
+ * Note: this is a temporary method, this functionatily will be part of the EntityHandle when we
+ * have one and it is used to create references.
+ *
+ * @throws InvalidForeignReferenceException if the [id] is not valid.
+ */
+fun <T : Entity> foreignReference(spec: EntitySpec<T>, id: String): Reference<T> {
+    if (!ForeignReferenceChecker.check(spec.SCHEMA, id)) {
+        throw InvalidForeignReferenceException("Cannot create reference to invalid ID $id.")
+    }
+    return Reference(
+        spec,
+        StorageReference(id, storageKey = ForeignStorageKey(spec.SCHEMA), version = null).also {
+            it.dereferencer = ForeignEntityDereferencer(spec.SCHEMA)
+        }
+    )
+}
+
+/** Exception thrown when we attempt to create a reference to an invalid ID. */
+class InvalidForeignReferenceException(message: String) : Exception(message)

--- a/java/arcs/core/entity/ForeignReferenceChecker.kt
+++ b/java/arcs/core/entity/ForeignReferenceChecker.kt
@@ -15,11 +15,11 @@ import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.keys.ForeignStorageKey
 
 /**
- * Singleton object used to register hooks that can check the validity of external references. A
- * check is associate with a namespace, represented by an empty Arcs schema. It checks a given id in
+ * Class used to register hooks that can check the validity of external references. A check is
+ *  associated with a namespace, represented by an empty Arcs schema. It checks a given id in
  * this namespace for external validity.
  */
-object ForeignReferenceChecker {
+class ForeignReferenceChecker {
     private val validityChecks = mutableMapOf<Schema, (String) -> Boolean>()
 
     // Registers the checker for the given spec, which acts as the namespace.
@@ -46,22 +46,16 @@ object ForeignReferenceChecker {
 }
 
 /**
- * Create a foreign [Reference] of type [T] with the given [id], checking for validity of that [id].
+ * Create a foreign [Reference] of type [T] with the given [id]. It does not check for validity of
+ * that [id].
  *
  * Note: this is a temporary method, this functionatily will be part of the EntityHandle when we
  * have one and it is used to create references.
- *
- * @throws InvalidForeignReferenceException if the [id] is not valid.
  */
 fun <T : Entity> foreignReference(spec: EntitySpec<T>, id: String): Reference<T> {
-    if (!ForeignReferenceChecker.check(spec.SCHEMA, id)) {
-        throw InvalidForeignReferenceException("Cannot create reference to invalid ID $id.")
-    }
     return Reference(
         spec,
-        StorageReference(id, storageKey = ForeignStorageKey(spec.SCHEMA), version = null).also {
-            it.dereferencer = ForeignEntityDereferencer(spec.SCHEMA)
-        }
+        StorageReference(id, storageKey = ForeignStorageKey(spec.SCHEMA), version = null)
     )
 }
 

--- a/java/arcs/core/entity/ForeignReferenceChecker.kt
+++ b/java/arcs/core/entity/ForeignReferenceChecker.kt
@@ -15,28 +15,30 @@ import arcs.core.storage.Reference as StorageReference
 import arcs.core.storage.keys.ForeignStorageKey
 
 /**
- * Class used to register hooks that can check the validity of external references. A check is
- *  associated with a namespace, represented by an empty Arcs schema. It checks a given id in
- * this namespace for external validity.
+ * Interface used to check the validity of external references. Checks are associated with a
+ * namespace, represented by an empty Arcs schema. A given id in this namespace can be checked for
+ * external validity.
  */
-class ForeignReferenceChecker {
-    private val validityChecks = mutableMapOf<Schema, (String) -> Boolean>()
+interface ForeignReferenceChecker {
+    fun check(namespace: Schema, value: String): Boolean
+}
 
-    // Registers the checker for the given spec, which acts as the namespace.
-    fun registerExternalEntityType(
-        spec: EntitySpec<out Entity>,
-        checker: (String) -> Boolean
-    ) = synchronized(this) {
-        checkNoFields(spec.SCHEMA)
-        validityChecks[spec.SCHEMA] = checker
+/**
+ * Implementation of ForeignReferenceChecker, based on the provided map of checks.
+ */
+class ForeignReferenceCheckerImpl(
+    private val validityChecks: Map<Schema, (String) -> Boolean>
+) : ForeignReferenceChecker {
+
+    init {
+        validityChecks.keys.forEach { checkNoFields(it) }
     }
 
     // Checks the given value using the checker for the given namespace.
-    fun check(namespace: Schema, value: String): Boolean = synchronized(this) {
-        return checkNotNull(validityChecks[namespace]) {
+    override fun check(namespace: Schema, value: String): Boolean =
+        checkNotNull(validityChecks[namespace]) {
             "Foreign type not registered: $namespace."
         }.invoke(value)
-    }
 
     private fun checkNoFields(schema: Schema) {
         check(schema.fields.singletons.isEmpty() && schema.fields.collections.isEmpty()) {
@@ -49,7 +51,7 @@ class ForeignReferenceChecker {
  * Create a foreign [Reference] of type [T] with the given [id]. It does not check for validity of
  * that [id].
  *
- * Note: this is a temporary method, this functionatily will be part of the EntityHandle when we
+ * Note: this is a temporary method, this functionality will be part of the EntityHandle when we
  * have one and it is used to create references.
  */
 fun <T : Entity> foreignReference(spec: EntitySpec<T>, id: String): Reference<T> {
@@ -58,6 +60,3 @@ fun <T : Entity> foreignReference(spec: EntitySpec<T>, id: String): Reference<T>
         StorageReference(id, storageKey = ForeignStorageKey(spec.SCHEMA), version = null)
     )
 }
-
-/** Exception thrown when we attempt to create a reference to an invalid ID. */
-class InvalidForeignReferenceException(message: String) : Exception(message)

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -28,6 +28,7 @@ import arcs.core.entity.Entity
 import arcs.core.entity.EntityDereferencerFactory
 import arcs.core.entity.EntityStorageAdapter
 import arcs.core.entity.ForeignReferenceChecker
+import arcs.core.entity.ForeignReferenceCheckerImpl
 import arcs.core.entity.Handle
 import arcs.core.entity.HandleContainerType
 import arcs.core.entity.HandleDataType
@@ -78,7 +79,7 @@ class EntityHandleManager(
     private val storageEndpointManager: StorageEndpointManager,
     private val idGenerator: Id.Generator = Id.Generator.newSession(),
     private val analytics: Analytics? = null,
-    val foreignReferenceChecker: ForeignReferenceChecker = ForeignReferenceChecker()
+    val foreignReferenceChecker: ForeignReferenceChecker = ForeignReferenceCheckerImpl(mapOf())
 ) : HandleManager {
     private val proxyMutex = Mutex()
     private val singletonStorageProxies by guardedBy(

--- a/java/arcs/core/host/EntityHandleManager.kt
+++ b/java/arcs/core/host/EntityHandleManager.kt
@@ -27,6 +27,7 @@ import arcs.core.entity.CollectionProxy
 import arcs.core.entity.Entity
 import arcs.core.entity.EntityDereferencerFactory
 import arcs.core.entity.EntityStorageAdapter
+import arcs.core.entity.ForeignReferenceChecker
 import arcs.core.entity.Handle
 import arcs.core.entity.HandleContainerType
 import arcs.core.entity.HandleDataType
@@ -76,7 +77,8 @@ class EntityHandleManager(
     private val scheduler: Scheduler,
     private val storageEndpointManager: StorageEndpointManager,
     private val idGenerator: Id.Generator = Id.Generator.newSession(),
-    private val analytics: Analytics? = null
+    private val analytics: Analytics? = null,
+    val foreignReferenceChecker: ForeignReferenceChecker = ForeignReferenceChecker()
 ) : HandleManager {
     private val proxyMutex = Mutex()
     private val singletonStorageProxies by guardedBy(
@@ -87,7 +89,10 @@ class EntityHandleManager(
         proxyMutex,
         mutableMapOf<StorageKey, CollectionProxy<Referencable>>()
     )
-    private val dereferencerFactory = EntityDereferencerFactory(storageEndpointManager)
+    private val dereferencerFactory = EntityDereferencerFactory(
+        storageEndpointManager,
+        foreignReferenceChecker
+    )
 
     @Deprecated("Will be replaced by ParticleContext lifecycle handling")
     suspend fun initiateProxySync() {

--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -21,6 +21,7 @@ import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.storage.driver.VolatileDriverProviderFactory
 import arcs.core.storage.keys.DatabaseStorageKey
+import arcs.core.storage.keys.ForeignStorageKey
 import arcs.core.storage.keys.JoinStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
@@ -66,7 +67,8 @@ object DriverAndKeyConfigurator {
             DatabaseStorageKey.Memory,
             CreatableStorageKey,
             ReferenceModeStorageKey,
-            JoinStorageKey
+            JoinStorageKey,
+            ForeignStorageKey
         )
 
         CapabilitiesResolver.reset()

--- a/java/arcs/core/storage/keys/BUILD
+++ b/java/arcs/core/storage/keys/BUILD
@@ -26,6 +26,7 @@ arcs_kt_library(
         ":protocols",
         "//java/arcs/core/common",
         "//java/arcs/core/data",
+        "//java/arcs/core/data:schema_fields",
         "//java/arcs/core/storage",
     ],
 )

--- a/java/arcs/core/storage/keys/BUILD
+++ b/java/arcs/core/storage/keys/BUILD
@@ -26,7 +26,6 @@ arcs_kt_library(
         ":protocols",
         "//java/arcs/core/common",
         "//java/arcs/core/data",
-        "//java/arcs/core/data:schema_fields",
         "//java/arcs/core/storage",
     ],
 )

--- a/java/arcs/core/storage/keys/ForeignStorageKey.kt
+++ b/java/arcs/core/storage/keys/ForeignStorageKey.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.storage.keys
+
+import arcs.core.data.Schema
+import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeySpec
+
+/*
+ * ForeignStorageKey are used in external references for deletion-propagation. They just identify a
+ * namespace for the reference, which is usually a Schema name of an empty schema.
+ */
+class ForeignStorageKey(
+    val namespace: String
+) : StorageKey(protocol) {
+
+    constructor(schema: Schema) : this(checkNotNull(schema.name?.name))
+
+    override fun toKeyString(): String = namespace
+
+    override fun childKeyWithComponent(component: String): StorageKey =
+        ForeignStorageKey("$namespace/$component")
+
+    companion object : StorageKeySpec<ForeignStorageKey> {
+        override val protocol = "foreign"
+
+        override fun parse(rawKeyString: String): ForeignStorageKey {
+            return ForeignStorageKey(rawKeyString)
+        }
+    }
+}

--- a/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/android/entity/DifferentAndroidHandleManagerDifferentStoresTest.kt
@@ -43,7 +43,8 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("reader"),
-            storageEndpointManager = DirectStorageEndpointManager(readStores)
+            storageEndpointManager = DirectStorageEndpointManager(readStores),
+            foreignReferenceChecker = foreignReferenceChecker
         )
         writeStores = StoreManager(activationFactory)
         writeHandleManager = EntityHandleManager(
@@ -51,7 +52,8 @@ class DifferentAndroidHandleManagerDifferentStoresTest : HandleManagerTestBase()
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            storageEndpointManager = DirectStorageEndpointManager(writeStores)
+            storageEndpointManager = DirectStorageEndpointManager(writeStores),
+            foreignReferenceChecker = foreignReferenceChecker
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)

--- a/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/DifferentHandleManagerTest.kt
@@ -44,14 +44,16 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("reader"),
-            storageEndpointManager = storageEndpointManager
+            storageEndpointManager = storageEndpointManager,
+            foreignReferenceChecker = foreignReferenceChecker
         )
         writeHandleManager = EntityHandleManager(
             arcId = "arcId",
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            storageEndpointManager = storageEndpointManager
+            storageEndpointManager = storageEndpointManager,
+            foreignReferenceChecker = foreignReferenceChecker
         )
         // Initialize WorkManager for instrumentation tests.
         WorkManagerTestInitHelper.initializeTestWorkManager(app)

--- a/javatests/arcs/android/entity/HardReferenceTest.kt
+++ b/javatests/arcs/android/entity/HardReferenceTest.kt
@@ -11,6 +11,7 @@ import arcs.core.data.HandleMode
 import arcs.core.entity.Entity
 import arcs.core.entity.EntitySpec
 import arcs.core.entity.ForeignReferenceChecker
+import arcs.core.entity.ForeignReferenceCheckerImpl
 import arcs.core.entity.HandleSpec
 import arcs.core.entity.ReadWriteCollectionHandle
 import arcs.core.entity.awaitReady
@@ -71,7 +72,10 @@ class HardReferenceTest {
         get() = DirectStorageEndpointManager(
             StoreManager(ServiceStoreFactory(app, connectionFactory = TestConnectionFactory(app)))
         )
-    val foreignReferenceChecker: ForeignReferenceChecker = ForeignReferenceChecker()
+    private val foreignReferenceChecker: ForeignReferenceChecker =
+        ForeignReferenceCheckerImpl(mapOf(TestReferencesParticle_Entity_Foreign.SCHEMA to { _ ->
+            true
+        }))
     private val handleManager: EntityHandleManager
         get() = EntityHandleManager(
             arcId = "arcId",
@@ -129,9 +133,6 @@ class HardReferenceTest {
     @Test
     fun foreignReferenceWorkEndToEnd() = runBlocking<Unit> {
         val id = "id"
-        foreignReferenceChecker.registerExternalEntityType(TestReferencesParticle_Entity_Foreign) {
-            true
-        }
         val reference = foreignReference(TestReferencesParticle_Entity_Foreign, id)
 
         val entity = TestReferencesParticle_Entity(foreign = reference)

--- a/javatests/arcs/android/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/android/entity/SameHandleManagerTest.kt
@@ -42,7 +42,8 @@ class SameHandleManagerTest : HandleManagerTestBase() {
             hostId = "hostId",
             time = fakeTime,
             scheduler = schedulerProvider("test"),
-            storageEndpointManager = DirectStorageEndpointManager(stores)
+            storageEndpointManager = DirectStorageEndpointManager(stores),
+            foreignReferenceChecker = foreignReferenceChecker
         )
         writeHandleManager = readHandleManager
 

--- a/javatests/arcs/android/entity/test.arcs
+++ b/javatests/arcs/android/entity/test.arcs
@@ -1,12 +1,15 @@
 meta
   namespace: arcs.android.entity
 
-schema ReferencedSchema
+schema HardReference
   number: Int
 
-schema HardReference
-  referenced: &ReferencedSchema @hardRef
+schema ForeignReference
+
+schema Entity
+  hard: &HardReference @hardRef
+  foreign: &ForeignReference
 
 particle TestReferencesParticle
-  entity: reads writes [HardReference]
+  entity: reads writes [Entity]
 

--- a/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerDifferentStoresTest.kt
@@ -31,7 +31,8 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
             hostId = "testHostId",
             time = fakeTime,
             scheduler = schedulerProvider("reader-#$i"),
-            storageEndpointManager = DirectStorageEndpointManager(readStores)
+            storageEndpointManager = DirectStorageEndpointManager(readStores),
+            foreignReferenceChecker = foreignReferenceChecker
         )
         writeStores = StoreManager()
         writeHandleManager = EntityHandleManager(
@@ -39,7 +40,8 @@ class DifferentHandleManagerDifferentStoresTest : HandleManagerTestBase() {
             hostId = "testHostId",
             time = fakeTime,
             scheduler = schedulerProvider("writer"),
-            storageEndpointManager = DirectStorageEndpointManager(writeStores)
+            storageEndpointManager = DirectStorageEndpointManager(writeStores),
+            foreignReferenceChecker = foreignReferenceChecker
         )
     }
 

--- a/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/DifferentHandleManagerTest.kt
@@ -27,14 +27,16 @@ class DifferentHandleManagerTest : HandleManagerTestBase() {
             hostId = "testHost",
             time = fakeTime,
             scheduler = schedulerProvider("reader-#$i"),
-            storageEndpointManager = storageEndpointManager
+            storageEndpointManager = storageEndpointManager,
+            foreignReferenceChecker = foreignReferenceChecker
         )
         writeHandleManager = EntityHandleManager(
             arcId = "testArc",
             hostId = "testHost",
             time = fakeTime,
             scheduler = schedulerProvider("writer-#$i"),
-            storageEndpointManager = storageEndpointManager
+            storageEndpointManager = storageEndpointManager,
+            foreignReferenceChecker = foreignReferenceChecker
         )
     }
 

--- a/javatests/arcs/core/entity/ForeignReferenceCheckerTest.kt
+++ b/javatests/arcs/core/entity/ForeignReferenceCheckerTest.kt
@@ -18,14 +18,11 @@ class ForeignReferenceCheckerTest {
         override val SCHEMA = EMPTY.copy(names = setOf(SchemaName("schemaName")))
         override fun deserialize(data: RawEntity) = throw UnsupportedOperationException()
     }
-    private val foreignReferenceChecker = ForeignReferenceChecker()
+    private val foreignReferenceChecker: ForeignReferenceChecker =
+        ForeignReferenceCheckerImpl(mapOf(spec.SCHEMA to { id -> id == "valid" }))
 
     @Test
     fun registerChecker_canCheck() {
-        foreignReferenceChecker.registerExternalEntityType(spec) {
-            it == "valid"
-        }
-
         // Valid ID.
         assertThat(foreignReferenceChecker.check(spec.SCHEMA, "valid")).isTrue()
 
@@ -42,9 +39,7 @@ class ForeignReferenceCheckerTest {
     @Test
     fun schemaWithFields_throws() {
         val e = assertFailsWith<IllegalStateException> {
-            foreignReferenceChecker.registerExternalEntityType(DummyEntity) {
-                it == "valid"
-            }
+            ForeignReferenceCheckerImpl(mapOf(DummyEntity.SCHEMA to { id -> id == "valid" }))
         }
         assertThat(e.message).isEqualTo("Only empty schemas can be used for foreign references.")
     }

--- a/javatests/arcs/core/entity/ForeignReferenceCheckerTest.kt
+++ b/javatests/arcs/core/entity/ForeignReferenceCheckerTest.kt
@@ -1,0 +1,93 @@
+package arcs.core.entity
+
+import arcs.core.data.RawEntity
+import arcs.core.data.Schema.Companion.EMPTY
+import arcs.core.data.SchemaName
+import arcs.core.storage.keys.ForeignStorageKey
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ForeignReferenceCheckerTest {
+
+    val spec = object : EntitySpec<Entity> {
+        override val SCHEMA = EMPTY.copy(names = setOf(SchemaName("schemaName")))
+        override fun deserialize(data: RawEntity) = throw UnsupportedOperationException()
+    }
+
+    @Test
+    fun registerChecker_canCheck() {
+        ForeignReferenceChecker.registerExternalEntityType(spec) {
+            it == "valid"
+        }
+
+        // Valid ID.
+        assertThat(ForeignReferenceChecker.check(spec.SCHEMA, "valid")).isTrue()
+
+        // Invalid ID.
+        assertThat(ForeignReferenceChecker.check(spec.SCHEMA, "invalid")).isFalse()
+
+        // Unregistered schema.
+        val e = assertFailsWith<IllegalStateException> {
+            ForeignReferenceChecker.check(EMPTY, "invalid")
+        }
+        assertThat(e.message).isEqualTo("Foreign type not registered: {}.")
+    }
+
+    @Test
+    fun schemaWithFields_throws() {
+        val e = assertFailsWith<IllegalStateException> {
+            ForeignReferenceChecker.registerExternalEntityType(DummyEntity) {
+                it == "valid"
+            }
+        }
+        assertThat(e.message).isEqualTo("Only empty schemas can be used for foreign references.")
+    }
+
+    @Test
+    fun foreignReference() = runBlocking {
+        ForeignReferenceChecker.registerExternalEntityType(spec) {
+            it == "valid"
+        }
+
+        val expectedReference = Reference(
+            spec,
+            arcs.core.storage.Reference(
+                "valid",
+                storageKey = ForeignStorageKey("schemaName"),
+                version = null
+            )
+        )
+        val reference = foreignReference(spec, "valid")
+        assertThat(reference).isEqualTo(expectedReference)
+        assertThat(reference.toReferencable().dereference()).isEqualTo(RawEntity(id = "valid"))
+
+        // Becomes invalid.
+        ForeignReferenceChecker.registerExternalEntityType(spec) {
+            false
+        }
+        assertThat(reference.toReferencable().dereference()).isNull()
+    }
+
+    @Test
+    fun foreignReference_invalidId() {
+        // Invalid ID.
+        val e = assertFailsWith<InvalidForeignReferenceException> {
+            foreignReference(spec, "invalid")
+        }
+        assertThat(e.message).isEqualTo("Cannot create reference to invalid ID invalid.")
+    }
+
+    @Test
+    fun foreignReference_invalidSchema() {
+        // Unregistered schema.
+        val e2 = assertFailsWith<IllegalStateException> {
+            foreignReference(DummyEntity, "invalid")
+        }
+        assertThat(e2.message).startsWith("Foreign type not registered: DummyEntity")
+    }
+}

--- a/javatests/arcs/core/entity/HandleManagerTestBase.kt
+++ b/javatests/arcs/core/entity/HandleManagerTestBase.kt
@@ -124,7 +124,11 @@ open class HandleManagerTestBase {
     val schedulerCoroutineContext = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     val schedulerProvider: SchedulerProvider = SimpleSchedulerProvider(schedulerCoroutineContext)
 
-    val foreignReferenceChecker: ForeignReferenceChecker = ForeignReferenceChecker()
+    private val validPackageName = "m.com.a"
+    private val packageChecker =
+        AbstractTestParticle.Package.SCHEMA to { name: String -> name == validPackageName }
+    val foreignReferenceChecker: ForeignReferenceChecker =
+        ForeignReferenceCheckerImpl(mapOf(packageChecker))
     lateinit var readHandleManager: EntityHandleManager
     lateinit var writeHandleManager: EntityHandleManager
     lateinit var monitorHandleManager: EntityHandleManager
@@ -388,10 +392,6 @@ open class HandleManagerTestBase {
 
     @Test
     fun singleton_referenceForeign() = testRunner {
-        val validPackageName = "m.com.a"
-        foreignReferenceChecker.registerExternalEntityType(AbstractTestParticle.Package) {
-            it == validPackageName
-        }
         val reference = foreignReference(AbstractTestParticle.Package, validPackageName)
         val entity = TestParticle_Entities(text = "Hello", app = reference)
         val writeHandle =

--- a/javatests/arcs/core/entity/SameHandleManagerTest.kt
+++ b/javatests/arcs/core/entity/SameHandleManagerTest.kt
@@ -24,7 +24,8 @@ class SameHandleManagerTest : HandleManagerTestBase() {
             hostId = "testHost",
             time = fakeTime,
             scheduler = schedulerProvider("test"),
-            storageEndpointManager = DirectStorageEndpointManager(stores)
+            storageEndpointManager = DirectStorageEndpointManager(stores),
+            foreignReferenceChecker = foreignReferenceChecker
         )
         writeHandleManager = readHandleManager
     }

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -26,7 +26,8 @@ import org.junit.runners.JUnit4
 class StorageAdapterTest {
     private val time = FakeTime()
     private val dereferencerFactory = EntityDereferencerFactory(
-        DirectStorageEndpointManager(StoreManager())
+        DirectStorageEndpointManager(StoreManager()),
+        ForeignReferenceChecker()
     )
     private val idGenerator = Id.Generator.newForTest("session")
     private val storageKey = DummyStorageKey("entities")

--- a/javatests/arcs/core/entity/StorageAdapterTest.kt
+++ b/javatests/arcs/core/entity/StorageAdapterTest.kt
@@ -27,7 +27,7 @@ class StorageAdapterTest {
     private val time = FakeTime()
     private val dereferencerFactory = EntityDereferencerFactory(
         DirectStorageEndpointManager(StoreManager()),
-        ForeignReferenceChecker()
+        ForeignReferenceCheckerImpl(mapOf())
     )
     private val idGenerator = Id.Generator.newForTest("session")
     private val storageKey = DummyStorageKey("entities")

--- a/javatests/arcs/core/entity/test.arcs
+++ b/javatests/arcs/core/entity/test.arcs
@@ -1,10 +1,13 @@
 meta
   namespace: arcs.core.entity
 
+schema Package
+
 schema TestEntity
   text: Text
   number: Number
   list: List<Long>
+  app: &Package
 
 schema TestInline
   inline: inline InlineEntity {long: Long, text: Text}
@@ -19,7 +22,7 @@ schema TestReferences
   referenceList: List<&ReferencedSchema>
 
 particle TestParticle
-  entities: reads writes [TestEntity {text, number, list} [text == ?]]
+  entities: reads writes [TestEntity {text, number, list, app} [text == ?]]
 
 particle TestInlineParticle
   entities: reads writes [TestInline {inline, inlines, inlineList}]

--- a/javatests/arcs/core/storage/keys/BUILD
+++ b/javatests/arcs/core/storage/keys/BUILD
@@ -16,6 +16,8 @@ arcs_kt_android_test_suite(
     package = "arcs.core.storage.keys",
     deps = [
         "//java/arcs/core/common",
+        "//java/arcs/core/data",
+        "//java/arcs/core/data:schema_fields",
         "//java/arcs/core/storage",
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/testutil",

--- a/javatests/arcs/core/storage/keys/ForeignStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/ForeignStorageKeyTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.storage.keys
+
+import arcs.core.data.Schema
+import arcs.core.data.SchemaFields
+import arcs.core.data.SchemaName
+import arcs.core.storage.StorageKeyParser
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for [VolatileStorageKey]. */
+@RunWith(JUnit4::class)
+class ForeignStorageKeyTest {
+    @Before
+    fun setup() {
+        StorageKeyParser.reset(ForeignStorageKey)
+    }
+
+    @Test
+    fun toString_rendersCorrectly() {
+        val key = ForeignStorageKey("foo")
+        assertThat(key.toString()).isEqualTo("foreign://foo")
+        assertThat(StorageKeyParser.parse(key.toString())).isEqualTo(key)
+    }
+
+    @Test
+    fun childKeyWithComponent_isCorrect() {
+        val parent = ForeignStorageKey("parent")
+        val child = parent.childKeyWithComponent("child")
+        assertThat(child.toString())
+            .isEqualTo("foreign://parent/child")
+    }
+
+    @Test
+    fun createFromSchema() {
+        val schema = Schema(
+            setOf(SchemaName("schemaName")),
+            SchemaFields(emptyMap(), emptyMap()),
+            "abcd"
+        )
+        val key = ForeignStorageKey(schema)
+        assertThat(key.toString()).isEqualTo("foreign://schemaName")
+    }
+}


### PR DESCRIPTION
…ng to an entity stored in Arcs. Validity checks for these are kept in a ForeignReferenceChecker and used when dereferencing this references. These references use a new type of storage key that encapsulates the namespace and id of the foreign object. This will be used for the database bulk delete when the object becomes invalid.