### PR TITLE
Improve type tracking through recipe.updateToClone.

### DIFF
--- a/src/planning/strategies/convert-constraints-to-connections.ts
+++ b/src/planning/strategies/convert-constraints-to-connections.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Recipe, EndPoint, Handle, ParticleEndPoint, newInstanceEndPoint, HandleRepr, reverseDirection, makeShape, find} from '../../runtime/recipe/lib-recipe.js';
+import {Recipe, EndPoint, Handle, ParticleEndPoint, newInstanceEndPoint, HandleRepr, reverseDirection, makeShape, find, Particle, HandleConnection} from '../../runtime/recipe/lib-recipe.js';
 import {StrategizerWalker, Strategy, StrategyParams} from '../strategizer.js';
 import {ParticleSpec} from '../../runtime/arcs-types/particle-spec.js';
 import {Direction} from '../../runtime/arcs-types/enums.js';
@@ -182,7 +182,7 @@ export class ConvertConstraintsToConnections extends Strategy {
             const recipeMap = recipe.updateToClone(match.match);
 
             for (const particle of Object.keys(map)) {
-              let recipeParticle = recipeMap[particle];
+              let recipeParticle = recipeMap[particle] as Particle;
               if (!recipeParticle) {
                 recipeParticle = recipe.newParticle(particle);
                 recipeParticle.spec = particlesByName[particle];
@@ -194,9 +194,9 @@ export class ConvertConstraintsToConnections extends Strategy {
                 let recipeHandleConnection = recipeParticle.connections[connection];
                 if (recipeHandleConnection == undefined) {
                   recipeHandleConnection =
-                      recipeParticle.addConnectionName(connection);
+                      recipeParticle.addConnectionName(connection) as HandleConnection;
                 }
-                let recipeHandle = recipeMap[handle.handle];
+                let recipeHandle = recipeMap[handle.handle] as Handle;
                 if (recipeHandle == null && recipeHandleConnection.handle == null) {
                   recipeHandle = recipe.newHandle();
                   recipeHandle.fate = 'create';
@@ -215,8 +215,8 @@ export class ConvertConstraintsToConnections extends Strategy {
                 () => 'constraints currently require particle endpoints at each end');
               const obligationTo = obligation.to.requireParticleEndPoint(
                 () => 'constraints currently require particle endpoints at each end');
-              const from = newInstanceEndPoint(recipeMap[obligationFrom.particle.name], obligationFrom.connection);
-              const to = newInstanceEndPoint(recipeMap[obligationTo.particle.name], obligationTo.connection);
+              const from = newInstanceEndPoint(recipeMap[obligationFrom.particle.name] as Particle, obligationFrom.connection);
+              const to = newInstanceEndPoint(recipeMap[obligationTo.particle.name] as Particle, obligationTo.connection);
               recipe.newObligation(from, to, obligation.direction, obligation.relaxed);
             }
             return score;

--- a/src/planning/strategies/match-recipe-by-verb.ts
+++ b/src/planning/strategies/match-recipe-by-verb.ts
@@ -89,7 +89,7 @@ export class MatchRecipeByVerb extends Strategy {
                     consumeConn.connectToSlot(mappedSlot);
                   }
                   for (const slot of constraints.providedSlots) {
-                    const {mappedSlot} = outputRecipe.updateToClone({mappedSlot: slot}) as {mappedSlot: Slot};
+                    const {mappedSlot} = outputRecipe.updateToClone({mappedSlot: slot});
 
                     const consumeConn = particle.getSlotConnectionByName(consumeSlot) || particle.addSlotConnection(consumeSlot);
                     consumeConn.disconnectProvidedSlot(slot.name);

--- a/src/runtime/recipe/internal/recipe-interface.ts
+++ b/src/runtime/recipe/internal/recipe-interface.ts
@@ -261,8 +261,8 @@ export interface Recipe {
   // TODO(shanestephens): rationalize these!
   // tslint:disable-next-line: no-any
   mergeInto(recipe: Recipe): {handles: Handle[], particles: Particle[], slots: Slot[], cloneMap: Map<any, any>};
-  // tslint:disable-next-line: no-any
-  updateToClone(dict: Dictionary<any>): Dictionary<any>;
+
+  updateToClone<T extends {}>(dict: T): T;
 }
 
 // TODO(shanestephens): this should move into the type library.

--- a/src/runtime/recipe/internal/recipe.ts
+++ b/src/runtime/recipe/internal/recipe.ts
@@ -591,11 +591,10 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
     recipe.patterns = recipe.patterns.concat(this.patterns);
   }
 
-  // tslint:disable-next-line: no-any
-  updateToClone(dict: Dictionary<any>): Dictionary<any> {
+  updateToClone<T extends {}>(dict: T): T {
     const result = {};
     Object.keys(dict).forEach(key => result[key] = this._cloneMap.get(dict[key]));
-    return result;
+    return result as T;
   }
 
   _makeLocalNameMap() {


### PR DESCRIPTION
This used to be typed as returning any; now it returns the same type
it is given, which means the output dict members all automatically
have the correct type.

It does make generic uses slightly more painful (e.g. see
convert-constraints-to-connections.ts) but even here we've now got
more type safety as we're forced to declare what we expect each output
to be.