### PR TITLE
Treat absence of '@policy' as error only if recipe has egresses.

### DIFF
--- a/java/arcs/tools/VerifyPolicy.kt
+++ b/java/arcs/tools/VerifyPolicy.kt
@@ -26,14 +26,21 @@ class VerifyPolicy : CliktCommand(
         val policyVerifier = PolicyVerifier()
 
         recipes.forEach { recipe ->
-            val policyName = recipe.policyName ?: throw CliktError(
-                "Recipe '${recipe.name}' does not have a @policy annotation."
-            )
-            val policy = policies[policyName] ?: throw CliktError(
-                "Recipe '${recipe.name}' refers to policy '$policyName', which does not exist in " +
-                    "the manifest."
-            )
-            policyVerifier.verifyPolicy(recipe, policy)
+            val policyName = recipe.policyName
+            if (policyName == null) {
+                val message = "Recipe '${recipe.name}' does not have a @policy annotation."
+                if (recipe.particles.any { it.spec.dataflowType.egress }) {
+                    throw CliktError(message)
+                } else {
+                    print("[WARNING] $message [No egress in recipe]\n")
+                }
+            } else {
+                val policy = policies[policyName] ?: throw CliktError(
+                    "Recipe '${recipe.name}' refers to policy '$policyName', which does not " +
+                    "exist in the manifest."
+                )
+                policyVerifier.verifyPolicy(recipe, policy)
+            }
         }
     }
 }


### PR DESCRIPTION
This only changes the behavior of the verify_policy tool and not the `PolicyVerifier` class.  See b/168242899.