### PR TITLE
Add a second constructor for JsonObjects

### DIFF
--- a/java/arcs/android/devtools/StoreMessage.kt
+++ b/java/arcs/android/devtools/StoreMessage.kt
@@ -22,10 +22,8 @@ class StoreMessage(
     override val kind: String = STORE_MESSAGE
     override val message: JsonValue<*>
         get() = JsonValue.JsonObject(
-            mapOf<String, JsonValue<*>>(
-                "id" to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
-                "operations" to JsonValue.JsonArray(getMessageAsList())
-            )
+            "id" to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
+            "operations" to JsonValue.JsonArray(getMessageAsList())
         )
 
     /**
@@ -38,71 +36,59 @@ class StoreMessage(
                 is CrdtSingleton.Operation.Update<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            mapOf(
-                                    "type" to JsonValue.JsonString(UPDATE_TYPE),
-                                    "value" to getValue(op.value),
-                                    "actor" to JsonValue.JsonString(op.actor),
-                                    "clock" to getJsonClock(op.clock)
-                            )
+                            "type" to JsonValue.JsonString(UPDATE_TYPE),
+                            "value" to getValue(op.value),
+                            "actor" to JsonValue.JsonString(op.actor),
+                            "clock" to getJsonClock(op.clock)
                         )
                     )
                 }
                 is CrdtSingleton.Operation.Clear<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            mapOf(
-                                    "type" to JsonValue.JsonString(CLEAR_TYPE),
-                                    "actor" to JsonValue.JsonString(op.actor),
-                                    "clock" to JsonValue.JsonString(op.clock.toString())
-                            )
+                                "type" to JsonValue.JsonString(CLEAR_TYPE),
+                                "actor" to JsonValue.JsonString(op.actor),
+                                "clock" to JsonValue.JsonString(op.clock.toString())
                         )
                     )
                 }
                 is CrdtSet.Operation.Add<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            mapOf(
-                                "type" to JsonValue.JsonString(ADD_TYPE),
-                                "added" to getValue(op.added),
-                                "actor" to JsonValue.JsonString(op.actor),
-                                "clock" to JsonValue.JsonString(op.clock.toString())
-                            )
+                            "type" to JsonValue.JsonString(ADD_TYPE),
+                            "added" to getValue(op.added),
+                            "actor" to JsonValue.JsonString(op.actor),
+                            "clock" to JsonValue.JsonString(op.clock.toString())
                         )
                     )
                 }
                 is CrdtSet.Operation.Clear<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            mapOf(
-                                "type" to JsonValue.JsonString(CLEAR_TYPE),
-                                "actor" to JsonValue.JsonString(op.actor),
-                                "clock" to JsonValue.JsonString(op.clock.toString())
-                            )
+                            "type" to JsonValue.JsonString(CLEAR_TYPE),
+                            "actor" to JsonValue.JsonString(op.actor),
+                            "clock" to JsonValue.JsonString(op.clock.toString())
                         )
                     )
                 }
                 is CrdtSet.Operation.Remove<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            mapOf(
-                                "type" to JsonValue.JsonString(REMOVE_TYPE),
-                                "value" to getValue(op.removed),
-                                "actor" to JsonValue.JsonString(op.actor),
-                                "clock" to JsonValue.JsonString(op.clock.toString())
-                            )
+                            "type" to JsonValue.JsonString(REMOVE_TYPE),
+                            "value" to getValue(op.removed),
+                            "actor" to JsonValue.JsonString(op.actor),
+                            "clock" to JsonValue.JsonString(op.clock.toString())
                         )
                     )
                 }
                 is CrdtSet.Operation.FastForward<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            mapOf(
-                                "type" to JsonValue.JsonString(ADD_TYPE),
-                                "added" to getAddedListValue(op.added),
-                                "removed" to getRemovedListValue(op.removed),
-                                "oldClock" to JsonValue.JsonString(op.oldClock.toString()),
-                                "clock" to JsonValue.JsonString(op.clock.toString())
-                            )
+                            "type" to JsonValue.JsonString(ADD_TYPE),
+                            "added" to getAddedListValue(op.added),
+                            "removed" to getRemovedListValue(op.removed),
+                            "oldClock" to JsonValue.JsonString(op.oldClock.toString()),
+                            "clock" to JsonValue.JsonString(op.clock.toString())
                         )
                     )
                 }

--- a/java/arcs/core/util/Json.kt
+++ b/java/arcs/core/util/Json.kt
@@ -152,6 +152,10 @@ sealed class JsonValue<T>() {
             JsonString(name).toString() + ":$value"
         }.joinToString(prefix = "{", postfix = "}", separator = ",")
 
+        constructor(vararg pairs: Pair<String, JsonValue<*>>) : this(
+            pairs.associateBy({ it.first }, { it.second })
+        )
+
         /** Lookup a object value by key. */
         operator fun get(key: String) = value[key] as JsonValue<*>
 

--- a/javatests/arcs/core/util/JsonTest.kt
+++ b/javatests/arcs/core/util/JsonTest.kt
@@ -87,6 +87,9 @@ class JsonTest {
         assertThat(JsonObject(mapOf(
             "x" to JsonNumber(42.0)
         )).toString()).isEqualTo("{\"x\":42.0}")
+        assertThat(JsonObject(
+            "foo" to JsonString("bar")
+        ).toString()).isEqualTo("{\"foo\":\"bar\"}")
         assertThat(JsonObject(mapOf(
             "x" to JsonNumber(42.0),
             "y" to JsonString("hello"),


### PR DESCRIPTION
- Add a second constructor for JsonObject that that takes vararg pairs: Pair<String, JsonValue<*>>
- Update devtools to use new constructor.

Suggested by @jasonwyatt so we could change all of the JsonObject(mapOf( .... )) to JsonObject( ... )