### PR TITLE
Add notes about usage of `runBlocking` on periodic tasks

### DIFF
--- a/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
+++ b/java/arcs/android/storage/database/DatabaseGarbageCollectionPeriodicTask.kt
@@ -28,6 +28,15 @@ class DatabaseGarbageCollectionPeriodicTask(
     private val log = TaggedLog { WORKER_TAG }
     init { log.debug { "Created." } }
 
+    // Note on `runBlocking` usage:
+    // `doWork` is run synchronously by the work manager.
+    // This is one of the rare cases that runBlocking was intended for: implementing the
+    // functionality of a synchronous API but requiring the use of suspending methods.
+    //
+    // Returning from `doWork` is a signal of completion, so we must block here.
+    //
+    // To avoid blocking thread issues, ensure that the work manager will not schedule this
+    // work on any important threads that you're using elsewhere.
     override fun doWork(): Result = runBlocking {
         log.debug { "Running." }
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -28,6 +28,16 @@ class PeriodicCleanupTask(
     private val log = TaggedLog { WORKER_TAG }
     init { log.debug { "Created." } }
 
+    // Note on `runBlocking` usage:
+    // `doWork` is run synchronously by the work manager.
+    // This is one of the rare cases that runBlocking was intended for: implementing the
+    // functionality of a synchronous API but requiring the use of suspending methods.
+    //
+    // Returning from `doWork` is a signal of completion, so we must block here.
+    //
+    // on the thread.
+    // To avoid blocking thread issues, ensure that the work manager will not schedule this
+    // work on any important threads that you're using elsewhere.
     override fun doWork(): Result = runBlocking {
         log.debug { "Running." }
         // Use the DatabaseDriverProvider instance of the databaseManager to make sure changes by

--- a/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
+++ b/java/arcs/android/storage/ttl/PeriodicCleanupTask.kt
@@ -35,7 +35,6 @@ class PeriodicCleanupTask(
     //
     // Returning from `doWork` is a signal of completion, so we must block here.
     //
-    // on the thread.
     // To avoid blocking thread issues, ensure that the work manager will not schedule this
     // work on any important threads that you're using elsewhere.
     override fun doWork(): Result = runBlocking {


### PR DESCRIPTION
These are two instances in which we want to keep runBlocking. I've added
comments at the usage location explaining why.