### PR TITLE
Remove usage of `runBlocking` from AbstractArcHost

### DIFF
--- a/javatests/arcs/android/e2e/testapp/PersonHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/PersonHostService.kt
@@ -62,7 +62,7 @@ class PersonHostService : ArcHostService() {
 
         override suspend fun stopArc(partition: Plan.Partition) {
             super.stopArc(partition)
-            if (isArcHostIdle) {
+            if (isArcHostIdle()) {
                 sendResult("ArcHost is idle")
             }
         }

--- a/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
+++ b/javatests/arcs/android/e2e/testapp/WriteAnimalHostService.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * Service wrapping an ArcHost which hosts a particle writing data to a handle.
@@ -44,7 +45,11 @@ class WriteAnimalHostService : ArcHostService() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val arcId = intent?.getStringExtra(ARC_ID_EXTRA)
-        val context = arcId?.let { arcHost.arcHostContext(it) }
+        val context = arcId?.let {
+            runBlocking {
+                arcHost.arcHostContext(it)
+            }
+        }
         val writeAnimalParticle =
             context?.particles?.first {
                 it.planParticle.particleName == "WriteAnimal"
@@ -72,7 +77,7 @@ class WriteAnimalHostService : ArcHostService() {
         schedulerProvider = schedulerProvider,
         particles = *initialParticles
     ) {
-        fun arcHostContext(arcId: String) = getArcHostContext(arcId)
+        suspend fun arcHostContext(arcId: String) = getArcHostContext(arcId)
     }
 
     inner class WriteAnimal : AbstractWriteAnimal() {

--- a/javatests/arcs/core/allocator/AllocatorTestBase.kt
+++ b/javatests/arcs/core/allocator/AllocatorTestBase.kt
@@ -474,8 +474,8 @@ open class AllocatorTestBase {
         assertThat((writePersonContext.particle as WritePerson).shutdownCalled).isTrue()
         assertThat((readPersonContext.particle as ReadPerson).shutdownCalled).isTrue()
 
-        assertThat(readingExternalHost.isIdle).isTrue()
-        assertThat(writingExternalHost.isIdle).isTrue()
+        assertThat(readingExternalHost.isIdle()).isTrue()
+        assertThat(writingExternalHost.isIdle()).isTrue()
     }
 
     @Test

--- a/javatests/arcs/core/host/AbstractArcHostTest.kt
+++ b/javatests/arcs/core/host/AbstractArcHostTest.kt
@@ -60,7 +60,7 @@ open class AbstractArcHostTest {
         override val platformTime = FakeTime()
 
         @Suppress("UNCHECKED_CAST")
-        fun getFooHandle(): ReadWriteSingletonHandle<DummyEntity> {
+        suspend fun getFooHandle(): ReadWriteSingletonHandle<DummyEntity> {
             val p = getArcHostContext("arcId")!!.particles.first {
                 it.planParticle.particleName == "Foobar"
             }.particle as TestParticle

--- a/javatests/arcs/core/host/TestingHost.kt
+++ b/javatests/arcs/core/host/TestingHost.kt
@@ -26,7 +26,7 @@ open class TestingHost(
     initialParticles = *particles
 ) {
 
-    fun arcHostContext(arcId: String) = getArcHostContext(arcId)
+    suspend fun arcHostContext(arcId: String) = getArcHostContext(arcId)
 
     var started = mutableListOf<Plan.Partition>()
     var deferred = CompletableDeferred<Boolean>()
@@ -45,11 +45,11 @@ open class TestingHost(
         }
     }
 
-    val isIdle = isArcHostIdle
+    suspend fun isIdle() = isArcHostIdle()
 
     override val platformTime: Time = FakeTime()
 
-    fun setup() {
+    suspend fun setup() {
         started.clear()
         clearCache()
         throws = false
@@ -72,7 +72,7 @@ open class TestingHost(
      * Note that this will always give you the first particle of the provided name, if
      * there are multiple instances of the same particle in the recipe.
      */
-    fun <T : Particle> getParticle(arcId: ArcId, particleName: String): T {
+    suspend fun <T : Particle> getParticle(arcId: ArcId, particleName: String): T {
         val arcHostContext = requireNotNull(getArcHostContext(arcId.toString()))
         @Suppress("UNCHECKED_CAST")
         return arcHostContext.particles.first {

--- a/javatests/arcs/showcase/ShowcaseEnvironment.kt
+++ b/javatests/arcs/showcase/ShowcaseEnvironment.kt
@@ -100,7 +100,7 @@ class ShowcaseEnvironment(
     /**
      * Retrieves a [Particle] instance from a given [Arc].
      */
-    inline fun <reified T : Particle> getParticle(arc: Arc): T {
+    suspend inline fun <reified T : Particle> getParticle(arc: Arc): T {
         return arcHost.getParticle(arc.id.toString(), T::class.simpleName!!)
     }
 
@@ -221,7 +221,7 @@ class ShowcaseHost(
     override val platformTime = JvmTime
 
     @Suppress("UNCHECKED_CAST")
-    fun <T> getParticle(arcId: String, particleName: String): T {
+    suspend fun <T> getParticle(arcId: String, particleName: String): T {
         val arcHostContext = requireNotNull(getArcHostContext(arcId)) {
             "ArcHost: No arc host context found for $arcId"
         }


### PR DESCRIPTION
Turns out this was fairly straightforward, all usages of methods
containing a runBlocking were already called from a coroutine.