### PR TITLE
Bugfix to a subtle field lookup bug

### DIFF
--- a/java/arcs/core/data/expression/Builders.kt
+++ b/java/arcs/core/data/expression/Builders.kt
@@ -189,7 +189,9 @@ open class MapScope<V>(
     override val scopeName: String,
     val map: MutableMap<String, V>
 ) : Scope {
-    override fun <V> lookup(param: String): V = map[param] as V
+    override fun <V> lookup(param: String): V = if (map.containsKey(param)) {
+        map[param] as V
+    } else throw IllegalArgumentException("Field '$param' not found on scope '$scopeName'")
     override fun set(param: String, value: Any?) {
         map[param] = value as V
     }


### PR DESCRIPTION
As described in the comment:
```
    // This is a regression test for the bug where in case of `foo?.bar` lookup
    // with `foo` evaluating to [null], `bar` was looked up on the current scope.
```


Also:
* Looking up non existent field is an exception.
* Looking up a field which has a null value is ok.
* Iterating over a sequence containing nulls is ok.