### PR TITLE
Fixes E2E app by registering a Volatile Driver

### DIFF
--- a/javatests/arcs/android/e2e/testapp/TestApplication.kt
+++ b/javatests/arcs/android/e2e/testapp/TestApplication.kt
@@ -16,9 +16,7 @@ import androidx.work.Configuration
 import arcs.android.storage.database.AndroidSqliteDatabaseManager
 import arcs.android.util.initLogForAndroid
 import arcs.core.storage.api.DriverAndKeyConfigurator
-import arcs.core.storage.driver.DatabaseDriverProvider
 import arcs.core.storage.driver.RamDisk
-import arcs.core.storage.driver.RamDiskDriverProvider
 import arcs.core.util.Log
 
 /** Application class for Arcs Test. */
@@ -31,16 +29,8 @@ class TestApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-
         RamDisk.clear()
-        RamDiskDriverProvider()
-
-        DriverAndKeyConfigurator.configureKeyParsers()
-
-        DatabaseDriverProvider.configure(AndroidSqliteDatabaseManager(this)) {
-            TestEntity.SCHEMA
-        }
-
+        DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(this))
         initLogForAndroid(Log.Level.Debug)
     }
 }


### PR DESCRIPTION
The app seems to work fine now (and doesn't crash on run arc, like it did before).