### PR TITLE
Remove the `snapshotAsync` method from PerformanceStatistics.

### DIFF
--- a/java/arcs/core/util/performance/PerformanceStatistics.kt
+++ b/java/arcs/core/util/performance/PerformanceStatistics.kt
@@ -13,11 +13,8 @@ package arcs.core.util.performance
 
 import arcs.core.util.RunningStatistics
 import arcs.core.util.guardedBy
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -76,11 +73,6 @@ class PerformanceStatistics private constructor(
     suspend fun snapshot(): Snapshot = mutex.withLock {
         Snapshot(runtimeStats.snapshot(), counters.snapshot())
     }
-
-    /** Asynchronously takes a [Snapshot] of the current performance statistics. */
-    fun snapshotAsync(
-        coroutineContext: CoroutineContext = Dispatchers.Default
-    ): Deferred<Snapshot> = CoroutineScope(coroutineContext).async { snapshot() }
 
     /**
      * Records the execution duration of the given [block].

--- a/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
+++ b/javatests/arcs/core/util/performance/PerformanceStatisticsTest.kt
@@ -57,24 +57,6 @@ class PerformanceStatisticsTest {
     }
 
     @Test
-    fun snapshotAsync() = runBlockingTest {
-        val initialSnapshot = PerformanceStatistics.Snapshot(
-            RunningStatistics.Snapshot(1, min = 0.0, max = 0.0),
-            CounterStatistics.Snapshot(
-                mapOf(
-                    "foo" to RunningStatistics.Snapshot(1, min = 10.0, max = 10.0),
-                    "bar" to RunningStatistics.Snapshot(1, min = 5.0, max = 5.0)
-                )
-            )
-        )
-        val stats = PerformanceStatistics(timer, initialSnapshot, "foo", "bar")
-
-        val deferred = stats.snapshotAsync(coroutineContext)
-
-        assertThat(deferred.await()).isEqualTo(initialSnapshot)
-    }
-
-    @Test
     fun time() = runBlocking {
         val stats = PerformanceStatistics(timer, "foo")
 


### PR DESCRIPTION
If the caller wants to run an async job, they can just use async
directly.