### PR TITLE
Remove runBlocking from AndroidSqliteDatabaseManager 

### DIFF
--- a/javatests/arcs/android/entity/TtlHandleTest.kt
+++ b/javatests/arcs/android/entity/TtlHandleTest.kt
@@ -375,7 +375,6 @@ class TtlHandleTest {
   private fun setUpManager(maxDbSize: Int = AndroidSqliteDatabaseManager.MAX_DB_SIZE_BYTES) {
     databaseManager = AndroidSqliteDatabaseManager(
       ApplicationProvider.getApplicationContext(),
-      null,
       maxDbSize
     )
     DriverAndKeyConfigurator.configure(databaseManager)

--- a/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
+++ b/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
@@ -109,7 +109,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun resetDatabaseIfTooLarge() = runBlockingTest {
     // A manager with a small maximum size (5 bytes).
     manager =
-      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), null, 5)
+      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), 5)
     val database = manager.getDatabase("foo", true)
     database.insertOrUpdate(key, entity)
     assertThat(database.get(key, DatabaseData.Entity::class, schema)).isEqualTo(entity)
@@ -142,7 +142,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun doesNotResetDatabaseIfSmallEnough() = runBlockingTest {
     // A manager with a larger maximum size (200 kilobytes).
     manager =
-      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), null, 200000)
+      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), 200000)
     val database = manager.getDatabase("foo", true)
     database.insertOrUpdate(key, entity)
     assertThat(database.get(key, DatabaseData.Entity::class, schema)).isEqualTo(entity)
@@ -157,7 +157,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun test_getEntitiesCount() = runBlockingTest {
     // A manager with a larger maximum size (50 kilobytes).
     manager =
-      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), null, 50000)
+      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), 50000)
     assertThat(manager.getEntitiesCount(true)).isEqualTo(0)
     assertThat(manager.getEntitiesCount(false)).isEqualTo(0)
 
@@ -186,7 +186,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun test_getStorageSize() = runBlockingTest {
     // A manager with a larger maximum size (50 kilobytes).
     manager =
-      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), null, 50000)
+      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), 50000)
     val onDiskDatabase = manager.getDatabase("foo", true)
     val inMemoryDatabase = manager.getDatabase("bar", false)
     val initialOnDiskSize = manager.getStorageSize(true)
@@ -215,7 +215,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun test_isStorageTooLarge_smallMaxSize() = runBlockingTest {
     // A manager with a small maximum size (1 byte).
     manager =
-      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), null, 1)
+      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), 1)
     manager.getDatabase("foo", true)
     assertThat(manager.isStorageTooLarge()).isTrue()
   }
@@ -224,7 +224,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun test_isStorageTooLarge_largeMaxSize() = runBlockingTest {
     // A manager with a larger maximum size (50 kilobytes).
     manager =
-      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), null, 500000)
+      AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext(), 500000)
     manager.getDatabase("foo", true)
     assertThat(manager.isStorageTooLarge()).isFalse()
   }

--- a/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
+++ b/javatests/arcs/android/storage/ttl/PeriodicCleanupTaskTest.kt
@@ -114,7 +114,7 @@ class PeriodicCleanupTaskTest {
   @Test
   fun ttlWorker_resetDatabaseWhenTooLarge() = runBlocking {
     DriverAndKeyConfigurator.configure(
-      AndroidSqliteDatabaseManager(context, null, maxDbSizeBytes = 5)
+      AndroidSqliteDatabaseManager(context, maxDbSizeBytes = 5)
     )
     // Set time to now, so entity is NOT expired.
     fakeTime.millis = JvmTime.currentTimeMillis


### PR DESCRIPTION
This also involves removing the [Lifecycle]-related functionality.

We create the AndroidSqliteDatabaseManager at the application level, so
this would only be triggered during Application.onDestroy, when
everything is about to be cleaned up, anyway.