### PR TITLE
Remove HandleHolderBase.awaitReady 

### DIFF
--- a/java/arcs/sdk/Particle.kt
+++ b/java/arcs/sdk/Particle.kt
@@ -11,7 +11,6 @@
 
 package arcs.sdk
 
-import arcs.core.entity.awaitReady
 import arcs.core.host.api.Particle
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -88,10 +87,5 @@ open class HandleHolderBase(
                 "Particle $particleName does not have a handle with name $handleName."
             )
         }
-    }
-
-    // TODO(b/158233725) - Temp workaround until Arc.waitForStart implies particles are started.
-    suspend fun awaitReady() {
-        handles.forEach { (_, handle) -> handle.awaitReady() }
     }
 }

--- a/javatests/arcs/showcase/inline/Reader.kt
+++ b/javatests/arcs/showcase/inline/Reader.kt
@@ -13,7 +13,6 @@ class Reader0 : AbstractReader0() {
     private fun Level0.fromArcs() = MyLevel0(name)
 
     suspend fun read(): List<MyLevel0> = withContext(handles.level0.dispatcher) {
-        handles.awaitReady()
         handles.level0.fetchAll().map { it.fromArcs() }
     }
 }
@@ -29,7 +28,6 @@ class Reader1 : AbstractReader1() {
     )
 
     suspend fun read(): List<MyLevel1> = withContext(handles.level1.dispatcher) {
-        handles.awaitReady()
         handles.level1.fetchAll().map { it.fromArcs() }
     }
 }
@@ -50,7 +48,6 @@ class Reader2 : AbstractReader2() {
     )
 
     suspend fun read(): List<MyLevel2> = withContext(handles.level2.dispatcher) {
-        handles.awaitReady()
         handles.level2.fetchAll().map { it.fromArcs() }
     }
 }

--- a/javatests/arcs/showcase/inline/Writer.kt
+++ b/javatests/arcs/showcase/inline/Writer.kt
@@ -13,7 +13,6 @@ class Writer0 : AbstractWriter0() {
     private fun MyLevel0.toArcs() = Level0(name)
 
     suspend fun write(item: MyLevel0) = withContext(handles.level0.dispatcher) {
-        handles.awaitReady()
         handles.level0.store(item.toArcs())
     }
 }
@@ -29,7 +28,6 @@ class Writer1 : AbstractWriter1() {
     )
 
     suspend fun write(item: MyLevel1) = withContext(handles.level1.dispatcher) {
-        handles.awaitReady()
         handles.level1.store(item.toArcs())
     }
 }
@@ -50,7 +48,6 @@ class Writer2 : AbstractWriter2() {
     )
 
     suspend fun write(item: MyLevel2) = withContext(handles.level2.dispatcher) {
-        handles.awaitReady()
         handles.level2.store(item.toArcs())
     }
 }

--- a/javatests/arcs/showcase/references/Reader.kt
+++ b/javatests/arcs/showcase/references/Reader.kt
@@ -23,7 +23,6 @@ class Reader0 : AbstractReader0() {
     private fun Level0.fromArcs() = MyLevel0(name)
 
     suspend fun read(): List<MyLevel0> = withContext(handles.level0.dispatcher) {
-        handles.awaitReady()
         handles.level0.fetchAll().map { it.fromArcs() }
     }
 }
@@ -39,7 +38,6 @@ class Reader1 : AbstractReader1() {
     )
 
     suspend fun read(): List<MyLevel1> = withContext(handles.level1.dispatcher) {
-        handles.awaitReady()
         handles.level1.fetchAll().map { it.fromArcs() }
     }
 }
@@ -60,7 +58,6 @@ class Reader2 : AbstractReader2() {
     )
 
     suspend fun read(): List<MyLevel2> = withContext(handles.level2.dispatcher) {
-        handles.awaitReady()
         handles.level2.fetchAll().map { it.fromArcs() }
     }
 }

--- a/javatests/arcs/showcase/references/Writer.kt
+++ b/javatests/arcs/showcase/references/Writer.kt
@@ -2,7 +2,6 @@
 
 package arcs.showcase.references
 
-import arcs.core.entity.awaitReady
 import arcs.jvm.host.TargetHost
 import arcs.sdk.Entity
 import arcs.sdk.ReadWriteCollectionHandle
@@ -24,7 +23,6 @@ class Writer0 : AbstractWriter0() {
     private fun MyLevel0.toArcs() = Level0(name)
 
     suspend fun write(item: MyLevel0) = withContext(handles.level0.dispatcher) {
-        handles.awaitReady()
         handles.level0.store(item.toArcs())
     }
 }
@@ -40,7 +38,6 @@ class Writer1 : AbstractWriter1() {
     )
 
     suspend fun write(item: MyLevel1) = withContext(handles.level1.dispatcher) {
-        handles.awaitReady()
         handles.level1.store(item.toArcs())
     }
 }
@@ -61,7 +58,6 @@ class Writer2 : AbstractWriter2() {
     )
 
     suspend fun write(item: MyLevel2) = withContext(handles.level2.dispatcher) {
-        handles.awaitReady()
         handles.level2.store(item.toArcs())
     }
 }


### PR DESCRIPTION
This had been used as workaround for that fact that startArc.waitForStart
wasn't waiting for particles to be in the ready state, which was fixed
long ago.