### PR TITLE
Fix DevTools parsing of clock and clean up constants.

### DIFF
--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -1,5 +1,6 @@
 package arcs.android.devtools
 
+import arcs.core.crdt.CrdtOperation
 import arcs.core.util.JsonValue
 
 /**
@@ -13,17 +14,50 @@ interface DevToolsMessage {
 
     /** Return a JSON string that can be passed to the client. */
     fun toJson() = JsonValue.JsonObject(mapOf(
-        "kind" to JsonValue.JsonString(kind),
-        "message" to message
+        KIND to JsonValue.JsonString(kind),
+        MESSAGE to message
     )).toString()
 
-    /** Track message types */
+    /** Track message constants */
     companion object {
         /** A [RAW_MESSAGE] should be used to send raw [ProxyMessage]s to the client. */
         const val RAW_MESSAGE = "RawStoreMessage"
         /** A [STORE_SYNC] should be used to notify the client that a store has synced. */
-        const val STORE_SYNC = "StoreSyncMessage"
+        const val SYNC_MESSAGE = "StoreSyncMessage"
         /** A [STORE_MESSAGE] should be used when an [Operation] [ProxyMessage] is received. */
         const val STORE_MESSAGE = "StoreMessage"
+
+        /** A [CLEAR_TYPE] should be used when a clear message is received. */
+        const val CLEAR_TYPE = "clear"
+        /** An [UPDATE_TYPE] should be used when a [CrdtSingleton.Operation.Update] is received. */
+        const val UPDATE_TYPE = "update"
+        /** An [ADD_TYPE] should be used when a [CrdtSet.Operation.Add] is received. */
+        const val ADD_TYPE = "add"
+        /** A [REMOVE_TYPE] should be used when a [CrdtSet.Operation.Remove] is received. */
+        const val REMOVE_TYPE = "remove"
+
+        // String constants to be used in JSON messages.
+        /** JSON key for [kind]. */
+        const val KIND = "kind"
+        /** JSON key for [message]. */
+        const val MESSAGE = "message"
+        /** JSON key for [Store.id]. */
+        const val STORE_ID = "id"
+        /** JSON key for [CrdtOperation]. */
+        const val OPERATIONS = "operations"
+        /** JSON key for the [CrdtOperation]'s type. */
+        const val TYPE = "type"
+        /** JSON key for the [actor] of the [CrdtOperation]. */
+        const val ACTOR = "actor"
+        /** JSON key for the update value from a [CrdtOperation]. */
+        const val VALUE = "value"
+        /** Json Key for the values added in a [CrdtOperation]. */
+        const val ADDED = "added"
+        /** Json Key for the values removed in a [CrdtOperation]. */
+        const val REMOVED = "removed"
+        /** Json Key for the old clock in a [FastForward] operation. */
+        const val OLD_CLOCK = "oldClock"
+        /** Json Key for the clock in a [CrdtOperation]. */
+        const val CLOCK = "clock"
     }
 }

--- a/java/arcs/android/devtools/StoreMessage.kt
+++ b/java/arcs/android/devtools/StoreMessage.kt
@@ -1,6 +1,19 @@
 package arcs.android.devtools
 
+import arcs.android.devtools.DevToolsMessage.Companion.ACTOR
+import arcs.android.devtools.DevToolsMessage.Companion.ADDED
+import arcs.android.devtools.DevToolsMessage.Companion.ADD_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.CLEAR_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.CLOCK
+import arcs.android.devtools.DevToolsMessage.Companion.OLD_CLOCK
+import arcs.android.devtools.DevToolsMessage.Companion.OPERATIONS
+import arcs.android.devtools.DevToolsMessage.Companion.REMOVED
+import arcs.android.devtools.DevToolsMessage.Companion.REMOVE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_ID
 import arcs.android.devtools.DevToolsMessage.Companion.STORE_MESSAGE
+import arcs.android.devtools.DevToolsMessage.Companion.TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.UPDATE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.VALUE
 import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
@@ -22,8 +35,8 @@ class StoreMessage(
     override val kind: String = STORE_MESSAGE
     override val message: JsonValue<*>
         get() = JsonValue.JsonObject(
-            "id" to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
-            "operations" to JsonValue.JsonArray(getMessageAsList())
+            STORE_ID to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
+            OPERATIONS to JsonValue.JsonArray(getMessageAsList())
         )
 
     /**
@@ -36,59 +49,59 @@ class StoreMessage(
                 is CrdtSingleton.Operation.Update<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            "type" to JsonValue.JsonString(UPDATE_TYPE),
-                            "value" to getValue(op.value),
-                            "actor" to JsonValue.JsonString(op.actor),
-                            "clock" to getJsonClock(op.clock)
+                            TYPE to JsonValue.JsonString(UPDATE_TYPE),
+                            VALUE to getValue(op.value),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
                         )
                     )
                 }
                 is CrdtSingleton.Operation.Clear<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                                "type" to JsonValue.JsonString(CLEAR_TYPE),
-                                "actor" to JsonValue.JsonString(op.actor),
-                                "clock" to JsonValue.JsonString(op.clock.toString())
+                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
                         )
                     )
                 }
                 is CrdtSet.Operation.Add<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            "type" to JsonValue.JsonString(ADD_TYPE),
-                            "added" to getValue(op.added),
-                            "actor" to JsonValue.JsonString(op.actor),
-                            "clock" to JsonValue.JsonString(op.clock.toString())
+                            TYPE to JsonValue.JsonString(ADD_TYPE),
+                            ADDED to getValue(op.added),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
                         )
                     )
                 }
                 is CrdtSet.Operation.Clear<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            "type" to JsonValue.JsonString(CLEAR_TYPE),
-                            "actor" to JsonValue.JsonString(op.actor),
-                            "clock" to JsonValue.JsonString(op.clock.toString())
+                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
                         )
                     )
                 }
                 is CrdtSet.Operation.Remove<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            "type" to JsonValue.JsonString(REMOVE_TYPE),
-                            "value" to getValue(op.removed),
-                            "actor" to JsonValue.JsonString(op.actor),
-                            "clock" to JsonValue.JsonString(op.clock.toString())
+                            TYPE to JsonValue.JsonString(REMOVE_TYPE),
+                            VALUE to getValue(op.removed),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
                         )
                     )
                 }
                 is CrdtSet.Operation.FastForward<*> -> {
                     list.add(
                         JsonValue.JsonObject(
-                            "type" to JsonValue.JsonString(ADD_TYPE),
-                            "added" to getAddedListValue(op.added),
-                            "removed" to getRemovedListValue(op.removed),
-                            "oldClock" to JsonValue.JsonString(op.oldClock.toString()),
-                            "clock" to JsonValue.JsonString(op.clock.toString())
+                            TYPE to JsonValue.JsonString(ADD_TYPE),
+                            ADDED to getAddedListValue(op.added),
+                            REMOVED to getRemovedListValue(op.removed),
+                            OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
+                            CLOCK to op.clock.toJson()
                         )
                     )
                 }
@@ -100,10 +113,10 @@ class StoreMessage(
     /**
      * Turn the clock [VersionMap] into a [JsonValue.JsonObject].
      */
-    private fun getJsonClock(clock: VersionMap): JsonValue<*> {
+    private fun VersionMap.toJson(): JsonValue<*> {
         val map = mutableMapOf<String, JsonValue<*>>()
-        clock.actors.forEach {
-            map.put(it, JsonValue.JsonNumber(clock[it].toDouble()))
+        actors.forEach {
+            map.put(it, JsonValue.JsonNumber(this[it].toDouble()))
         }
         return JsonValue.JsonObject(map)
     }
@@ -160,16 +173,5 @@ class StoreMessage(
             }
         }
         return JsonValue.JsonNull
-    }
-
-    companion object {
-        /** A [CLEAR_TYPE] should be used when a clear message is received. */
-        const val CLEAR_TYPE = "clear"
-        /** An [UPDATE_TYPE] should be used when a [CrdtSingleton.Operation.Update] is received. */
-        const val UPDATE_TYPE = "update"
-        /** An [ADD_TYPE] should be used when a [CrdtSet.Operation.Add] is received. */
-        const val ADD_TYPE = "add"
-        /** A [REMOVE_TYPE] should be used when a [CrdtSet.Operation.Remove] is received. */
-        const val REMOVE_TYPE = "remove"
     }
 }

--- a/java/arcs/android/devtools/StoreSyncMessage.kt
+++ b/java/arcs/android/devtools/StoreSyncMessage.kt
@@ -1,6 +1,6 @@
 package arcs.android.devtools
 
-import arcs.android.devtools.DevToolsMessage.Companion.STORE_SYNC
+import arcs.android.devtools.DevToolsMessage.Companion.SYNC_MESSAGE
 import arcs.core.util.JsonValue
 
 /**
@@ -8,5 +8,5 @@ import arcs.core.util.JsonValue
  * [SyncRequest].
  */
 class StoreSyncMessage(override val message: JsonValue.JsonNumber) : DevToolsMessage {
-    override val kind: String = STORE_SYNC
+    override val kind: String = SYNC_MESSAGE
 }


### PR DESCRIPTION
- Fix bug where the clock was being sent as a string instead of a JSON object.
- Instead of using manual strings in JSON messages, create constants in DevToolsMessage.
  - Use newly created strings in DevTools Messages.

cc: @piotrswigon 