### PR TITLE
immutable scopes + orderby

### DIFF
--- a/java/arcs/core/data/expression/Builders.kt
+++ b/java/arcs/core/data/expression/Builders.kt
@@ -192,9 +192,8 @@ open class MapScope<V>(
     override fun <V> lookup(param: String): V = if (map.containsKey(param)) {
         map[param] as V
     } else throw IllegalArgumentException("Field '$param' not found on scope '$scopeName'")
-    override fun set(param: String, value: Any?) {
-        map[param] = value as V
-    }
+    override fun set(param: String, value: Any?): Scope =
+        MapScope<V>(scopeName, map.toMutableMap().also { it[param] = value as V })
     override fun toString() = map.toString()
 }
 

--- a/java/arcs/core/data/expression/Builders.kt
+++ b/java/arcs/core/data/expression/Builders.kt
@@ -187,13 +187,23 @@ class CurrentScope<V>(map: MutableMap<String, V>) : MapScope<V>("<this>", map)
 /** A scope with a simple map backing it, mostly for test purposes. */
 open class MapScope<V>(
     override val scopeName: String,
-    val map: MutableMap<String, V>
+    val map: Map<String, V>,
+    val parentScope: Scope? = null
 ) : Scope {
-    override fun <V> lookup(param: String): V = if (map.containsKey(param)) {
-        map[param] as V
-    } else throw IllegalArgumentException("Field '$param' not found on scope '$scopeName'")
-    override fun set(param: String, value: Any?): Scope =
-        MapScope<V>(scopeName, map.toMutableMap().also { it[param] = value as V })
+    override fun <V> lookup(param: String): V = map.getOrElse(param) {
+        parentScope?.lookup<V>(param)
+    } as V
+
+    override fun builder() = object : Scope.Builder {
+        val fields = mutableMapOf<String, V>()
+        override fun set(param: String, value: Any?): Scope.Builder {
+            fields[param] = value as V
+            return this
+        }
+
+        override fun build(): Scope = MapScope(scopeName, fields, this@MapScope)
+    }
+
     override fun toString() = map.toString()
 }
 
@@ -207,35 +217,43 @@ fun <T> Map<String, T>.asScope(scopeName: String = "<object>") = MapScope(
 fun <T> query(queryArgName: String) = Expression.QueryParameterExpression<T>(queryArgName)
 
 /** Helper used to build [FromExpression]. */
-data class FromBuilder(val iterName: String, val qualifier: Expression<Sequence<Unit>>?)
+data class FromBuilder(val iterName: String, val qualifier: Expression<Sequence<Scope>>?)
 
 /** Build a [FromExpression] whose [Sequence] iterates using a scope variable named [iterName]. */
 fun from(iterName: String) = FromBuilder(iterName, null)
 
 /** Build a nested [FromExpression] whose [Sequence] iterates a scope variable named [iterName]. */
-infix fun Expression<Sequence<Unit>>.from(iterName: String) = FromBuilder(iterName, this)
+infix fun Expression<Sequence<Scope>>.from(iterName: String) = FromBuilder(iterName, this)
 
 /** Designates the expression which holds the [Sequence] the from expression iterates on. */
-infix fun FromBuilder.on(sequence: Expression<Sequence<Any>>) =
-    Expression.FromExpression(this.qualifier, sequence, this.iterName)
+infix fun FromBuilder.on(sequence: Expression<Sequence<Scope>>) =
+    Expression.FromExpression(
+        this.qualifier,
+        sequence,
+        this.iterName
+    )
 
 /** Constructs a [WhereExpression]. */
-infix fun Expression<Sequence<Unit>>.where(expr: Expression<Boolean>) =
+infix fun Expression<Sequence<Scope>>.where(expr: Expression<Boolean>) =
     Expression.WhereExpression(this, expr)
 
 /** Helper used to build [LetExpression]. */
-data class LetBuilder(val variableName: String, val qualifier: Expression<Sequence<Unit>>)
+data class LetBuilder(val variableName: String, val qualifier: Expression<Sequence<Scope>>)
 
 /** Build a let expression nested inside a qualified expression. */
-infix fun Expression<Sequence<Unit>>.let(variableName: String) =
+infix fun Expression<Sequence<Scope>>.let(variableName: String) =
     LetBuilder(variableName, this)
 
 /** Assigns an expression to be evaluated as a value to be introduced into the scope. */
 infix fun LetBuilder.be(expression: Expression<Any>) =
-    Expression.LetExpression(this.qualifier, expression, this.variableName)
+    Expression.LetExpression(
+        this.qualifier,
+        expression,
+        this.variableName
+    )
 
 /** Constructs a [SelectExpression]. */
-infix fun <T> Expression<Sequence<Unit>>.select(expr: Expression<T>) =
+infix fun <T> Expression<Sequence<Scope>>.select(expr: Expression<T>) =
     Expression.SelectExpression(this, expr)
 
 /** Helper to construct [NewExpression]. */

--- a/java/arcs/core/data/expression/Evaluator.kt
+++ b/java/arcs/core/data/expression/Evaluator.kt
@@ -99,11 +99,10 @@ class ExpressionEvaluator(
     }
 
     override fun visit(expr: Expression.NewExpression): Any {
-        val newScope = scopeCreator(expr.schemaName.firstOrNull() ?: "")
-        expr.fields.forEach { (fieldName, fieldExpr) ->
-            newScope.set(fieldName, fieldExpr.accept(this))
+        val initScope = scopeCreator(expr.schemaName.firstOrNull() ?: "")
+        return expr.fields.fold(initScope) { scope, (fieldName, fieldExpr) ->
+           scope.set(fieldName, fieldExpr.accept(this))
         }
-        return newScope
     }
 
     override fun <T> visit(expr: Expression.FunctionExpression<T>): Any? {

--- a/java/arcs/core/data/expression/Evaluator.kt
+++ b/java/arcs/core/data/expression/Evaluator.kt
@@ -23,10 +23,10 @@ import arcs.core.util.Time
  * reflected as exceptions.
  */
 class ExpressionEvaluator(
-    var currentScope: Scope = CurrentScope<Any?>(),
+    val rootScope: Scope = CurrentScope<Any?>(),
     val parameterScope: Scope = ParameterScope(),
     val scopeCreator: (String) -> Scope = { name -> MapScope<Any?>(name, mutableMapOf()) }
-) : Expression.Visitor<Any?> {
+) : Expression.Visitor<Any?, Scope> {
 
     // TODO: allow this to be plumbed through via injection
     val time = object : Time() {
@@ -36,16 +36,23 @@ class ExpressionEvaluator(
             get() = PlatformTime.currentTimeMillis
     }
 
-    override fun <E, T> visit(expr: Expression.UnaryExpression<E, T>): Any? {
-        return expr.op(expr.expr.accept(this) as E) as Any
+    override fun <E, T> visit(expr: Expression.UnaryExpression<E, T>, ctx: Scope): Any? {
+        return expr.op(expr.expr.accept(this, ctx) as E) as Any
     }
 
-    override fun <L, R, T> visit(expr: Expression.BinaryExpression<L, R, T>): Any? {
-        return expr.op(expr.left.accept(this) as L, expr.right.accept(this) as R)
+    override fun <L, R, T> visit(expr: Expression.BinaryExpression<L, R, T>, ctx: Scope): Any? {
+        return expr.op(expr.left.accept(this, ctx) as L, expr.right.accept(this, ctx) as R)
     }
 
-    override fun <T> visit(expr: Expression.FieldExpression<T>): Any? =
-        (if (expr.qualifier == null) {
+    override fun <T> visit(expr: Expression.FieldExpression<T>, ctx: Scope): Any? =
+        (expr.qualifier?.accept(this, ctx) as? Scope ?: ctx).apply {
+            @Suppress("SENSELESS_COMPARISON") if (this == null && !expr.nullSafe) {
+                throw IllegalArgumentException("Field '${expr.field}' not found")
+            }
+        }?.lookup(expr.field)
+
+    /*
+     (if (expr.qualifier == null) {
             currentScope
         } else {
             expr.qualifier.accept(this) as Scope?
@@ -54,77 +61,79 @@ class ExpressionEvaluator(
                 throw IllegalArgumentException("Field '${expr.field}' looked up on null scope")
             }
         }?.lookup(expr.field)
-
-    override fun <E> visit(expr: Expression.QueryParameterExpression<E>): Any {
+     */
+    override fun <E> visit(expr: Expression.QueryParameterExpression<E>, ctx: Scope): Any {
         return parameterScope.lookup(expr.paramIdentifier) as? Any
             ?: throw IllegalArgumentException(
                 "Unbound parameter '${expr.paramIdentifier}'"
             )
     }
 
-    override fun visit(expr: Expression.NumberLiteralExpression): Number = expr.value
+    override fun visit(expr: Expression.NumberLiteralExpression, ctx: Scope): Number = expr.value
 
-    override fun visit(expr: Expression.TextLiteralExpression): String = expr.value
+    override fun visit(expr: Expression.TextLiteralExpression, ctx: Scope): String = expr.value
 
-    override fun visit(expr: Expression.BooleanLiteralExpression): Boolean = expr.value
+    override fun visit(expr: Expression.BooleanLiteralExpression, ctx: Scope): Boolean = expr.value
 
-    override fun visit(expr: Expression.NullLiteralExpression): Any? = expr.value
+    override fun visit(expr: Expression.NullLiteralExpression, ctx: Scope): Any? = expr.value
 
-    override fun visit(expr: Expression.FromExpression): Any {
-        return (expr.qualifier?.accept(this) as Sequence<*>? ?: sequenceOf(null)).flatMap { scope ->
-            asSequence<Any>(expr.source.accept(this)).map {
-                currentScope = (scope as? Scope ?: currentScope).set(expr.iterationVar, it)
-                currentScope
+    override fun visit(expr: Expression.FromExpression, ctx: Scope): Any {
+        val qualSequence = expr.qualifier?.accept(this, ctx) as? Sequence<Scope> ?: sequenceOf(null)
+        return qualSequence.flatMap { scope ->
+            asSequence<Any>(expr.source.accept(this, scope ?: ctx)).map {
+                (scope ?: ctx).set(expr.iterationVar, it)
             }
         }
     }
 
-    override fun visit(expr: Expression.WhereExpression): Any {
-        return (expr.qualifier.accept(this) as Sequence<*>).filter {
-            expr.expr.accept(this) == true
+    override fun visit(expr: Expression.WhereExpression, ctx: Scope): Any {
+        return (expr.qualifier.accept(this, ctx) as Sequence<Scope>).filter {
+            expr.expr.accept(this, it) == true
         }
     }
 
-    override fun visit(expr: Expression.LetExpression): Any {
-        return (expr.qualifier.accept(this) as Sequence<*>).map {
-            currentScope = currentScope.set(expr.variableName, expr.variableExpr.accept(this))
-            currentScope
+    override fun visit(expr: Expression.LetExpression, ctx: Scope): Any {
+        return (expr.qualifier.accept(this, ctx) as Sequence<Scope>).map { scope ->
+            scope.set(expr.variableName, expr.variableExpr.accept(this, scope))
         }
     }
 
-    override fun <T> visit(expr: Expression.SelectExpression<T>): Any? {
-        return (expr.qualifier.accept(this) as Sequence<*>).map {
-            expr.expr.accept(this) as T
+    override fun <T> visit(expr: Expression.SelectExpression<T>, ctx: Scope): Any? {
+        return (expr.qualifier.accept(this, ctx) as Sequence<Scope>).map {
+            expr.expr.accept(this, it) as T
         }
     }
 
-    override fun visit(expr: Expression.NewExpression): Any {
+    override fun visit(expr: Expression.NewExpression, ctx: Scope): Any {
         val initScope = scopeCreator(expr.schemaName.firstOrNull() ?: "")
-        return expr.fields.fold(initScope) { scope, (fieldName, fieldExpr) ->
-           scope.set(fieldName, fieldExpr.accept(this))
-        }
+        return expr.fields.fold(initScope.builder()) { builder, (fieldName, fieldExpr) ->
+           builder.set(fieldName, fieldExpr.accept(this, ctx))
+        }.build()
     }
 
-    override fun <T> visit(expr: Expression.FunctionExpression<T>): Any? {
-        val arguments = expr.arguments.map { it.accept(this) }.toList()
+    override fun <T> visit(expr: Expression.FunctionExpression<T>, ctx: Scope): Any? {
+        val arguments = expr.arguments.map { it.accept(this, ctx) }.toList()
         return expr.function.invoke(this, arguments)
     }
 
-    override fun <T> visit(expr: Expression.OrderByExpression<T>): Any {
-        return (expr.qualifier.accept(this) as Sequence<Scope>).sortedWith(
-            compareBy(
-                // construct lambda (Scope) -> Comparable<Any> evaluated in context of scope
-                *expr.selectors.map { selector: Expression<Any> ->
-                    { scope: Scope ->
-                        currentScope = scope
-                        selector.accept(this@ExpressionEvaluator) as Comparable<Any>
-                    }
-                }.toTypedArray()
-            ).let { comparator: Comparator<Scope> ->
-                if (expr.descending) Comparator<Scope> { a, b ->
-                    comparator.compare(b, a)
-                } else comparator
-            }
+    private fun compareBy(selector: Pair<Expression<Any>, Boolean>): Comparator<Scope> {
+        val comparator = { scope: Scope ->
+            selector.first.accept(this@ExpressionEvaluator, scope) as Comparable<Any>
+        }
+
+        return if (selector.second) {
+            compareByDescending(comparator)
+        } else {
+            compareBy(comparator)
+        }
+    }
+
+    override fun <T> visit(expr: Expression.OrderByExpression<T>, ctx: Scope): Any {
+        val nullComp: Comparator<Scope>? = null
+        return (expr.qualifier.accept(this, ctx) as Sequence<Scope>).sortedWith(
+            expr.selectors.fold(nullComp) { previous, selector ->
+                previous?.then(compareBy(selector)) ?: compareBy(selector)
+            } as Comparator<Scope>
         ).map {
             /*
              * Since sortedWith() is a terminal operation that forces the traversal of the entire
@@ -132,7 +141,6 @@ class ExpressionEvaluator(
              * a new mapped sequence which sets the current scope for any subsequent expressions
              * this might qualify.
              */
-            currentScope = it
             it
         }
     }
@@ -232,5 +240,5 @@ fun <T> evalExpression(
 ): T {
     val parameterScope = mapOf(*params)
     val evaluator = ExpressionEvaluator(currentScope, parameterScope.asScope())
-    return expression.accept(evaluator) as T
+    return expression.accept(evaluator, currentScope) as T
 }

--- a/java/arcs/core/data/expression/Evaluator.kt
+++ b/java/arcs/core/data/expression/Evaluator.kt
@@ -134,15 +134,7 @@ class ExpressionEvaluator(
             expr.selectors.fold(nullComp) { previous, selector ->
                 previous?.then(compareBy(selector)) ?: compareBy(selector)
             } as Comparator<Scope>
-        ).map {
-            /*
-             * Since sortedWith() is a terminal operation that forces the traversal of the entire
-             * Sequence of scopes, and then restarts the traversal from the beginning, we return
-             * a new mapped sequence which sets the current scope for any subsequent expressions
-             * this might qualify.
-             */
-            it
-        }
+        )
     }
 }
 

--- a/java/arcs/core/data/expression/Expression.kt
+++ b/java/arcs/core/data/expression/Expression.kt
@@ -465,8 +465,12 @@ sealed class Expression<out T> {
      */
     data class OrderByExpression<T>(
         override val qualifier: Expression<Sequence<Scope>>,
-        val selectors: List<Pair<Expression<Any>, Boolean>>
+        val selectors: List<Selector>
     ) : QualifiedExpression, Expression<Sequence<T>>() {
+
+        /** the orderby [expr] and a boolean whether it is a descending sort. */
+        data class Selector(val expr: Expression<Any>, val descending: Boolean)
+
         init {
             require(!selectors.isEmpty()) {
                 "OrderBy expressions must have at least 1 selector."

--- a/java/arcs/core/data/expression/Expression.kt
+++ b/java/arcs/core/data/expression/Expression.kt
@@ -44,7 +44,7 @@ sealed class Expression<out T> {
         fun <T> lookup(param: String): T
 
         /** Return a builder used to create a new immutable scope. */
-        fun builder(): Builder
+        fun builder(subName: String? = null): Builder
 
         /** Return a new scope with the given entry. */
         fun set(param: String, value: Any?) = builder().set(param, value).build()

--- a/java/arcs/core/data/expression/Expression.kt
+++ b/java/arcs/core/data/expression/Expression.kt
@@ -29,70 +29,82 @@ sealed class Expression<out T> {
      * to entities, but could also be used for coercions, e.g. 'numberField.integerPart'.
      */
     interface Scope {
+        /** Used to construct new immutable scopes as children of the current [Scope]. */
+        interface Builder {
+            /** Set's the parameter to the given entry. */
+            fun set(param: String, value: Any?): Builder
+            /** builds a new [Scope] as a child of this [Scope] with entries collected via [set] */
+            fun build(): Scope
+        }
+
         /** The name of the scope, used for debugging and stringification */
         val scopeName: String
 
         /** Lookup an entry in a given scope. */
         fun <T> lookup(param: String): T
 
+        /** Return a builder used to create a new immutable scope. */
+        fun builder(): Builder
+
         /** Return a new scope with the given entry. */
-        fun set(param: String, value: Any?): Scope
+        fun set(param: String, value: Any?) = builder().set(param, value).build()
     }
 
     /**
      * Visitor pattern for traversing expressions. Implementations of visitor are used for
      * evaluation, serialization, and type flow.
      * @param Result type returned from processing a visitation of an [Expression]
+     * @param Context a user defined context for any evaluation or traversal
      */
-    interface Visitor<Result> {
+    interface Visitor<Result, Context> {
         /** Called when [UnaryExpression] encountered. */
-        fun <E, T> visit(expr: UnaryExpression<E, T>): Result
+        fun <E, T> visit(expr: UnaryExpression<E, T>, ctx: Context): Result
 
         /** Called when [BinaryExpression] encountered. */
-        fun <L, R, T> visit(expr: BinaryExpression<L, R, T>): Result
+        fun <L, R, T> visit(expr: BinaryExpression<L, R, T>, ctx: Context): Result
 
         /** Called when [FieldExpression] encountered. */
-        fun <T> visit(expr: FieldExpression<T>): Result
+        fun <T> visit(expr: FieldExpression<T>, ctx: Context): Result
 
         /** Called when [QueryParameterExpression] encountered. */
-        fun <T> visit(expr: QueryParameterExpression<T>): Result
+        fun <T> visit(expr: QueryParameterExpression<T>, ctx: Context): Result
 
         /** Called when [NumberLiteralExpression] encountered. */
-        fun visit(expr: NumberLiteralExpression): Result
+        fun visit(expr: NumberLiteralExpression, ctx: Context): Result
 
         /** Called when [TextLiteralExpression] encountered. */
-        fun visit(expr: TextLiteralExpression): Result
+        fun visit(expr: TextLiteralExpression, ctx: Context): Result
 
         /** Called when [BooleanLiteralExpression] encountered. */
-        fun visit(expr: BooleanLiteralExpression): Result
+        fun visit(expr: BooleanLiteralExpression, ctx: Context): Result
 
         /** Called when [NullLiteralExpression] encountered. */
-        fun visit(expr: NullLiteralExpression): Result
+        fun visit(expr: NullLiteralExpression, ctx: Context): Result
 
         /** Called when [FromExpression] encountered. */
-        fun visit(expr: FromExpression): Result
+        fun visit(expr: FromExpression, ctx: Context): Result
 
         /** Called when [WhereExpression] encountered. */
-        fun visit(expr: WhereExpression): Result
+        fun visit(expr: WhereExpression, ctx: Context): Result
 
         /** Called when [SelectExpression] encountered. */
-        fun <T> visit(expr: SelectExpression<T>): Result
+        fun <T> visit(expr: SelectExpression<T>, ctx: Context): Result
 
         /** Called when [LetExpression] encountered. */
-        fun visit(expr: LetExpression): Result
+        fun visit(expr: LetExpression, ctx: Context): Result
 
         /** Called when [FunctionExpression] encountered. */
-        fun <T> visit(expr: FunctionExpression<T>): Result
+        fun <T> visit(expr: FunctionExpression<T>, ctx: Context): Result
 
         /** Called when [NewExpression] encountered. */
-        fun visit(expr: NewExpression): Result
+        fun visit(expr: NewExpression, ctx: Context): Result
 
         /** Called when [OrderByExpression] encountered. */
-        fun <T> visit(expr: OrderByExpression<T>): Result
+        fun <T> visit(expr: OrderByExpression<T>, ctx: Context): Result
     }
 
     /** Accepts a visitor and invokes the appropriate [Visitor.visit] method. */
-    abstract fun <Result> accept(visitor: Visitor<Result>): Result
+    abstract fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context): Result
 
     override fun toString() = this.stringify()
 
@@ -255,7 +267,9 @@ sealed class Expression<out T> {
         val left: Expression<L>,
         val right: Expression<R>
     ) : Expression<T>() {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
+
         override fun toString() = this.stringify()
     }
 
@@ -268,7 +282,8 @@ sealed class Expression<out T> {
         val op: UnaryOp<E, T>,
         val expr: Expression<E>
     ) : Expression<T>() {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         override fun toString() = this.stringify()
     }
 
@@ -282,7 +297,8 @@ sealed class Expression<out T> {
         val field: String,
         val nullSafe: Boolean
     ) : Expression<T>() {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         override fun toString() = this.stringify()
     }
 
@@ -291,7 +307,8 @@ sealed class Expression<out T> {
      *  @param T the type of the resulting query parameter
      */
     data class QueryParameterExpression<T>(val paramIdentifier: String) : Expression<T>() {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         override fun toString() = this.stringify()
     }
 
@@ -316,27 +333,31 @@ sealed class Expression<out T> {
 
     /** A reference to a literal [Number] value, e.g. 42.0 */
     class NumberLiteralExpression(number: Number) : LiteralExpression<Number>(number) {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
     }
 
     /** A reference to a literal text value, e.g. "Hello" */
     class TextLiteralExpression(text: String) : LiteralExpression<String>(text) {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
     }
 
     /** A reference to a literal boolean value, e.g. true/false */
     class BooleanLiteralExpression(boolean: Boolean) : LiteralExpression<Boolean>(boolean) {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
     }
 
     /** A reference to a literal null */
     class NullLiteralExpression() : LiteralExpression<Any?>(null) {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
     }
 
     /** Subtypes represent a [Expression]s that operate over the result of the [qualifier]. */
     interface QualifiedExpression {
-        val qualifier: Expression<Sequence<Unit>>?
+        val qualifier: Expression<Sequence<Scope>>?
         fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression
     }
 
@@ -346,14 +367,15 @@ sealed class Expression<out T> {
      * a new sequence.
      */
     data class FromExpression(
-        override val qualifier: Expression<Sequence<Unit>>?,
+        override val qualifier: Expression<Sequence<Scope>>?,
         val source: Expression<Sequence<Any>>,
         val iterationVar: String
-    ) : QualifiedExpression, Expression<Sequence<Unit>>() {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+    ) : QualifiedExpression, Expression<Sequence<Scope>>() {
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         @Suppress("UNCHECKED_CAST")
         override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
-            this.copy(qualifier = qualifier as? Expression<Sequence<Unit>>)
+            this.copy(qualifier = qualifier as? Expression<Sequence<Scope>>)
         override fun toString() = this.stringify()
     }
 
@@ -361,13 +383,14 @@ sealed class Expression<out T> {
      * Represents a filter expression that returns true or false.
      */
     data class WhereExpression(
-        override val qualifier: Expression<Sequence<Unit>>,
+        override val qualifier: Expression<Sequence<Scope>>,
         val expr: Expression<Boolean>
-    ) : QualifiedExpression, Expression<Sequence<Unit>>() {
-        override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
+    ) : QualifiedExpression, Expression<Sequence<Scope>>() {
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         @Suppress("UNCHECKED_CAST")
         override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
-            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Unit>>) }
+            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Scope>>) }
                 ?: this
         override fun toString() = this.stringify()
     }
@@ -376,14 +399,15 @@ sealed class Expression<out T> {
      * Represents introducing a new identifier into the scope.
      */
     data class LetExpression(
-        override val qualifier: Expression<Sequence<Unit>>,
+        override val qualifier: Expression<Sequence<Scope>>,
         val variableExpr: Expression<*>,
         val variableName: String
-    ) : QualifiedExpression, Expression<Sequence<Unit>>() {
-        override fun <Result> accept(visitor: Visitor<Result>) = visitor.visit(this)
+    ) : QualifiedExpression, Expression<Sequence<Scope>>() {
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         @Suppress("UNCHECKED_CAST")
         override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
-            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Unit>>) }
+            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Scope>>) }
                 ?: this
         override fun toString() = this.stringify()
     }
@@ -394,13 +418,14 @@ sealed class Expression<out T> {
      * @param T the type of the new elements in the sequence
      */
     data class SelectExpression<T>(
-        override val qualifier: Expression<Sequence<Unit>>,
+        override val qualifier: Expression<Sequence<Scope>>,
         val expr: Expression<T>
     ) : QualifiedExpression, Expression<Sequence<T>>() {
-        override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         @Suppress("UNCHECKED_CAST")
         override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
-            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Unit>>) }
+            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Scope>>) }
                 ?: this
         override fun toString() = this.stringify()
     }
@@ -413,7 +438,8 @@ sealed class Expression<out T> {
         val schemaName: Set<String>,
         val fields: List<Pair<String, Expression<*>>>
     ) : Expression<Scope>() {
-        override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         override fun toString() = this.stringify()
     }
 
@@ -426,7 +452,8 @@ sealed class Expression<out T> {
         val function: GlobalFunction,
         val arguments: List<Expression<*>>
     ) : Expression<T>() {
-        override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         override fun toString() = this.stringify()
     }
 
@@ -437,20 +464,20 @@ sealed class Expression<out T> {
      * [selectors] is a non-empty list of expressions that return values to be used for ordering.
      */
     data class OrderByExpression<T>(
-        override val qualifier: Expression<Sequence<Unit>>,
-        val selectors: List<Expression<Any>>,
-        val descending: Boolean
+        override val qualifier: Expression<Sequence<Scope>>,
+        val selectors: List<Pair<Expression<Any>, Boolean>>
     ) : QualifiedExpression, Expression<Sequence<T>>() {
         init {
             require(!selectors.isEmpty()) {
                 "OrderBy expressions must have at least 1 selector."
             }
         }
-        override fun <Result> accept(visitor: Visitor<Result>): Result = visitor.visit(this)
+        override fun <Result, Context> accept(visitor: Visitor<Result, Context>, ctx: Context) =
+            visitor.visit(this, ctx)
         override fun toString() = this.stringify()
         @Suppress("UNCHECKED_CAST")
         override fun withQualifier(qualifier: QualifiedExpression?): QualifiedExpression =
-            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Unit>>) }
+            qualifier?.let { this.copy(qualifier = qualifier as Expression<Sequence<Scope>>) }
                 ?: this
     }
 }

--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -217,8 +217,9 @@ object PaxelParser {
         it?.let { dir -> dir == "descending" } ?: false
     }
 
+    @Suppress("UNCHECKED_CAST")
     private val selectorExpression = (refinementExpression + orderDirection).map { (expr, dir) ->
-        expr to dir
+        Expression.OrderByExpression.Selector(expr as Expression<Any>, dir)
     }
 
     private val orderBySelectors =
@@ -226,15 +227,13 @@ object PaxelParser {
             listOf(first) + rest
         }
 
-
-
     @Suppress("UNCHECKED_CAST")
     private val orderByExpression = -token("orderby") +
         (whitespace + orderBySelectors).map { selectors ->
             Expression.OrderByExpression<Any>(
-            selectors[0].first as Expression<Sequence<Scope>>,
-            selectors as List<Pair<Expression<Any>, Boolean>>
-        )
+                selectors[0].expr as Expression<Sequence<Scope>>,
+                selectors
+            )
     }
 
     private val schemaNames = (ident + many(whitespace + ident)).map { (ident, rest) ->

--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -219,7 +219,7 @@ object PaxelParser {
                 (selectors, descending) ->
             Expression.OrderByExpression<Any>(
             selectors[0] as Expression<Sequence<kotlin.Unit>>,
-            selectors,
+            selectors as List<Expression<Any>>,
             descending == "descending"
         )
     }

--- a/java/arcs/core/data/expression/RawEntityScope.kt
+++ b/java/arcs/core/data/expression/RawEntityScope.kt
@@ -50,7 +50,7 @@ class RawEntityScope(val rawEntity: RawEntity) : Expression.Scope {
         }
     }
 
-    override fun builder() = object : Expression.Scope.Builder {
+    override fun builder(subName: String?) = object : Expression.Scope.Builder {
         override fun set(param: String, value: Any?): Expression.Scope.Builder {
             return this
         }

--- a/java/arcs/core/data/expression/RawEntityScope.kt
+++ b/java/arcs/core/data/expression/RawEntityScope.kt
@@ -50,7 +50,13 @@ class RawEntityScope(val rawEntity: RawEntity) : Expression.Scope {
         }
     }
 
-    override fun set(param: String, value: Any?): Expression.Scope = this
+    override fun builder() = object : Expression.Scope.Builder {
+        override fun set(param: String, value: Any?): Expression.Scope.Builder {
+            return this
+        }
+
+        override fun build(): Expression.Scope = this@RawEntityScope
+    }
 }
 
 /** Turn a [RawEntity] into a [Expression.Scope]. */

--- a/java/arcs/core/data/expression/RawEntityScope.kt
+++ b/java/arcs/core/data/expression/RawEntityScope.kt
@@ -50,8 +50,7 @@ class RawEntityScope(val rawEntity: RawEntity) : Expression.Scope {
         }
     }
 
-    override fun set(param: String, value: Any?) {
-    }
+    override fun set(param: String, value: Any?): Expression.Scope = this
 }
 
 /** Turn a [RawEntity] into a [Expression.Scope]. */

--- a/java/arcs/core/data/expression/Stringifier.kt
+++ b/java/arcs/core/data/expression/Stringifier.kt
@@ -12,7 +12,7 @@ package arcs.core.data.expression
 
 /** Traverses a tree of [Expression] objects, converting each node to manifest format (String). */
 class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScope()) :
-    Expression.Visitor<String> {
+    Expression.Visitor<String, Unit> {
     /*
      * TODO: implement a precedence visitor to optimize parenthesis removal
      * If a parent expression has higher precedence than a child node, you don't need to emit
@@ -20,71 +20,73 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
      * tree (* (+ 1 2) 3) representing 3 * (1 + 2) needs parens because precedence * > precedence +
      */
     private fun <E> maybeParen(expr: Expression<E>) = when (expr) {
-        !is Expression.BinaryExpression<*, *, *> -> expr.accept(this)
-        else -> "(" + expr.accept(this) + ")"
+        !is Expression.BinaryExpression<*, *, *> -> expr.accept(this, Unit)
+        else -> "(" + expr.accept(this, Unit) + ")"
     }
 
-    override fun <E, T> visit(expr: Expression.UnaryExpression<E, T>) =
-        expr.op.token + expr.expr.accept(this)
+    override fun <E, T> visit(expr: Expression.UnaryExpression<E, T>, ctx: Unit) =
+        expr.op.token + expr.expr.accept(this, ctx)
 
-    override fun <L, R, T> visit(expr: Expression.BinaryExpression<L, R, T>) =
+    override fun <L, R, T> visit(expr: Expression.BinaryExpression<L, R, T>, ctx: Unit) =
         maybeParen(expr.left) + " ${expr.op.token} " + maybeParen(expr.right)
 
-    override fun <T> visit(expr: Expression.FieldExpression<T>) =
+    override fun <T> visit(expr: Expression.FieldExpression<T>, ctx: Unit) =
         if (expr.qualifier != null) {
-            "${expr.qualifier.accept(this)}${if (expr.nullSafe) "?." else "."}${expr.field}"
+            "${expr.qualifier.accept(this, ctx)}${if (expr.nullSafe) "?." else "."}${expr.field}"
         } else {
             expr.field
         }
 
-    override fun <T> visit(expr: Expression.QueryParameterExpression<T>) =
+    override fun <T> visit(expr: Expression.QueryParameterExpression<T>, ctx: Unit) =
         "?${expr.paramIdentifier}"
 
-    override fun visit(expr: Expression.NumberLiteralExpression) = expr.value.toString()
+    override fun visit(expr: Expression.NumberLiteralExpression, ctx: Unit) = expr.value.toString()
 
-    override fun visit(expr: Expression.TextLiteralExpression) = "\"${expr.value}\""
+    override fun visit(expr: Expression.TextLiteralExpression, ctx: Unit) = "\"${expr.value}\""
 
-    override fun visit(expr: Expression.BooleanLiteralExpression) = expr.value.toString()
+    override fun visit(expr: Expression.BooleanLiteralExpression, ctx: Unit) = expr.value.toString()
 
-    override fun visit(expr: Expression.NullLiteralExpression) = "null"
+    override fun visit(expr: Expression.NullLiteralExpression, ctx: Unit) = "null"
 
-    override fun visit(expr: Expression.FromExpression): String =
-        (expr.qualifier?.accept(this)?.plus("\n") ?: "") +
-            "from ${expr.iterationVar} in ${expr.source.accept(this)}"
+    override fun visit(expr: Expression.FromExpression, ctx: Unit): String =
+        (expr.qualifier?.accept(this, ctx)?.plus("\n") ?: "") +
+            "from ${expr.iterationVar} in ${expr.source.accept(this, ctx)}"
 
-    override fun visit(expr: Expression.WhereExpression): String =
-        expr.qualifier.accept(this) + "\nwhere " + expr.expr.accept(this)
+    override fun visit(expr: Expression.WhereExpression, ctx: Unit): String =
+        expr.qualifier.accept(this, ctx) + "\nwhere " + expr.expr.accept(this, ctx)
 
-    override fun visit(expr: Expression.LetExpression): String =
-        expr.qualifier.accept(this) + "\n" +
-        "let ${expr.variableName} = (${expr.variableExpr.accept(this)})"
+    override fun visit(expr: Expression.LetExpression, ctx: Unit): String =
+        expr.qualifier.accept(this, ctx) + "\n" +
+        "let ${expr.variableName} = (${expr.variableExpr.accept(this, ctx)})"
 
-    override fun <T> visit(expr: Expression.SelectExpression<T>): String =
-        expr.qualifier.accept(this) + "\nselect " + expr.expr.accept(this) + "\n"
+    override fun <T> visit(expr: Expression.SelectExpression<T>, ctx: Unit): String =
+        expr.qualifier.accept(this, ctx) + "\nselect " + expr.expr.accept(this, ctx) + "\n"
 
-    override fun visit(expr: Expression.NewExpression): String =
+    override fun visit(expr: Expression.NewExpression, ctx: Unit): String =
         "new " + expr.schemaName.joinToString(" ") + expr.fields.joinToString(
             ",\n  ",
             " {\n  ",
             "\n}", transform = { (name, fieldExpr) ->
-                "$name: " + fieldExpr.accept(this)
+                "$name: " + fieldExpr.accept(this, ctx)
             }
         )
 
-    override fun <T> visit(expr: Expression.FunctionExpression<T>): String =
+    override fun <T> visit(expr: Expression.FunctionExpression<T>, ctx: Unit): String =
         expr.function.name + expr.arguments.joinToString(
             ",\n  ",
             "(\n  ",
             "\n)", transform = { argExpr ->
-                argExpr.accept(this)
+                argExpr.accept(this, ctx)
             }
         )
 
-    override fun <T> visit(expr: Expression.OrderByExpression<T>): String =
-        expr.qualifier.accept(this) + "\norder by " + expr.selectors.joinToString(
+    override fun <T> visit(expr: Expression.OrderByExpression<T>, ctx: Unit): String =
+        expr.qualifier.accept(this, ctx) + "\norderby " + expr.selectors.joinToString(
             separator = ", "
-        ) { it.accept(this) } + (if (expr.descending) { " descending\n" } else { "\n" })
+        ) { (sel, desc) ->
+            sel.accept(this, ctx) + (if (desc) { " descending" } else { "" })
+        } + "\n"
 }
 
 /** Given an expression, return a string representation. */
-fun <T> Expression<T>.stringify() = this.accept(ExpressionStringifier())
+fun <T> Expression<T>.stringify() = this.accept(ExpressionStringifier(), Unit)

--- a/java/arcs/core/data/expression/Stringifier.kt
+++ b/java/arcs/core/data/expression/Stringifier.kt
@@ -83,8 +83,8 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
     override fun <T> visit(expr: Expression.OrderByExpression<T>, ctx: Unit): String =
         expr.qualifier.accept(this, ctx) + "\norderby " + expr.selectors.joinToString(
             separator = ", "
-        ) { (sel, desc) ->
-            sel.accept(this, ctx) + (if (desc) { " descending" } else { "" })
+        ) { sel ->
+            sel.expr.accept(this, ctx) + (if (sel.descending) { " descending" } else { "" })
         } + "\n"
 }
 

--- a/java/arcs/core/data/expression/Stringifier.kt
+++ b/java/arcs/core/data/expression/Stringifier.kt
@@ -79,6 +79,11 @@ class ExpressionStringifier(val parameterScope: Expression.Scope = ParameterScop
                 argExpr.accept(this)
             }
         )
+
+    override fun <T> visit(expr: Expression.OrderByExpression<T>): String =
+        expr.qualifier.accept(this) + "\norder by " + expr.selectors.joinToString(
+            separator = ", "
+        ) { it.accept(this) } + (if (expr.descending) { " descending\n" } else { "\n" })
 }
 
 /** Given an expression, return a string representation. */

--- a/javatests/arcs/core/data/expression/ExpressionTest.kt
+++ b/javatests/arcs/core/data/expression/ExpressionTest.kt
@@ -44,7 +44,17 @@ class ExpressionTest {
                 mapOf("val" to 20, "words" to listOf("dolor", "sit", "amet")).asScope()
             ),
             "numbers" to numbers,
-            "emptySeq" to emptySequence<Any>()
+            "emptySeq" to emptySequence<Any>(),
+            "names" to listOf(
+                mapOf("last" to "jefferson", "first" to "john").asScope(),
+                mapOf("last" to "apple", "first" to "tim").asScope(),
+                mapOf("last" to "jefferson", "first" to "xander").asScope()
+            ),
+            "parents" to listOf(
+                mapOf("last" to "jefferson", "first" to "john", "mother" to "christina").asScope(),
+                mapOf("last" to "jefferson", "first" to "xander", "mother" to "betty").asScope(),
+                mapOf("last" to "apple", "first" to "tim", "mother" to "amy").asScope()
+            )
         )
     )
 
@@ -321,6 +331,32 @@ class ExpressionTest {
             mapOf("val" to 10, "count" to 0, "sum" to 10),
             mapOf("val" to 20, "count" to 3, "sum" to 23)
         )
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun evaluate_paxel_orderby() {
+        val output = evalExpression(
+            PaxelParser.parse("""
+                |from name in names
+                |orderby name.last, name.first descending
+                |select name.first
+                |""".trimMargin()),
+            currentScope
+        )
+        assertThat((output as Sequence<String>).toList()).containsExactly("xander", "john", "tim")
+
+        val output2 = evalExpression(
+            PaxelParser.parse("""
+                |from name in names 
+                |from parent in parents
+                |where name.last == parent.last and name.first == parent.first
+                |orderby parent.mother
+                |select name.first
+                |""".trimMargin()),
+            currentScope
+        )
+        assertThat((output2 as Sequence<String>).toList()).containsExactly("tim", "xander", "john")
     }
 
     @Test

--- a/javatests/arcs/core/data/expression/ExpressionTest.kt
+++ b/javatests/arcs/core/data/expression/ExpressionTest.kt
@@ -334,8 +334,14 @@ class ExpressionTest {
                     mapOf("last" to "jefferson", "first" to "xander").asScope()
                 ),
                 "parents" to listOf(
-                    mapOf("last" to "jefferson", "first" to "john", "mother" to "christina").asScope(),
-                    mapOf("last" to "jefferson", "first" to "xander", "mother" to "betty").asScope(),
+                    mapOf("last" to "jefferson",
+                        "first" to "john",
+                        "mother" to "christina"
+                    ).asScope(),
+                    mapOf("last" to "jefferson",
+                        "first" to "xander",
+                        "mother" to "betty"
+                    ).asScope(),
                     mapOf("last" to "apple", "first" to "tim", "mother" to "amy").asScope()
                 )
             )

--- a/javatests/arcs/core/data/expression/ParserTest.kt
+++ b/javatests/arcs/core/data/expression/ParserTest.kt
@@ -217,6 +217,32 @@ class ParserTest {
             |select new Foo {
             |  x: first(from x in p select x).x 
             |}""".trimMargin())
+
+        PaxelParser.parse("from p in q where p < 1 orderby p select p")
+
+        PaxelParser.parse("""
+            |from p in q
+            |where p < 1
+            |orderby p
+            |select new Foo {
+            |  x: first(from x in p select x).x
+            |}""".trimMargin())
+
+        PaxelParser.parse("""
+            |from p in q
+            |where p < 1
+            |orderby p.a descending
+            |select new Foo {
+            |  x: first(from x in p select x).x
+            |}""".trimMargin())
+
+        PaxelParser.parse("""
+            |from p in q
+            |where p < 1
+            |orderby p.a, p.b descending
+            |select new Foo {
+            |  x: first(from x in p select x).x
+            |}""".trimMargin())
     }
 
     @Test


### PR DESCRIPTION
* Immutable scopes! 
** Scope.set() now returns a new scope instead of modifying the existing one
** Scope.builder() for setting multiple
** New scopes are chained off their parents, and lookup variables by traversing up the parent heirarchy
* Evaluating QualifiedExpressions produces Sequence<Scope>
* Visit/Accept passes now pass along a context
* Evaluator passes 'current scope' as context
* OrderBy does the following
** Map selectors to a lambda of Scope -> Comparable by evaluating the Paxel selector with respect to the scope
** Constructs a new (restarted) sequence over the sorted scopes



