### PR TITLE
Compute the max read schema based on all policies.

### DIFF
--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -190,8 +190,8 @@ export class IngressValidation {
 
   private static mergeField(field: FieldType, newField: FieldType) {
     assert(field.kind === newField.kind);
-    let fieldEntityType = field.getEntityType();
-    let newFieldEntityType = newField.getEntityType();
+    const fieldEntityType = field.getEntityType();
+    const newFieldEntityType = newField.getEntityType();
     if (fieldEntityType == null || newFieldEntityType == null) return;
     this.mergeFields(fieldEntityType.entitySchema.fields,
                      newFieldEntityType.entitySchema.fields);

--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {Policy, PolicyField} from './policy.js';
 import {Capability, Capabilities} from '../capabilities.js';
-import {Type, Schema, FieldType} from '../../types/lib-types.js';
+import {EntityType, Type, Schema, FieldType} from '../../types/lib-types.js';
 import {Recipe, Handle, HandleConnection} from '../recipe/lib-recipe.js';
 
 // Helper class for validating ingress fields and capabilities.
@@ -161,6 +161,40 @@ export class IngressValidation {
   private policiesContainType(type: Type): boolean {
     return this.policies.some(policy => policy.targets.some(
       target => target.schemaName === type.getEntitySchema().name));
+  }
+
+  // Get the max readable type for `typeName` according to the given `policies`.
+  static getMaxReadType(typeName: string, policies: Policy[]): Type|null {
+    const fields = {};
+    let type = null;
+    for (const policy of policies) {
+      for (const target of policy.targets) {
+        if (typeName === target.schemaName) {
+          type = target.type;
+          IngressValidation.mergeFields(fields, target.getRestrictedFields());
+        }
+      }
+    }
+    return type ? EntityType.make([typeName], fields, type.getEntitySchema()) : null;
+  }
+
+  private static mergeFields(fields: {}, newFields: {}) {
+    for (const newFieldName of Object.keys(newFields)) {
+      if (fields[newFieldName]) {
+        IngressValidation.mergeField(fields[newFieldName], newFields[newFieldName]);
+      } else {
+        fields[newFieldName] = newFields[newFieldName];
+      }
+    }
+  }
+
+  private static mergeField(field: FieldType, newField: FieldType) {
+    assert(field.kind === newField.kind);
+    let fieldEntityType = field.getEntityType();
+    let newFieldEntityType = newField.getEntityType();
+    if (fieldEntityType == null || newFieldEntityType == null) return;
+    this.mergeFields(fieldEntityType.entitySchema.fields,
+                     newFieldEntityType.entitySchema.fields);
   }
 }
 

--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -167,11 +167,11 @@ export class IngressValidation {
   // Get the max readable schema for `typeName` according to the given `policies`.
   static getMaxReadSchema(typeName: string, policies: Policy[]): Schema|null {
     const fields: Dictionary<FieldType> = {};
-    var schema = null;
+    let schema = null;
     for (const policy of policies) {
       for (const target of policy.targets) {
         if (typeName === target.schemaName) {
-          let targetSchema = target.getMaxReadSchema();
+          const targetSchema = target.getMaxReadSchema();
           schema = (schema === null)
             ? targetSchema
             : Schema.union(schema, targetSchema);

--- a/src/runtime/policy/policy.ts
+++ b/src/runtime/policy/policy.ts
@@ -320,7 +320,7 @@ export class PolicyField {
       }
       case 'type-name':
       case 'schema-inline': {
-        let entityType = field.getEntityType();
+        const entityType = field.getEntityType();
         if (entityType == null) return this;
         return FieldType.create({
           kind: field.kind,
@@ -343,7 +343,7 @@ export class PolicyField {
   private restrictedEntityType(entityType): EntityType {
     assert(entityType != null);
     const restrictedFields = {};
-    let schema = entityType.entitySchema;
+    const schema = entityType.entitySchema;
     for (const subfield of this.subfields) {
       restrictedFields[subfield.name] = schema.fields[subfield.name];
     }

--- a/src/runtime/policy/policy.ts
+++ b/src/runtime/policy/policy.ts
@@ -12,7 +12,7 @@ import {AnnotationRef} from '../arcs-types/annotation.js';
 import {assert} from '../../platform/assert-web.js';
 import {IndentingStringBuilder} from '../../utils/lib-utils.js';
 import {Ttl, Capabilities, Capability, Persistence, Encryption} from '../capabilities.js';
-import {EntityType, InterfaceType, Type, Schema} from '../../types/lib-types.js';
+import {EntityType, FieldType, InterfaceType, Type, Schema} from '../../types/lib-types.js';
 import {FieldPathType, resolveFieldPathType} from '../field-path.js';
 
 export enum PolicyRetentionMedium {
@@ -197,6 +197,17 @@ export class PolicyTarget {
       return Capabilities.create(ranges);
     });
   }
+
+  getRestrictedFields() {
+    return this.fields.map(f => f.getRestrictedFields(this.type))
+          .reduce((fields, field) => ({...fields, [field[0]]: field[1]}), {});
+  }
+
+  // Return the max read type according to this policy.
+  getMaxReadType(): EntityType {
+    return EntityType.make(this.type.getEntitySchema().names,
+        this.getRestrictedFields(), this.type.getEntitySchema());
+  }
 }
 
 export class PolicyField {
@@ -278,6 +289,65 @@ export class PolicyField {
       usage: usageType as PolicyAllowedUsageType,
       label: label === 'raw' ? '' : label,
     };
+  }
+
+  getRestrictedFields(parentType: Type) {
+    const field = parentType.getEntitySchema().fields[this.name];
+    return [this.name, this.restrictField(field)];
+  }
+
+  private restrictField(field) {
+    switch (field.kind) {
+      case 'kotlin-primitive':
+      case 'schema-primitive': {
+        assert(this.subfields.length === 0);
+        return field;
+      }
+      case 'schema-collection':
+      case 'schema-ordered-list':
+      case 'schema-nested': {
+        return FieldType.create(
+          {kind: field.kind, schema: this.restrictField(field.schema)}
+        );
+      }
+      case 'schema-reference': {
+        return FieldType.create({
+          kind: 'schema-reference', schema: {
+            ...field.schema,
+            model: this.restrictedEntityType(field.getEntityType())
+          }
+        });
+      }
+      case 'type-name':
+      case 'schema-inline': {
+        let entityType = field.getEntityType();
+        if (entityType == null) return this;
+        return FieldType.create({
+          kind: field.kind,
+          model: this.restrictedEntityType(entityType)
+        });
+      }
+      // TODO(bgogul): `field-path` does not support these types yet.
+      // case 'schema-union':
+      // case 'schema-tuple':
+      //   return FieldType.create({
+      //     ...field,
+      //     types: field.getFieldTypes().map(t => this.restrictField(t))
+      //   });
+      default: {
+        assert(`Unsupported field kind: ${field.kind}`);
+      }
+    }
+  }
+
+  private restrictedEntityType(entityType): EntityType {
+    assert(entityType != null);
+    const restrictedFields = {};
+    let schema = entityType.entitySchema;
+    for (const subfield of this.subfields) {
+      restrictedFields[subfield.name] = schema.fields[subfield.name];
+    }
+    return EntityType.make(schema.names, restrictedFields, schema);
   }
 }
 

--- a/src/runtime/policy/policy.ts
+++ b/src/runtime/policy/policy.ts
@@ -204,10 +204,9 @@ export class PolicyTarget {
       .reduce((fields, {name, field}) => ({...fields, [name]: field}), {});
   }
 
-  // Return the max read type according to this policy.
-  getMaxReadType(): EntityType {
-    return EntityType.make(this.type.getEntitySchema().names,
-        this.toSchemaFields(), this.type.getEntitySchema());
+  // Return the max readable schema according to this policy.
+  getMaxReadSchema(): Schema {
+    return new Schema(this.type.getEntitySchema().names, this.toSchemaFields());
   }
 }
 

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -361,7 +361,7 @@ policy MyPolicy {
         `Unexpected capabilities: ${capabilities[1].toDebugString()}`);
   });
 
-  it.only('restricts types according to policy', async () => {
+  it('restricts types according to policy', async () => {
     const manifest = await Manifest.parse(`
 schema Address
   number: Number
@@ -400,7 +400,7 @@ schema Person
     assert.deepEqual(schema, expectedSchemas['Person']);
   });
 
-  it.only('restricts inline types according to policy', async () => {
+  it('restricts inline types according to policy', async () => {
     const manifest = await Manifest.parse(`
 schema Address
   number: Number
@@ -443,7 +443,7 @@ schema Person
     assert.deepEqual(schema, expectedSchemas['Person']);
   });
 
-  it.only('restricts types according to multiple policies', async () => {
+  it('restricts types according to multiple policies', async () => {
     const [policy0, policy1, policy2] = (await Manifest.parse(`
 schema Address
   number: Number

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -387,7 +387,7 @@ policy MyPolicy {
         }
       }`);
     const policy = manifest.policies[0];
-    const schema = policy.targets[0].getMaxReadType().getEntitySchema();
+    const schema = policy.targets[0].getMaxReadSchema();
     const expectedSchemas = (await Manifest.parse(`
       schema Address
         number: Number
@@ -433,7 +433,7 @@ policy MyPolicy {
         }
       }`);
     const policy = manifest.policies[0];
-    const schema = policy.targets[0].getMaxReadType().getEntitySchema();
+    const schema = policy.targets[0].getMaxReadSchema();
     const expectedSchemas = (await Manifest.parse(`
       schema Address
         number: Number
@@ -491,8 +491,7 @@ policy MyPolicy {
           otherAddresses {country}
         }
       }`)).policies;
-    const maxReadType = IngressValidation.getMaxReadType('Person', [policy0, policy1, policy2]);
-    const maxReadSchema = maxReadType.getEntitySchema();
+    const maxReadSchema = IngressValidation.getMaxReadSchema('Person', [policy0, policy1, policy2]);
     const expectedSchemas = (await Manifest.parse(`
       schema Address
         number: Number

--- a/src/types/lib-types.ts
+++ b/src/types/lib-types.ts
@@ -14,7 +14,7 @@ export {Type, TypeLiteral, CountType, EntityType, SingletonType, CollectionType,
         TypeVarReference, InterfaceInfoLiteral, MatchResult} from './internal/type.js';
 
 export {Schema} from './internal/schema.js';
-export {FieldType, PrimitiveField, OrderedListField} from './internal/schema-field.js';
+export {FieldType, PrimitiveField, OrderedListField, ReferenceField, InlineField} from './internal/schema-field.js';
 
 export {Refinement, RefinementExpressionLiteral, RefinementExpressionVisitor, BinaryExpression,
         UnaryExpression, FieldNamePrimitive, QueryArgumentPrimitive, BuiltIn, NumberPrimitive,


### PR DESCRIPTION
 This PR computes the max read schema based on the given list of policies. This is one of the steps required to automatically create phantom readers for ingress restricting. (Some of the code is adapted from #5706.)

b/168040363