### PR TITLE
Fix a race condition during particle shutdown

### DIFF
--- a/java/arcs/core/entity/BaseHandle.kt
+++ b/java/arcs/core/entity/BaseHandle.kt
@@ -56,9 +56,13 @@ abstract class BaseHandle<T : Storable>(config: BaseHandleConfig) : Handle {
         return block()
     }
 
+    override fun unregisterForStorageEvents() {
+        storageProxy.removeCallbacksForName(callbackIdentifier)
+    }
+
     override fun close() {
         closed = true
-        storageProxy.removeCallbacksForName(callbackIdentifier)
+        unregisterForStorageEvents()
     }
 
     /**

--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -51,6 +51,9 @@ interface Handle {
     /** Internal method used to connect [StorageProxy] events to the [ParticleContext]. */
     fun registerForStorageEvents(notify: (StorageEvent) -> Unit)
 
+    /** Remove any storage callbacks, but still allow write methods. */
+    fun unregisterForStorageEvents()
+
     /** Internal method used to trigger a sync request on this handle's [StorageProxy]. */
     fun maybeInitiateSync()
 

--- a/java/arcs/core/host/api/HandleHolder.kt
+++ b/java/arcs/core/host/api/HandleHolder.kt
@@ -39,6 +39,9 @@ interface HandleHolder {
     /** Sets the given [Handle]. */
     fun setHandle(handleName: String, handle: Handle)
 
+    /** Remove all storage callbacks from the handles. Handle writing methods can still be used. */
+    fun detach()
+
     /** Erase and release all handle references from the [HandleHolder]. */
     fun reset()
 

--- a/javatests/arcs/core/host/ParticleContextTest.kt
+++ b/javatests/arcs/core/host/ParticleContextTest.kt
@@ -95,6 +95,7 @@ class ParticleContextTest {
             verify(notifyReady).invoke(particle)
 
             verify(mark).invoke("stopParticle")
+            verify(handles).detach()
             verify(particle).onShutdown()
             verify(particle).handles
             verify(handles).reset()
@@ -144,6 +145,8 @@ class ParticleContextTest {
             verify(notifyReady).invoke(particle)
 
             verify(mark).invoke("stopParticle")
+            verify(particle).handles
+            verify(handles).detach()
             verify(particle).onShutdown()
             verify(particle).handles
             verify(handles).reset()
@@ -278,6 +281,8 @@ class ParticleContextTest {
             verify(particle).onFirstStart()
             verify(particle).onStart()
             verify(particle).onReady()
+            verify(particle).handles
+            verify(handles).detach()
             verify(particle).onShutdown()
             verify(particle).handles
             verify(handles).reset()


### PR DESCRIPTION
During particle shutdown, there's a window in which we'd like to stop
receiving storage events for the handle, but we'd like to allow handles to
continue to use the handles to write (while executing the on Shutdown
method).

To allow this, handles now have a "detach" method, and handle holders
will:
* detach handles
* call onShutdown
* close handles

These changes fixes a flakey allocator test which was sometimes receiving
storage events after removing all of the handles for the particle,
leading to a crash.