### PR TITLE
remove deprecated method ReinstantiateParticle api-channel

### DIFF
--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -531,7 +531,6 @@ export abstract class PECOuterPort extends APIPort {
   DefineHandle(@RedundantInitializer store: AbstractStore, @ByLiteral(Type) type: Type, @Direct name: string, @Direct storageKey: string, @ByLiteral(Ttl) ttl: Ttl) {}
   DefineHandleFactory(@RedundantInitializer store: AbstractStore, @ByLiteral(Type) type: Type, @Direct name: string, @Direct storageKey: string, @ByLiteral(Ttl) ttl: Ttl) {}
   InstantiateParticle(@Initializer particle: libRecipe.Particle, @Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, AbstractStore>, @ObjectMap(MappingType.Direct, MappingType.Mapped) storeMuxers: Map<string, AbstractStore>, @Direct reinstantiate: boolean) {}
-  ReinstantiateParticle(@Identifier @Direct id: string, @ByLiteral(ParticleSpec) spec: ParticleSpec, @ObjectMap(MappingType.Direct, MappingType.Mapped) stores: Map<string, AbstractStore>) {}
   ReloadParticles(@OverridingInitializer particles: libRecipe.Particle[], @List(MappingType.Direct) ids: string[]) {}
 
   UIEvent(@Mapped particle: libRecipe.Particle, @Direct slotName: string, @Direct event: {}) {}
@@ -589,7 +588,6 @@ export abstract class PECInnerPort extends APIPort {
   abstract onDefineHandle(identifier: string, type: Type, name: string, storageKey: string, ttl: Ttl);
   abstract onDefineHandleFactory(identifier: string, type: Type, name: string, storageKey: string, ttl: Ttl);
   abstract onInstantiateParticle(id: string, spec: ParticleSpec, proxies: Map<string, StorageProxy|StorageProxyNG<CRDTTypeRecord>>, proxyMuxers: Map<string, StorageProxyMuxer<CRDTMuxEntity>>, reinstantiate: boolean);
-  abstract onReinstantiateParticle(id: string, spec: ParticleSpec, proxies: Map<string, StorageProxy>);
   abstract onReloadParticles(ids: string[]);
 
   abstract onUIEvent(particle: Particle, slotName: string, event: {});

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -303,11 +303,6 @@ export class Arc implements ArcInterface {
     return [...this.loadedParticleInfo.values()].map(({spec}) => spec);
   }
 
-  async reinstantiateParticle(recipeParticle: Particle) {
-    const info = await this._getParticleInstantiationInfo(recipeParticle);
-    this.peh.reinstantiate(recipeParticle, info.stores);
-  }
-
   async _instantiateParticle(recipeParticle: Particle, reinstantiate: boolean) {
     if (!recipeParticle.id) {
       recipeParticle.id = this.generateID('particle');

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -124,10 +124,6 @@ export class ParticleExecutionContext implements StorageCommunicationEndpointPro
         return pec.instantiateParticle(id, spec, proxies, proxyMuxers, reinstantiate);
       }
 
-      async onReinstantiateParticle(id: string, spec: ParticleSpec, proxies: ReadonlyMap<string, StorageProxy<CRDTTypeRecord>>) {
-        assert(false, `Not implemented`);
-      }
-
       async onReloadParticles(ids: string[]) {
         return pec.reloadParticles(ids);
       }

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -118,17 +118,6 @@ export class ParticleExecutionHost {
     apiPort.InstantiateParticle(particle, particle.id.toString(), particle.spec, stores, storeMuxers, reinstantiate);
   }
 
-  reinstantiate(particle: Particle, stores: Map<string, AbstractStore>): void {
-    assert(this.particles.find(p => p === particle),
-           `Cannot reinstantiate nonexistent particle ${particle.name}`);
-    this.apiPorts.forEach(apiPort => { apiPort.clear(); });
-    const apiPort = this.getPort(particle);
-    stores.forEach((store, name) => {
-      apiPort.DefineHandle(store, store.type.resolvedType(), name, store.storageKey.toString(), particle.getConnectionByName(name).handle.getTtl());
-    });
-    apiPort.ReinstantiateParticle(particle.id.toString(), particle.spec, stores);
-  }
-
   reload(particles: Particle[]) {
     // Create a mapping from port to given list of particles
     const portMap = new Map<PECOuterPort, Particle[]>();

--- a/src/runtime/tests/api-channel-test.ts
+++ b/src/runtime/tests/api-channel-test.ts
@@ -110,7 +110,6 @@ describe('API channel', function() {
       onGetDirectStoreMuxerCallback() {}
       onInnerArcRender() {}
       onInstantiateParticle() {}
-      onReinstantiateParticle() {}
       onReloadParticles() {}
       onMapHandleCallback() {}
       onSimpleCallback() {}


### PR DESCRIPTION
it was used by the DevEx code that's been deprecated and removed earlier.