### PR TITLE
PaxelParser supports field access of nested expressions

### DIFF
--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -155,7 +155,6 @@ object PaxelParser {
         }
 
     private val primaryExpression: Parser<Expression<Any?>> =
-        nestedExpression /
         discreteValue /
         numberValue /
         unaryOperation /
@@ -257,7 +256,7 @@ object PaxelParser {
         }
 
     private val paxelExpression =
-        (newExpression / expressionWithQualifier / refinementExpression / primaryExpression) as Parser<Expression<Any>>
+        (newExpression / expressionWithQualifier / refinementExpression) as Parser<Expression<Any>>
 
     private val paxelProgram = paxelExpression + eof
 

--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -130,7 +130,9 @@ object PaxelParser {
             )
         }
 
-    private val scopeQualifier = functionCall / ident.map { FieldExpression<Any>(null, it, false) } / parser(::nestedExpression)
+    private val scopeQualifier =
+        functionCall / ident.map { FieldExpression<Any>(null, it, false) } /
+            parser(::nestedExpression)
 
     @OptIn(kotlin.ExperimentalStdlibApi::class)
     private val scopeLookup = (scopeQualifier + many((token("?.") / token(".")) + ident)).map {

--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -130,7 +130,7 @@ object PaxelParser {
             )
         }
 
-    private val scopeQualifier = functionCall / ident.map { FieldExpression<Any>(null, it, false) }
+    private val scopeQualifier = functionCall / ident.map { FieldExpression<Any>(null, it, false) } / parser(::nestedExpression)
 
     @OptIn(kotlin.ExperimentalStdlibApi::class)
     private val scopeLookup = (scopeQualifier + many((token("?.") / token(".")) + ident)).map {
@@ -257,7 +257,7 @@ object PaxelParser {
         }
 
     private val paxelExpression =
-        (newExpression / expressionWithQualifier / refinementExpression) as Parser<Expression<Any>>
+        (newExpression / expressionWithQualifier / refinementExpression / primaryExpression) as Parser<Expression<Any>>
 
     private val paxelProgram = paxelExpression + eof
 

--- a/javatests/arcs/core/data/expression/ParserTest.kt
+++ b/javatests/arcs/core/data/expression/ParserTest.kt
@@ -224,6 +224,11 @@ class ParserTest {
         PaxelParser.parse("1 + 2 * 3 + 3 * 4 == 3 * 2 * 3 + 1 and 2 == 2")
     }
 
+    @Test
+    fun parseFieldAccessOfObject() {
+        PaxelParser.parse("(new Object {x: foo}).x")
+    }
+
     fun parseNum(num: String): Expression.NumberLiteralExpression {
         val number: Expression<Number> = PaxelParser.parse(num) as Expression<Number>
         assertThat(number).isInstanceOf(Expression.NumberLiteralExpression::class.java)

--- a/javatests/arcs/core/data/expression/ParserTest.kt
+++ b/javatests/arcs/core/data/expression/ParserTest.kt
@@ -225,8 +225,10 @@ class ParserTest {
     }
 
     @Test
-    fun parseFieldAccessOfObject() {
+    fun parseFieldAccessOfNestedExpression() {
         PaxelParser.parse("(new Object {x: foo}).x")
+        PaxelParser.parse("(from p in q select p).p")
+        PaxelParser.parse("from p in q select new Foo { x: (from a in b select a).a }")
     }
 
     fun parseNum(num: String): Expression.NumberLiteralExpression {


### PR DESCRIPTION
This change to the parser supports use cases like: 
```
(new Foo {x: a, y: b}).x
```