### PR TITLE
Make sure the correct error gets reported during manifest parsing.

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -532,20 +532,21 @@ ${e.message}
       // the list as long as we see progress.
       // TODO(b/156427820): Improve this with 2 pass schema resolution and support cycles.
       const processItems = async (kind: string, f: Function) => {
-        let firstError: boolean;
+        let firstError: Error | null = null;
         let itemsToProcess = [...items.filter(i => i.kind === kind)];
         let thisRound = [];
 
         do {
           thisRound = itemsToProcess;
           itemsToProcess = [];
-          firstError = null;
           for (const item of thisRound) {
             try {
               Manifest._augmentAstWithTypes(manifest, item);
               await f(item);
             } catch (err) {
-              if (!firstError) firstError = err;
+              if (firstError == null) {
+                firstError = err;
+              }
               itemsToProcess.push(item);
               continue;
             }

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -5095,6 +5095,16 @@ recipe
           () => manifest.validateUniqueDefinitions(),
           `Duplicate definition of store named 'Dupe'.`);
     });
+    it('reports the correct error when multiple items exist', async () => {
+      assertThrowsAsync(async () => await Manifest.parse(`
+        particle P
+          a: reads B {}
+          a: reads C {}
+
+        particle Q
+          a: reads B {}
+      `), 'Particle Spec P already has a handle connection named "a"');
+    });
   });
 });
 describe('expressions', () => {


### PR DESCRIPTION
firstError was being cleared each round while incrementally processing
items in manifest parsing. This meant that the most recent error was
reported rather than the first error.

Also cleaned up the types a little.