### PR TITLE
Removed StoreMuxer

### DIFF
--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -21,7 +21,7 @@ import {PropagatedException, reportGlobalException} from './arc-exceptions.js';
 import {Consumer, Literal, Literalizable, floatingPromiseToAudit} from '../utils/lib-utils.js';
 import {MessagePort} from './message-channel.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
-import {ProxyCallback, ProxyMessage, Store, StoreMuxer} from './storage/store.js';
+import {ProxyCallback, ProxyMessage, Store} from './storage/store.js';
 import {NoTraceWithReason, SystemTrace} from '../tracelib/systrace.js';
 import {workerPool} from './worker-pool.js';
 import {Ttl} from './capabilities.js';
@@ -538,14 +538,14 @@ export abstract class PECOuterPort extends APIPort {
   AwaitIdle(@Direct version: number) {}
 
   abstract onRegister(handle: Store<CRDTTypeRecord>, messagesCallback: number, idCallback: number);
-  abstract onDirectStoreMuxerRegister(handle: StoreMuxer<CRDTMuxEntity>, messagesCallback: number, idCallback: number);
+  abstract onDirectStoreMuxerRegister(handle: Store<CRDTMuxEntity>, messagesCallback: number, idCallback: number);
   abstract onProxyMessage(handle: Store<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
-  abstract onStorageProxyMuxerMessage(handle: StoreMuxer<CRDTMuxEntity>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
+  abstract onStorageProxyMuxerMessage(handle: Store<CRDTMuxEntity>, message: ProxyMessage<CRDTTypeRecord>, callback: number);
 
   abstract onIdle(version: number, relevance: Map<libRecipe.Particle, number[]>);
 
   abstract onGetDirectStoreMuxer(callback: number, storageKey: string, type: Type);
-  GetDirectStoreMuxerCallback(@Initializer store: StoreMuxer<CRDTMuxEntity>, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
+  GetDirectStoreMuxerCallback(@Initializer store: Store<CRDTMuxEntity>, @RemoteMapped callback: number, @ByLiteral(Type) type: Type, @Direct name: string, @Identifier @Direct id: string, @Direct storageKey: string) {}
 
   abstract onConstructInnerArc(callback: number, particle: libRecipe.Particle);
   ConstructArcCallback(@RemoteMapped callback: number, @LocalMapped arc: {}) {}

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -22,7 +22,7 @@ import {Type, EntityType, ReferenceType, InterfaceType, SingletonType, MuxType} 
 import {Services} from './services.js';
 import {Arc} from './arc.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
-import {ProxyMessage, Store, StoreMuxer} from './storage/store.js';
+import {ProxyMessage, Store} from './storage/store.js';
 import {VolatileStorageKey} from './storage/drivers/volatile.js';
 import {NoTrace, SystemTrace} from '../tracelib/systrace.js';
 import {Client, getClientClass} from '../tracelib/systrace-clients.js';
@@ -173,7 +173,7 @@ class PECOuterPortImpl extends PECOuterPort {
         this.SimpleCallback.bind(this, idCallback));
   }
 
-  async onDirectStoreMuxerRegister(store: StoreMuxer<CRDTMuxEntity>, messagesCallback: number, idCallback: number) {
+  async onDirectStoreMuxerRegister(store: Store<CRDTMuxEntity>, messagesCallback: number, idCallback: number) {
     this.arc.storageService.onDirectStoreMuxerRegister(store,
       this.SimpleCallback.bind(this, messagesCallback),
       this.SimpleCallback.bind(this, idCallback));
@@ -183,7 +183,7 @@ class PECOuterPortImpl extends PECOuterPort {
     this.arc.storageService.onProxyMessage(store, message);
   }
 
-  async onStorageProxyMuxerMessage(store: StoreMuxer<CRDTMuxEntity>, message: ProxyMessage<CRDTMuxEntity>) {
+  async onStorageProxyMuxerMessage(store: Store<CRDTMuxEntity>, message: ProxyMessage<CRDTMuxEntity>) {
     this.arc.storageService.onStorageProxyMuxerMessage(store, message);
   }
 
@@ -197,8 +197,8 @@ class PECOuterPortImpl extends PECOuterPort {
       throw new Error(`Don't know how to invent new storage keys for new storage stack when we only have type information`);
     }
     const key = StorageKeyParser.parse(storageKey);
-    const storeMuxerBase = new StoreMuxer(type, {id: storageKey, exists: Exists.MayExist, storageKey: key});
-    this.GetDirectStoreMuxerCallback(storeMuxerBase, callback, type, type.toString(), storageKey, storageKey);
+    const storeBase = new Store(type, {id: storageKey, exists: Exists.MayExist, storageKey: key}) as Store<CRDTMuxEntity>;
+    this.GetDirectStoreMuxerCallback(storeBase, callback, type, type.toString(), storageKey, storageKey);
   }
 
   onConstructInnerArc(callback: number, particle: Particle) {

--- a/src/runtime/storage/storage-service.ts
+++ b/src/runtime/storage/storage-service.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Store, StoreMuxer} from './store.js';
+import {Store} from './store.js';
 import {CRDTTypeRecord} from '../../crdt/internal/crdt.js';
 import {CRDTMuxEntity} from './storage.js';
 import {ProxyMessage} from './store-interface.js';
@@ -21,12 +21,12 @@ export interface StorageService {
     messagesCallback: StorageServiceCallback,
     idCallback: StorageServiceCallback);
 
-  onDirectStoreMuxerRegister(store: StoreMuxer<CRDTMuxEntity>,
+  onDirectStoreMuxerRegister(store: Store<CRDTMuxEntity>,
     messagesCallback: StorageServiceCallback,
     idCallback: StorageServiceCallback);
 
   onProxyMessage(store: Store<CRDTTypeRecord>, message: ProxyMessage<CRDTTypeRecord>);
-  onStorageProxyMuxerMessage(store: StoreMuxer<CRDTMuxEntity>, message: ProxyMessage<CRDTMuxEntity>);
+  onStorageProxyMuxerMessage(store: Store<CRDTMuxEntity>, message: ProxyMessage<CRDTMuxEntity>);
 }
 
 export class StorageServiceImpl implements StorageService {
@@ -41,7 +41,7 @@ export class StorageServiceImpl implements StorageService {
     idCallback(id);
   }
 
-  async onDirectStoreMuxerRegister(store: StoreMuxer<CRDTMuxEntity>,
+  async onDirectStoreMuxerRegister(store: Store<CRDTMuxEntity>,
     messagesCallback: StorageServiceCallback,
     idCallback: StorageServiceCallback) {
       const id = (await store.activate()).on(async data => {
@@ -56,7 +56,7 @@ export class StorageServiceImpl implements StorageService {
     noAwait((await store.activate()).onProxyMessage(message));
   }
 
-  async onStorageProxyMuxerMessage(store: StoreMuxer<CRDTMuxEntity>, message: ProxyMessage<CRDTMuxEntity>) {
+  async onStorageProxyMuxerMessage(store: Store<CRDTMuxEntity>, message: ProxyMessage<CRDTMuxEntity>) {
     noAwait((await store.activate()).onProxyMessage(message));
   }
 }

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -14,7 +14,7 @@ import {CRDTTypeRecord, CRDTSingletonTypeRecord, CRDTCollectionTypeRecord, CRDTE
 import {Ttl} from '../capabilities.js';
 import {SingletonHandle, CollectionHandle, Handle} from './handle.js';
 import {Particle} from '../particle.js';
-import {ActiveStore, Store, StoreMuxer} from './store.js';
+import {ActiveStore, Store} from './store.js';
 import {Entity, SerializedEntity} from '../entity.js';
 import {Id, IdGenerator} from '../id.js';
 import {ParticleSpec, StorableSerializedParticleSpec} from '../arcs-types/particle-spec.js';
@@ -72,7 +72,7 @@ export type SingletonInterfaceHandle = SingletonHandle<ParticleSpec>;
 
 export type MuxEntityType = MuxType<EntityType>;
 export type CRDTMuxEntity = CRDTEntityTypeRecord<Identified, Identified>;
-export type MuxEntityStore = StoreMuxer<CRDTMuxEntity>;
+export type MuxEntityStore = Store<CRDTMuxEntity>;
 export type ActiveMuxEntityStore = ActiveStore<CRDTMuxEntity>;
 export type MuxEntityHandle = EntityHandleFactory<CRDTMuxEntity>;
 
@@ -138,9 +138,6 @@ export type ToHandle<T extends CRDTTypeRecord>
    Handle<T>|EntityHandleFactory<CRDTMuxEntity>)))));
 
 export function newStore<T extends Type>(type: T, opts: StoreInfo & {storageKey: StorageKey, exists: Exists}): ToStore<T> {
-  if (type.isMuxType()) {
-    return new StoreMuxer(type, opts) as ToStore<T>;
-  }
   return new Store(type, opts) as ToStore<T>;
 }
 
@@ -156,9 +153,6 @@ export async function newHandle<T extends Type>(type: T, storageKey: StorageKey,
   options['storageKey'] = storageKey;
   options['exists'] = Exists.MayExist;
   const store = newStore(type, options as StoreInfo & {storageKey: StorageKey, exists: Exists});
-  if (isMuxEntityStore(store)) {
-    return await handleForMuxer(store, arc, options) as ToHandle<TypeToCRDTTypeRecord<T>>;
-  }
   return handleForStore(store as unknown as Store<TypeToCRDTTypeRecord<T>>, arc, options);
 }
 
@@ -192,9 +186,5 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
 }
 
 export async function handleForStore<T extends CRDTTypeRecord>(store: Store<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<T>> {
-  return handleForActiveStore(await store.activate(), arc, options) as ToHandle<T>;
-}
-
-export async function handleForMuxer<T extends CRDTMuxEntity>(store: StoreMuxer<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<T>> {
   return handleForActiveStore(await store.activate(), arc, options) as ToHandle<T>;
 }

--- a/src/runtime/storage/store.ts
+++ b/src/runtime/storage/store.ts
@@ -14,7 +14,7 @@ import {StorageKey} from './storage-key.js';
 import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint, StorageCommunicationEndpointProvider, StoreConstructor} from './store-interface.js';
 import {AbstractStore, StoreInfo} from './abstract-store.js';
 import {ReferenceModeStorageKey} from './reference-mode-storage-key.js';
-import {CRDTTypeRecordToType, CRDTMuxEntity} from './storage.js';
+import {CRDTTypeRecordToType} from './storage.js';
 
 export {
   ActiveStore,
@@ -59,9 +59,14 @@ export class Store<T extends CRDTTypeRecord> extends AbstractStore implements St
     this.type = type;
     this.storageKey = opts.storageKey;
     this.exists = opts.exists;
-    this.mode = opts.storageKey instanceof ReferenceModeStorageKey ? StorageMode.ReferenceMode : StorageMode.Direct;
     this.parsedVersionToken = opts.versionToken;
     this.model = opts.model as T['data'];
+
+    if (type.isMux) {
+      this.mode = StorageMode.Backing;
+    } else {
+      this.mode = opts.storageKey instanceof ReferenceModeStorageKey ? StorageMode.ReferenceMode : StorageMode.Direct;
+    }
   }
 
   get versionToken() {
@@ -93,78 +98,6 @@ export class Store<T extends CRDTTypeRecord> extends AbstractStore implements St
     }) as ActiveStore<T>;
     this.exists = Exists.ShouldExist;
     return this.activeStore;
-  }
-
-  // TODO(shans): DELETEME once we've switched to this storage stack
-  get referenceMode() {
-    return this.mode === StorageMode.ReferenceMode;
-  }
-}
-
-export class StoreMuxer<T extends CRDTMuxEntity> extends AbstractStore implements StoreInterface<T> {
-  protected unifiedStoreType: 'Store' = 'Store';
-
-  readonly storageKey: StorageKey;
-  exists: Exists;
-  readonly mode: StorageMode;
-  type: CRDTTypeRecordToType<T>;
-
-  // The last known version of this store that was stored in the serialized
-  // representation.
-  parsedVersionToken: string = null;
-  modelConstructor: new () => CRDTModel<T>;
-
-  // If there's a parsed model then it's stored here and provided to activate() when
-  // reconstituting an ActiveStore.
-  model: T['data'] | null;
-
-  private activeStore: ActiveStore<T> | null;
-
-  // This map creates a cyclic dependency, so it is inject from store-constructors
-  // instead of being defined here.
-  static constructors : Map<StorageMode, StoreConstructor> = null;
-
-  constructor(type: CRDTTypeRecordToType<T>, opts: StoreInfo & {storageKey: StorageKey, exists: Exists}) {
-    super(opts);
-    this.type = type;
-    this.storageKey = opts.storageKey;
-    this.exists = opts.exists;
-    this.mode = StorageMode.Backing;
-    this.parsedVersionToken = opts.versionToken;
-    this.model = opts.model as T['data'];
-  }
-
-  get versionToken() {
-    if (this.activeStore) {
-      return this.activeStore.versionToken;
-    }
-    return this.parsedVersionToken;
-  }
-
-  async activate(): Promise<ActiveStore<T>> {
-    if (this.activeStore) {
-      return this.activeStore;
-    }
-
-    if (Store.constructors.get(this.mode) == null) {
-      throw new Error(`StorageMode ${this.mode} not yet implemented`);
-    }
-    const constructor = Store.constructors.get(this.mode);
-    if (constructor == null) {
-      throw new Error(`No constructor registered for mode ${this.mode}`);
-    }
-
-    const activeStore = await constructor.construct<T>({
-      storageKey: this.storageKey,
-      exists: this.exists,
-      type: this.type,
-      mode: this.mode,
-      baseStore: this,
-      versionToken: this.parsedVersionToken
-    }) as ActiveStore<T>;
-    this.exists = Exists.ShouldExist;
-    this.activeStore = activeStore;
-    return activeStore;
   }
 
   // TODO(shans): DELETEME once we've switched to this storage stack

--- a/src/runtime/storage/tests/direct-store-muxer-test.ts
+++ b/src/runtime/storage/tests/direct-store-muxer-test.ts
@@ -11,7 +11,7 @@
 import {MockHierarchicalStorageKey, MockStorageDriverProvider} from '../testing/test-storage.js';
 import {DirectStoreMuxer} from '../direct-store-muxer.js';
 import {MuxType, EntityType, Schema} from '../../../types/lib-types.js';
-import {StoreMuxer} from '../store.js';
+import {Store} from '../store.js';
 import {Exists} from '../drivers/driver.js';
 import {ProxyMessageType} from '../store-interface.js';
 import {Identified, CRDTEntityTypeRecord, CRDTEntity, EntityOpTypes, CRDTSingleton} from '../../../crdt/lib-crdt.js';
@@ -34,7 +34,7 @@ describe('Direct Store Muxer', async () => {
   });
 
   it('can facilitate communication between a direct store and a storage proxy muxer', async () => {
-    const dsm = await new StoreMuxer(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
+    const dsm = await new Store(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
 
     const spmListener = new Promise(async (resolve) => {
       const id = await dsm.on(async msg => {
@@ -53,7 +53,7 @@ describe('Direct Store Muxer', async () => {
   });
 
   it('will propagate model updates from a direct store to all listeners', async () => {
-    const dsm = await new StoreMuxer(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
+    const dsm = await new Store(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
     const entityCRDT = new CRDTEntity<{name: {id: string}, age: {id: string, value: number}}, {}>({name: new CRDTSingleton<{id: string}>(), age: new CRDTSingleton<{id: string, value: number}>()}, {});
     entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor: 'me', clock: {['me']: 1}});
     entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob'}, actor: 'me', clock: {['me']: 1}});
@@ -90,7 +90,7 @@ describe('Direct Store Muxer', async () => {
   });
 
   it('will only send a model update response from requesting proxy muxer', async () => {
-    const dsm = await new StoreMuxer(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
+    const dsm = await new Store(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
 
     return new Promise(async (resolve) => {
       // storage proxy muxer that will request a model update
@@ -110,7 +110,7 @@ describe('Direct Store Muxer', async () => {
   });
 
   it('will not send model update to the listener who updated the model', async () => {
-    const dsm = await new StoreMuxer(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
+    const dsm = await new Store(muxType, {id: 'base-store-id', exists: Exists.ShouldCreate, storageKey: testKey}).activate() as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
 
     const entityCRDT = new CRDTEntity<{name: {id: string}, age: {id: string, value: number}}, {}>({name: new CRDTSingleton<{id: string}>(), age: new CRDTSingleton<{id: string, value: number}>()}, {});
     entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor: 'me', clock: {['me']: 1}});

--- a/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
@@ -9,7 +9,7 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
-import {StorageMode, ProxyMessageType, ProxyMessage, StoreMuxer} from '../store.js';
+import {StorageMode, ProxyMessageType, ProxyMessage, Store} from '../store.js';
 import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
 import {DriverFactory} from '../drivers/driver-factory.js';
 import {Exists} from '../drivers/driver.js';
@@ -43,7 +43,7 @@ describe('RamDisk + Direct Store Muxer Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
-    const baseStore = new StoreMuxer<CRDTMuxEntity>(new MuxType(new EntityType(simpleSchema)), {storageKey, exists: Exists.ShouldCreate, id: 'base-store-id'});
+    const baseStore = new Store<CRDTMuxEntity>(new MuxType(new EntityType(simpleSchema)), {storageKey, exists: Exists.ShouldCreate, id: 'base-store-id'});
     const store = await DirectStoreMuxer.construct<Identified, Identified, CRDTMuxEntity>({
       storageKey,
       exists: Exists.ShouldCreate,


### PR DESCRIPTION
This is the last step to redesigning storage class relationships in order for the DSM to extend an active store. It involves removing `StoreMuxer` and allowing the `DirectStoreMuxer`'s base store to be of type `Store` instead of `StoreMuxer`.