### PR TITLE
Initial add of DevToolsProxy to DirectStore.

### DIFF
--- a/java/arcs/android/storage/service/DevToolsProxyImpl.kt
+++ b/java/arcs/android/storage/service/DevToolsProxyImpl.kt
@@ -12,13 +12,23 @@ class DevToolsProxyImpl : IDevToolsProxy.Stub(), DevToolsProxy {
     private val onRefModeStoreProxyMessageCallbacks = mutableMapOf<Int, IStorageServiceCallback>()
     private var refModeStoreCallbackCounter = 0
 
+    private val onDirectStoreProxyMessageCallbacks = mutableMapOf<Int, IStorageServiceCallback>()
+    private var directStoreCallbackCounter = 0
+
     /**
-     * TODO: (sarahheimlich) remove once we dive into stores (b/162955831)
-     *
-     * Execute the callbacks to be called with the [BindingContext] receives a [ProxyMessage]
+     * Execute the callbacks to be called when the [ReferenceModeStore] receives a [ProxyMessage]
      */
     override fun onRefModeStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>) {
         onRefModeStoreProxyMessageCallbacks.forEach { (_, callback) ->
+            callback.onProxyMessage(proxyMessage.toProto().toByteArray())
+        }
+    }
+
+    /**
+     * Execute the callbacks to be called when the [DirectStore] receives a [ProxyMessage]
+     */
+    override fun onDirectStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>) {
+        onDirectStoreProxyMessageCallbacks.forEach { (_, callback) ->
             callback.onProxyMessage(proxyMessage.toProto().toByteArray())
         }
     }
@@ -31,7 +41,19 @@ class DevToolsProxyImpl : IDevToolsProxy.Stub(), DevToolsProxy {
         return refModeStoreCallbackCounter
     }
 
+    override fun registerDirectStoreProxyMessageCallback(
+        callback: IStorageServiceCallback
+    ): Int {
+        directStoreCallbackCounter++
+        onDirectStoreProxyMessageCallbacks.put(directStoreCallbackCounter, callback)
+        return directStoreCallbackCounter
+    }
+
     override fun deRegisterRefModeStoreProxyMessageCallback(callbackToken: Int) {
         onRefModeStoreProxyMessageCallbacks.remove(callbackToken)
+    }
+
+    override fun deRegisterDirectStoreProxyMessageCallback(callbackToken: Int) {
+        onDirectStoreProxyMessageCallbacks.remove(callbackToken)
     }
 }

--- a/java/arcs/android/storage/service/IDevToolsProxy.aidl
+++ b/java/arcs/android/storage/service/IDevToolsProxy.aidl
@@ -16,4 +16,14 @@ interface IDevToolsProxy {
      * Remove a callback that is called when the [ReferenceModeStore] receives a [ProxyMessage]
      */
     oneway void deRegisterRefModeStoreProxyMessageCallback(in int callbackToken);
+
+    /**
+     * Register a callback to be called when the [DirectStore] receives a [ProxyMessage]
+     */
+    int registerDirectStoreProxyMessageCallback(in IStorageServiceCallback callback);
+
+    /**
+     * Remove a callback that is called when the [DirectStore] receives a [ProxyMessage]
+     */
+    oneway void deRegisterDirectStoreProxyMessageCallback(in int callbackToken);
 }

--- a/java/arcs/core/storage/DevToolsProxy.kt
+++ b/java/arcs/core/storage/DevToolsProxy.kt
@@ -9,4 +9,9 @@ interface DevToolsProxy {
      * Function to call when a [ReferenceModeStore] receives a [ProxyMessage].
      */
     fun onRefModeStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>)
+
+    /**
+     * Function to call when a [ReferenceModeStore] receives a [ProxyMessage].
+     */
+    fun onDirectStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>)
 }

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -35,7 +35,8 @@ import kotlinx.coroutines.sync.withLock
 class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     val storageKey: StorageKey,
     val backingType: Type,
-    private val options: StoreOptions? = null
+    private val options: StoreOptions? = null,
+    private val devToolsProxy: DevToolsProxy?
 ) {
     private val storeMutex = Mutex()
     private val log = TaggedLog { "DirectStoreMuxer" }
@@ -135,7 +136,8 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
                 storageKey = storageKey.childKeyWithComponent(referenceId),
                 type = backingType,
                 coroutineScope = options?.coroutineScope
-            )
+            ),
+            devToolsProxy = devToolsProxy
         )
 
         val id = store.on(ProxyCallback {

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -153,7 +153,8 @@ class ReferenceModeStore private constructor(
     val backingStore = DirectStoreMuxer<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(
         storageKey = backingKey,
         backingType = backingType,
-        options = options
+        options = options,
+        devToolsProxy = devToolsProxy
     ).also {
         it.on { muxedMessage ->
             receiveQueue.enqueue {
@@ -715,7 +716,8 @@ class ReferenceModeStore private constructor(
                     type = refType,
                     versionToken = options.versionToken,
                     coroutineScope = options.coroutineScope
-                )
+                ),
+                devToolsProxy = devToolsProxy
             )
 
             return ReferenceModeStore(

--- a/java/arcs/core/storage/Store.kt
+++ b/java/arcs/core/storage/Store.kt
@@ -29,7 +29,7 @@ object DefaultActivationFactory : ActivationFactory {
     ): ActiveStore<Data, Op, T> = when (options.storageKey) {
         is ReferenceModeStorageKey ->
             ReferenceModeStore.create(options, devToolsProxy) as ActiveStore<Data, Op, T>
-        else -> DirectStore.create(options)
+        else -> DirectStore.create(options, devToolsProxy)
     }
 }
 

--- a/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
+++ b/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
@@ -43,7 +43,8 @@ class DirectStoreMuxerTest {
 
         val directStoreMuxer = DirectStoreMuxer<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(
             storageKey = storageKey,
-            backingType = EntityType(schema)
+            backingType = EntityType(schema),
+            devToolsProxy = null
         )
 
         directStoreMuxer.on {
@@ -76,7 +77,8 @@ class DirectStoreMuxerTest {
             StoreOptions(
                 storageKey = storageKey.childKeyWithComponent("a"),
                 type = EntityType(schema)
-            )
+            ),
+            null
         )
 
         val newValue = CrdtSingleton(

--- a/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
@@ -62,7 +62,8 @@ class RamDiskDirectStoreMuxerIntegrationTest {
         val storageKey = RamDiskStorageKey("unique")
         val store = DirectStoreMuxer<CrdtData, CrdtOperationAtTime, Any?>(
             storageKey = storageKey,
-            backingType = CountType()
+            backingType = CountType(),
+            devToolsProxy = null
         ).also {
             it.on { muxedProxyMessage ->
                 message.value = muxedProxyMessage.message

--- a/javatests/arcs/core/storage/RamDiskStoreIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskStoreIntegrationTest.kt
@@ -211,7 +211,8 @@ class RamDiskStoreIntegrationTest {
                 StoreOptions(
                     storageKey,
                     type = CountType()
-                )
+                ),
+                null
             )
         }
     }


### PR DESCRIPTION
- Add DevToolsProxy? to DirectStore, matching the implementation in ReferenceModeStore
- Add needed methods to DevToolsProxy, IDevToolsProxy, and DevToolsProxyImpl
- Route proxy messages through to the client as a RawMessage.

(NOTE: Do not merge after 1pm on Friday September 18)

cc: @piotrswigon 