### PR TITLE
Remove the result callback from Storage Service's `sendProxyMessage`

### DIFF
--- a/java/arcs/android/storage/service/BindingContext.kt
+++ b/java/arcs/android/storage/service/BindingContext.kt
@@ -172,16 +172,10 @@ class BindingContext(
   }
 
   @Suppress("UNCHECKED_CAST")
-  override fun sendProxyMessage(
-    proxyMessage: ByteArray,
-    resultCallback: IResultCallback
-  ) {
+  override fun sendProxyMessage(proxyMessage: ByteArray) {
     launchNonIdleAction {
       bindingContextStatisticsSink.traceTransaction("sendProxyMessage") {
         bindingContextStatisticsSink.measure {
-          // Acknowledge client immediately, for best performance.
-          resultCallback.takeIf { it.asBinder().isBinderAlive }?.onResult(null)
-
           val actualMessage = proxyMessage.decodeProxyMessage()
 
           (store() as ActiveStore<CrdtData, CrdtOperation, Any?>).let { store ->

--- a/java/arcs/android/storage/service/IStorageService.aidl
+++ b/java/arcs/android/storage/service/IStorageService.aidl
@@ -42,6 +42,5 @@ interface IStorageService {
      * @param proxyMessage {@link arcs.android.storage.ProxyMessageProto},
      *     serialized to bytes.
      */
-    oneway void sendProxyMessage(
-        in byte[] proxyMessage, IResultCallback resultCallback);
+    oneway void sendProxyMessage(in byte[] proxyMessage);
 }

--- a/java/arcs/sdk/android/storage/AndroidStorageServiceEndpointManager.kt
+++ b/java/arcs/sdk/android/storage/AndroidStorageServiceEndpointManager.kt
@@ -9,7 +9,6 @@ import arcs.android.storage.service.suspendForResultCallback
 import arcs.android.storage.toProto
 import arcs.core.common.CounterFlow
 import arcs.core.crdt.CrdtData
-import arcs.core.crdt.CrdtException
 import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.storage.ProxyCallback
@@ -96,19 +95,7 @@ class AndroidStorageEndpoint<Data : CrdtData, Op : CrdtOperationAtTime, T> inter
 
   override suspend fun onProxyMessage(message: ProxyMessage<Data, Op, T>) {
     outgoingMessagesCount.increment()
-    try {
-      suspendForResultCallback { resultCallback ->
-        service.sendProxyMessage(
-          message.withId(channelId).toProto().toByteArray(),
-          resultCallback
-        )
-      }
-    } catch (e: CrdtException) {
-      // Just return false if the message couldn't be applied.
-      log.debug(e) { "CrdtException occurred in onProxyMessage" }
-    } finally {
-      outgoingMessagesCount.decrement()
-    }
+    service.sendProxyMessage(message.withId(channelId).toProto().toByteArray())
   }
 
   override suspend fun close() {

--- a/javatests/arcs/android/storage/service/BindingContextTest.kt
+++ b/javatests/arcs/android/storage/service/BindingContextTest.kt
@@ -159,9 +159,7 @@ class BindingContextTest {
       id = 1
     )
 
-    suspendForResultCallback {
-      bindingContext.sendProxyMessage(message.toProto().toByteArray(), it)
-    }
+    bindingContext.sendProxyMessage(message.toProto().toByteArray())
 
     // sendProxyMessage does not wait for the op to complete.
     suspendForResultCallback { resultCallback ->

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceConnectionTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceConnectionTest.kt
@@ -60,10 +60,7 @@ class StorageServiceConnectionTest {
         resultCallback.onSuccess(1)
       }
 
-      override fun sendProxyMessage(
-        message: ByteArray,
-        resultCallback: IResultCallback?
-      ) = Unit
+      override fun sendProxyMessage(message: ByteArray) = Unit
 
       override fun unregisterCallback(token: Int, callback: IResultCallback) {
         callback.onResult(null)

--- a/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
+++ b/javatests/arcs/sdk/android/storage/service/StorageServiceTest.kt
@@ -99,9 +99,7 @@ class StorageServiceTest {
         listOf(op), id = 1
       )
 
-      suspendForResultCallback {
-        context.sendProxyMessage(proxyMessage.toProto().toByteArray(), it)
-      }
+      context.sendProxyMessage(proxyMessage.toProto().toByteArray())
 
       suspendForResultCallback {
         context.idle(10000, it)


### PR DESCRIPTION
When the StorageService was created, `onProxyMessage` calls on stores
would return a boolean result indicating success or failure. That's
since been removed.

We also removed the reporting of any meaningful information other than
an ACK that the service received the call.

Since the callback no longer provides any sort of actionable signal, we
can just remove it altogether.