### PR TITLE
Fix a set of serialization and API issues for ArcsInstant 

### DIFF
--- a/java/arcs/core/data/util/ReferencablePrimitive.kt
+++ b/java/arcs/core/data/util/ReferencablePrimitive.kt
@@ -134,7 +134,8 @@ data class ReferencablePrimitive<T>(
                 className == primitiveArcsInstant ->
                     ReferencablePrimitive(
                         ArcsInstant::class,
-                        ArcsInstant.ofEpochMilli(value.toLong())
+                        ArcsInstant.ofEpochMilli(value.toLong()),
+                        value
                     )
                 else -> null
             }
@@ -193,4 +194,4 @@ fun BigInt.toReferencable(): ReferencablePrimitive<BigInt> =
 
 /** Makes a [ArcsInstant]-based [ReferencablePrimitive] from the receiving [ArcsInstant]. */
 fun ArcsInstant.toReferencable(): ReferencablePrimitive<ArcsInstant> =
-    ReferencablePrimitive(ArcsInstant::class, this)
+    ReferencablePrimitive(ArcsInstant::class, this, this.toEpochMilli().toString())

--- a/java/arcs/core/entity/StorageAdapter.kt
+++ b/java/arcs/core/entity/StorageAdapter.kt
@@ -80,7 +80,8 @@ class EntityStorageAdapter<T : Entity>(
         }
 
         require(entitySpec.SCHEMA.refinement(rawEntity)) {
-            "Invalid entity stored to handle $handleName(failed refinement)"
+            "Invalid entity stored to handle (failed refinement)\n" +
+            "Handle name: $handleName\nSchema: ${entitySpec.SCHEMA}"
         }
         return rawEntity
     }

--- a/java/arcs/core/util/ArcsDuration.kt
+++ b/java/arcs/core/util/ArcsDuration.kt
@@ -25,7 +25,7 @@ class ArcsDuration private constructor(
     fun toMillis(): Long = platformDuration.toMillis()
 
     @Suppress("NewApi") // See b/167491554
-    override fun compareTo(other: ArcsDuration): Int =
+    override operator fun compareTo(other: ArcsDuration): Int =
         platformDuration.compareTo(other.platformDuration)
 
     @Suppress("NewApi") // See b/167491554
@@ -36,9 +36,13 @@ class ArcsDuration private constructor(
         return platformDuration.equals(other.platformDuration)
     }
 
+    fun toPlatform() = platformDuration
+
     companion object {
         fun valueOf(long: Long): ArcsDuration = ArcsDuration(long)
         @Suppress("NewApi") // See b/167491554
         fun ofDays(days: Long): ArcsDuration = ArcsDuration(PlatformDuration.ofDays(days))
+        @Suppress("NewApi") // See b/167491554
+        fun ofHours(days: Long): ArcsDuration = ArcsDuration(PlatformDuration.ofHours(days))
     }
 }

--- a/java/arcs/core/util/ArcsInstant.kt
+++ b/java/arcs/core/util/ArcsInstant.kt
@@ -15,9 +15,15 @@ package arcs.core.util
  * Provides a platform-independent version of [ArcsInstant]
  * from java.time.Instant.
  */
-class ArcsInstant private constructor(val platformInstant: PlatformInstant) {
+class ArcsInstant private constructor(
+    val platformInstant: PlatformInstant
+) : Comparable<ArcsInstant> {
     @Suppress("NewApi") // See b/167491554
     fun toEpochMilli(): Long = platformInstant.toEpochMilli()
+
+    @Suppress("NewApi") // See b/167491554
+    override operator fun compareTo(other: ArcsInstant): Int =
+        platformInstant.compareTo(other.platformInstant)
 
     @Suppress("NewApi") // See b/167491554
     override fun toString(): String = platformInstant.toString()
@@ -26,6 +32,16 @@ class ArcsInstant private constructor(val platformInstant: PlatformInstant) {
         if (other == null || other !is ArcsInstant) return false
         return platformInstant == other.platformInstant
     }
+
+    @Suppress("NewApi") // See b/167491554
+    fun plus(time: ArcsDuration): ArcsInstant =
+        ArcsInstant(platformInstant.plus(time.toPlatform()))
+
+    @Suppress("NewApi") // See b/167491554
+    fun minus(time: ArcsDuration): ArcsInstant =
+        ArcsInstant(platformInstant.minus(time.toPlatform()))
+
+    fun toPlatform() = platformInstant
 
     companion object {
         @Suppress("NewApi") // See b/167491554

--- a/java/arcs/core/util/ArcsInstant.kt
+++ b/java/arcs/core/util/ArcsInstant.kt
@@ -17,7 +17,7 @@ package arcs.core.util
  */
 class ArcsInstant private constructor(
     val platformInstant: PlatformInstant
-) : Comparable<ArcsInstant> {
+) : Number(), Comparable<ArcsInstant> {
     @Suppress("NewApi") // See b/167491554
     fun toEpochMilli(): Long = platformInstant.toEpochMilli()
 
@@ -50,4 +50,19 @@ class ArcsInstant private constructor(
         @Suppress("NewApi") // See b/167491554
         fun now(): ArcsInstant = ArcsInstant(PlatformInstant.now())
     }
+
+    @Suppress("NewApi") // See b/167491554
+    override fun toByte(): Byte = platformInstant.toEpochMilli().toByte()
+    @Suppress("NewApi") // See b/167491554
+    override fun toChar(): Char = platformInstant.toEpochMilli().toChar()
+    @Suppress("NewApi") // See b/167491554
+    override fun toDouble(): Double = platformInstant.toEpochMilli().toDouble()
+    @Suppress("NewApi") // See b/167491554
+    override fun toFloat(): Float = platformInstant.toEpochMilli().toFloat()
+    @Suppress("NewApi") // See b/167491554
+    override fun toInt(): Int = platformInstant.toEpochMilli().toInt()
+    @Suppress("NewApi") // See b/167491554
+    override fun toLong(): Long = platformInstant.toEpochMilli().toLong()
+    @Suppress("NewApi") // See b/167491554
+    override fun toShort(): Short = platformInstant.toEpochMilli().toShort()
 }

--- a/java/arcs/core/util/platform/js/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/js/PlatformDuration.kt
@@ -36,7 +36,7 @@ class PlatformDuration {
         @Suppress("UNUSED_PARAMETER")
         fun ofDays(days: Long): PlatformDuration = TODO("Add support for ArcsDuration in Kotlin JS")
         @Suppress("UNUSED_PARAMETER")
-        fun ofHours(days: Long): PlatformDuration
-            = TODO("Add support for ArcsDuration in Kotlin JS")
+        fun ofHours(days: Long): PlatformDuration =
+            TODO("Add support for ArcsDuration in Kotlin JS")
     }
 }

--- a/java/arcs/core/util/platform/js/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/js/PlatformDuration.kt
@@ -13,11 +13,11 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsDuration]. */
 class PlatformDuration {
-    override fun toString(): String = TODO("Add support for ArcsDuration in Kotlin JS")
+    override fun toString(): String = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
-    fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin JS")
+    fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
-    fun compareTo(other: PlatformDuration): Int = TODO("Add support for ArcsDuration in Kotlin JS")
+    fun compareTo(other: PlatformDuration): Int = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformDuration) return false
@@ -27,16 +27,16 @@ class PlatformDuration {
     companion object {
         @Suppress("UNUSED_PARAMETER")
         fun ofMillis(value: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin JS")
+            TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
         fun valueOf(value: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin JS")
+            TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
-        fun ofDays(days: Long): PlatformDuration = TODO("Add support for ArcsDuration in Kotlin JS")
+        fun ofDays(days: Long): PlatformDuration = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
         @Suppress("UNUSED_PARAMETER")
         fun ofHours(days: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin JS")
+            TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
     }
 }

--- a/java/arcs/core/util/platform/js/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/js/PlatformDuration.kt
@@ -18,6 +18,7 @@ class PlatformDuration {
 
     fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
+    @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformDuration): Int =
         TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 

--- a/java/arcs/core/util/platform/js/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/js/PlatformDuration.kt
@@ -35,5 +35,8 @@ class PlatformDuration {
 
         @Suppress("UNUSED_PARAMETER")
         fun ofDays(days: Long): PlatformDuration = TODO("Add support for ArcsDuration in Kotlin JS")
+        @Suppress("UNUSED_PARAMETER")
+        fun ofHours(days: Long): PlatformDuration
+            = TODO("Add support for ArcsDuration in Kotlin JS")
     }
 }

--- a/java/arcs/core/util/platform/js/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/js/PlatformDuration.kt
@@ -13,11 +13,13 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsDuration]. */
 class PlatformDuration {
-    override fun toString(): String = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
+    override fun toString(): String =
+        TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
     fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
-    fun compareTo(other: PlatformDuration): Int = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
+    fun compareTo(other: PlatformDuration): Int =
+        TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformDuration) return false
@@ -34,7 +36,8 @@ class PlatformDuration {
             TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
-        fun ofDays(days: Long): PlatformDuration = TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
+        fun ofDays(days: Long): PlatformDuration =
+            TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588
         @Suppress("UNUSED_PARAMETER")
         fun ofHours(days: Long): PlatformDuration =
             TODO("Add support for ArcsDuration in Kotlin JS") // See b/169213588

--- a/java/arcs/core/util/platform/js/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/js/PlatformInstant.kt
@@ -13,13 +13,15 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsInstant]. */
 class PlatformInstant {
-    override fun toString(): String = TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
+    override fun toString(): String =
+        TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     fun toEpochMilli(): Long =
         TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
-    fun compareTo(other: PlatformInstant): Int = TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
+    fun compareTo(other: PlatformInstant): Int =
+        TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun plus(time: PlatformInstant): PlatformInstant =

--- a/java/arcs/core/util/platform/js/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/js/PlatformInstant.kt
@@ -18,7 +18,16 @@ class PlatformInstant {
     fun toEpochMilli(): Long =
         TODO("Add support for ArcsInstant in Kotlin JS")
 
+    @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformInstant): Int = TODO("Add support for ArcsInstant in Kotlin JS")
+
+    @Suppress("UNUSED_PARAMETER")
+    fun plus(time: PlatformInstant): PlatformInstant =
+        TODO("Add support for ArcsInstant in Kotlin JS")
+
+    @Suppress("UNUSED_PARAMETER")
+    fun minus(time: PlatformInstant): PlatformInstant =
+        TODO("Add support for ArcsInstant in Kotlin JS")
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformInstant) return false

--- a/java/arcs/core/util/platform/js/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/js/PlatformInstant.kt
@@ -13,21 +13,21 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsInstant]. */
 class PlatformInstant {
-    override fun toString(): String = TODO("Add support for ArcsInstant in Kotlin JS")
+    override fun toString(): String = TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     fun toEpochMilli(): Long =
-        TODO("Add support for ArcsInstant in Kotlin JS")
+        TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
-    fun compareTo(other: PlatformInstant): Int = TODO("Add support for ArcsInstant in Kotlin JS")
+    fun compareTo(other: PlatformInstant): Int = TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun plus(time: PlatformInstant): PlatformInstant =
-        TODO("Add support for ArcsInstant in Kotlin JS")
+        TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun minus(time: PlatformInstant): PlatformInstant =
-        TODO("Add support for ArcsInstant in Kotlin JS")
+        TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformInstant) return false
@@ -37,12 +37,12 @@ class PlatformInstant {
     companion object {
         @Suppress("UNUSED_PARAMETER")
         fun ofEpochMilli(value: Long): PlatformInstant =
-            TODO("Add support for ArcsInstant in Kotlin JS")
+            TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
         fun now(): PlatformInstant =
-            TODO("Add support for ArcsInstant in Kotlin JS")
+            TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
         fun valueOf(value: Long): PlatformInstant =
-            TODO("Add support for ArcsInstant in Kotlin JS")
+            TODO("Add support for ArcsInstant in Kotlin JS") // See b/169213588
     }
 }

--- a/java/arcs/core/util/platform/native/PlatformBigInt.kt
+++ b/java/arcs/core/util/platform/native/PlatformBigInt.kt
@@ -15,26 +15,33 @@ package arcs.core.util
 class PlatformBigInt() {
     constructor(bigInt: String) : this() {}
 
-    fun toByte(): Byte = TODO()
+    fun toByte(): Byte = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun toChar(): Char = TODO()
+    fun toChar(): Char = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun toDouble(): Double = TODO()
+    fun toDouble(): Double = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun toFloat(): Float = TODO()
+    fun toFloat(): Float = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun toInt(): Int = TODO()
+    fun toInt(): Int = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun toLong(): Long = TODO()
+    fun toLong(): Long = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun toShort(): Short = TODO()
+    fun toShort(): Short = TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    fun add(other: PlatformBigInt): PlatformBigInt = TODO()
-    fun subtract(other: PlatformBigInt): PlatformBigInt = TODO()
-    fun multiply(other: PlatformBigInt): PlatformBigInt = TODO()
-    fun divide(other: PlatformBigInt): PlatformBigInt = TODO()
-    fun and(other: PlatformBigInt): PlatformBigInt = TODO()
-    fun or(other: PlatformBigInt): PlatformBigInt = TODO()
+    fun add(other: PlatformBigInt): PlatformBigInt =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
+    fun subtract(other: PlatformBigInt): PlatformBigInt =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
+    fun multiply(other: PlatformBigInt): PlatformBigInt =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
+    fun divide(other: PlatformBigInt): PlatformBigInt =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
+    fun and(other: PlatformBigInt): PlatformBigInt =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
+    fun or(other: PlatformBigInt): PlatformBigInt =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 
-    operator fun compareTo(other: PlatformBigInt): Int = TODO()
+    operator fun compareTo(other: PlatformBigInt): Int =
+        TODO("Add support for BigInt in Kotlin Native") // See b/169213588
 }

--- a/java/arcs/core/util/platform/native/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/native/PlatformDuration.kt
@@ -13,9 +13,11 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsDuration]. */
 class PlatformDuration {
-    override fun toString(): String = TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
+    override fun toString(): String =
+        TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
-    fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
+    fun toMillis(): String =
+        TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformDuration): Int =

--- a/java/arcs/core/util/platform/native/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/native/PlatformDuration.kt
@@ -17,7 +17,7 @@ class PlatformDuration {
 
     fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin Native")
 
-    @Suppress("unused")
+    @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformDuration): Int =
         TODO("Add support for ArcsDuration in Kotlin Native")
 

--- a/java/arcs/core/util/platform/native/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/native/PlatformDuration.kt
@@ -13,13 +13,13 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsDuration]. */
 class PlatformDuration {
-    override fun toString(): String = TODO("Add support for ArcsDuration in Kotlin Native")
+    override fun toString(): String = TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
-    fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin Native")
+    fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformDuration): Int =
-        TODO("Add support for ArcsDuration in Kotlin Native")
+        TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformDuration) return false
@@ -29,18 +29,18 @@ class PlatformDuration {
     companion object {
         @Suppress("UNUSED_PARAMETER")
         fun ofMillis(value: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin Native")
+            TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
         fun valueOf(value: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin Native")
+            TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
         fun ofDays(days: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin Native")
+            TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
         fun ofHours(hours: Long): PlatformDuration =
-            TODO("Add support for ArcsDuration in Kotlin Native")
+            TODO("Add support for ArcsDuration in Kotlin Native") // See b/169213588
     }
 }

--- a/java/arcs/core/util/platform/native/PlatformDuration.kt
+++ b/java/arcs/core/util/platform/native/PlatformDuration.kt
@@ -17,6 +17,7 @@ class PlatformDuration {
 
     fun toMillis(): String = TODO("Add support for ArcsDuration in Kotlin Native")
 
+    @Suppress("unused")
     fun compareTo(other: PlatformDuration): Int =
         TODO("Add support for ArcsDuration in Kotlin Native")
 
@@ -36,6 +37,10 @@ class PlatformDuration {
 
         @Suppress("UNUSED_PARAMETER")
         fun ofDays(days: Long): PlatformDuration =
+            TODO("Add support for ArcsDuration in Kotlin Native")
+
+        @Suppress("UNUSED_PARAMETER")
+        fun ofHours(hours: Long): PlatformDuration =
             TODO("Add support for ArcsDuration in Kotlin Native")
     }
 }

--- a/java/arcs/core/util/platform/native/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/native/PlatformInstant.kt
@@ -22,7 +22,6 @@ class PlatformInstant {
     fun compareTo(other: PlatformInstant): Int =
         TODO("Add support for ArcsInstant in Kotlin Native")
 
-    @Suppress("UNUSED_PARAMETER")
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformInstant) return false
         return this.compareTo(other) == 0

--- a/java/arcs/core/util/platform/native/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/native/PlatformInstant.kt
@@ -18,15 +18,23 @@ class PlatformInstant {
     fun toEpochMilli(): Long =
         TODO("Add support for ArcsInstant in Kotlin Native")
 
-    @Suppress("unused")
+    @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformInstant): Int =
         TODO("Add support for ArcsInstant in Kotlin Native")
 
-    @Suppress("unused")
+    @Suppress("UNUSED_PARAMETER")
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformInstant) return false
         return this.compareTo(other) == 0
     }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun plus(time: PlatformInstant): PlatformInstant =
+        TODO("Add support for ArcsInstant in Kotlin Native")
+
+    @Suppress("UNUSED_PARAMETER")
+    fun minus(time: PlatformInstant): PlatformInstant =
+        TODO("Add support for ArcsInstant in Kotlin Native")
 
     companion object {
         @Suppress("UNUSED_PARAMETER")

--- a/java/arcs/core/util/platform/native/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/native/PlatformInstant.kt
@@ -13,14 +13,14 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsInstant]. */
 class PlatformInstant {
-    override fun toString(): String = TODO("Add support for ArcsInstant in Kotlin Native")
+    override fun toString(): String = TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
     fun toEpochMilli(): Long =
-        TODO("Add support for ArcsInstant in Kotlin Native")
+        TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun compareTo(other: PlatformInstant): Int =
-        TODO("Add support for ArcsInstant in Kotlin Native")
+        TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformInstant) return false
@@ -29,21 +29,21 @@ class PlatformInstant {
 
     @Suppress("UNUSED_PARAMETER")
     fun plus(time: PlatformInstant): PlatformInstant =
-        TODO("Add support for ArcsInstant in Kotlin Native")
+        TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
     @Suppress("UNUSED_PARAMETER")
     fun minus(time: PlatformInstant): PlatformInstant =
-        TODO("Add support for ArcsInstant in Kotlin Native")
+        TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
     companion object {
         @Suppress("UNUSED_PARAMETER")
         fun ofEpochMilli(value: Long): PlatformInstant =
-            TODO("Add support for ArcsInstant in Kotlin Native")
+            TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
         fun now(): PlatformInstant =
-            TODO("Add support for ArcsInstant in Kotlin Native")
+            TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
         @Suppress("UNUSED_PARAMETER")
         fun valueOf(value: Long): PlatformInstant =
-            TODO("Add support for ArcsInstant in Kotlin Native")
+            TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
     }
 }

--- a/java/arcs/core/util/platform/native/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/native/PlatformInstant.kt
@@ -13,7 +13,8 @@ package arcs.core.util
 
 /** Provides a platform-dependent version of [ArcsInstant]. */
 class PlatformInstant {
-    override fun toString(): String = TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
+    override fun toString(): String =
+        TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588
 
     fun toEpochMilli(): Long =
         TODO("Add support for ArcsInstant in Kotlin Native") // See b/169213588

--- a/java/arcs/core/util/platform/native/PlatformInstant.kt
+++ b/java/arcs/core/util/platform/native/PlatformInstant.kt
@@ -18,9 +18,11 @@ class PlatformInstant {
     fun toEpochMilli(): Long =
         TODO("Add support for ArcsInstant in Kotlin Native")
 
+    @Suppress("unused")
     fun compareTo(other: PlatformInstant): Int =
         TODO("Add support for ArcsInstant in Kotlin Native")
 
+    @Suppress("unused")
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is PlatformInstant) return false
         return this.compareTo(other) == 0

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1866,13 +1866,10 @@ FunctionArguments
   }
 
 FunctionCall
-  = fn: (fieldName '(' FunctionArguments? ')')
+  = fnName:fieldName '(' args:FunctionArguments? ')'
   {
     // TODO: fieldName is too restrictive here (and will give misleading error messages).
-    // We should also accept built in function names.
-    const fnName = fn[0];
-    const args = typeof(fn) !== 'string' && fn[2] || [];
-
+    args = args || [];
     if (!isPaxelMode()) {
       if (args.length > 0) {
         error("Functions may have arguments only in paxel expressions.");
@@ -1969,9 +1966,12 @@ UnitName
     return unit+'s';
   }
 
+TypeIdentifier = typeIdentifier:('n'/'i'/'l'/'f'/'d') &[^a-zA-Z0-9_] {
+  return text();
+}
+
 NumericValue
-  = neg:'-'? whole:[0-9_]+ decimal:('.' [0-9_]*)? typeIdentifier:('n'/'i'/'l'/'f'/'d')? units:Units
-  {
+  = neg:'-'? whole:[0-9_]+ decimal:('.' [0-9_]*)? typeIdentifier:TypeIdentifier? units:Units {
     const type = (() => {
       switch (typeIdentifier) {
         case 'n': return 'BigInt';
@@ -1989,7 +1989,7 @@ NumericValue
             return 'Number';
           }
       }
-      throw new Error(`Unexpected type identifier ${typeIdentifier} (expected one of n, i, l, f, d)`);
+      throw new Error(`Unexpected type identifier '${typeIdentifier}' (expected one of n, i, l, f, d)`);
     })();
     const getDigits = (chars) => chars.filter(x => x !== '_').join('');
     const decimalStr = decimal ? `.${getDigits(decimal[1])}` : '';

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1966,12 +1966,13 @@ UnitName
     return unit+'s';
   }
 
-TypeIdentifier = typeIdentifier:('n'/'i'/'l'/'f'/'d') &[^a-zA-Z0-9_] {
+// This is a suffix to add to a value (e.g. 12.3f) that marks the type associated with the value.
+LiteralTypeAnnotation = typeIdentifier:('n'/'i'/'l'/'f'/'d') &[^a-zA-Z0-9_] {
   return text();
 }
 
 NumericValue
-  = neg:'-'? whole:[0-9_]+ decimal:('.' [0-9_]*)? typeIdentifier:TypeIdentifier? units:Units {
+  = neg:'-'? whole:[0-9_]+ decimal:('.' [0-9_]*)? typeIdentifier:LiteralTypeAnnotation? units:Units {
     const type = (() => {
       switch (typeIdentifier) {
         case 'n': return 'BigInt';

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -165,6 +165,9 @@ ${tryImport('arcs.core.data.expression.Expression.BinaryOp.*', this.namespace)}
 ${tryImport('arcs.core.data.Plan.*', this.namespace)}
 ${tryImport('arcs.core.storage.StorageKeyParser', this.namespace)}
 ${tryImport('arcs.core.entity.toPrimitiveValue', this.namespace)}
+${tryImport('arcs.core.util.ArcsInstant', this.namespace)}
+${tryImport('arcs.core.util.ArcsDuration', this.namespace)}
+${tryImport('arcs.core.util.BigInt', this.namespace)}
 `;
   }
 

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -35,7 +35,8 @@ export class Schema2Kotlin extends Schema2Base {
       imports.push(
         'import arcs.sdk.Particle',
         'import arcs.sdk.testing.*',
-        'import arcs.core.util.ArcsInstant',
+        'import arcs.sdk.ArcsDuration',
+        'import arcs.sdk.ArcsInstant',
         'import arcs.sdk.BigInt',
         'import arcs.sdk.toBigInt',
         'import kotlinx.coroutines.CoroutineScope',
@@ -53,6 +54,7 @@ export class Schema2Kotlin extends Schema2Base {
         'import arcs.core.data.expression.Expression.BinaryOp.*',
         'import arcs.core.data.util.toReferencable',
         'import arcs.core.entity.toPrimitiveValue',
+        'import arcs.sdk.ArcsDuration',
         'import arcs.sdk.ArcsInstant',
         'import arcs.sdk.BigInt',
         'import arcs.sdk.toBigInt',

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -14,6 +14,9 @@ import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
 import arcs.core.entity.toPrimitiveValue
+import arcs.core.util.ArcsInstant
+import arcs.core.util.ArcsDuration
+import arcs.core.util.BigInt
 
 val IngestionOnly_Handle0 by lazy {
     Handle(

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -13,6 +13,7 @@ import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.util.toReferencable
 import arcs.core.entity.toPrimitiveValue
+import arcs.sdk.ArcsDuration
 import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt
 import arcs.sdk.toBigInt

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -7,7 +7,8 @@ package arcs.golden
 // GENERATED CODE -- DO NOT EDIT
 //
 
-import arcs.core.util.ArcsInstant
+import arcs.sdk.ArcsDuration
+import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt
 import arcs.sdk.Particle
 import arcs.sdk.testing.*

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -13,6 +13,7 @@ import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.util.toReferencable
 import arcs.core.entity.toPrimitiveValue
+import arcs.sdk.ArcsDuration
 import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt
 import arcs.sdk.toBigInt

--- a/src/tools/tests/goldens/plan-generator-plans.cgtest
+++ b/src/tools/tests/goldens/plan-generator-plans.cgtest
@@ -40,6 +40,9 @@ import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
 import arcs.core.entity.toPrimitiveValue
+import arcs.core.util.ArcsInstant
+import arcs.core.util.ArcsDuration
+import arcs.core.util.BigInt
 
 val Ingest_Handle0 by lazy {
     Handle(
@@ -157,6 +160,9 @@ import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
 import arcs.core.entity.toPrimitiveValue
+import arcs.core.util.ArcsInstant
+import arcs.core.util.ArcsDuration
+import arcs.core.util.BigInt
 
 val R_Handle0 by lazy {
     Handle(
@@ -255,6 +261,9 @@ import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
 import arcs.core.entity.toPrimitiveValue
+import arcs.core.util.ArcsInstant
+import arcs.core.util.ArcsDuration
+import arcs.core.util.BigInt
 
 val R_Handle0 by lazy {
     Handle(

--- a/src/types/internal/refiner.ts
+++ b/src/types/internal/refiner.ts
@@ -234,6 +234,7 @@ abstract class RefinementExpression {
       case 'BuiltInNode': return BuiltIn.fromLiteral(expr);
       case 'QueryArgumentPrimitiveNode': return QueryArgumentPrimitive.fromLiteral(expr);
       case 'NumberPrimitiveNode': return NumberPrimitive.fromLiteral(expr);
+      case 'DiscretePrimitiveNode': return DiscretePrimitive.fromLiteral(expr);
       case 'BooleanPrimitiveNode': return BooleanPrimitive.fromLiteral(expr);
       case 'TextPrimitiveNode': return TextPrimitive.fromLiteral(expr);
       default:


### PR DESCRIPTION
Fixes:
- Add missing imports for ArcsInstant and ArcsDuration to code generation for Particles and Plans
- Fix early parse failure in refinement and paxel numeric value in type annotation and unit (e.g. 12days would be parsed as 12d)
- Improve conformance of non-jvm ArcsInstant and ArcsDuration APIs to jvm base
- Fix up conversion of ArcsInstant to ReferencablePrimitive (add missing parameter)
- Implement missing case for fromLiteral for DiscretePrimitiveNode
- Improve error for refinement failure in StorageAdapter (Provide Schema information in error)