### PR TITLE
Created new tests to demonstrate entity mutation in Typescript

### DIFF
--- a/src/runtime/storage/handle.ts
+++ b/src/runtime/storage/handle.ts
@@ -598,9 +598,7 @@ export class EntityHandle<T> extends Handle<CRDTMuxEntity> {
     return serializedEntity;
   }
 
-  onUpdate(update: EntityOperation<Identified, Identified>): void {
-    throw new Error('Method not implemented yet.');
-  }
+  onUpdate(update: EntityOperation<Identified, Identified>): void {}
 
   async onSync(model: RawEntity<Identified, Identified>): Promise<void> {
     assert(this.canRead, 'onSync should not be called for non-readable handles');


### PR DESCRIPTION
The `EntityHandle.onUpdate` method is invoked when the entity is mutated, and therefore it can not throw an error. For now it does nothing. In a follow up PR we can implement a way to allow particles to listen to entity updates which would require implementing `EntityHandle.onUpdate`.