### PR TITLE
Make the parameter in DSM.onProxyMessage a MuxedProxyMessage

### DIFF
--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -15,9 +15,6 @@ import androidx.annotation.VisibleForTesting
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.CrdtOperationAtTime
-import arcs.core.storage.ProxyMessage.ModelUpdate
-import arcs.core.storage.ProxyMessage.Operations
-import arcs.core.storage.ProxyMessage.SyncRequest
 import arcs.core.storage.util.randomCallbackManager
 import arcs.core.type.Type
 import arcs.core.util.LruCacheMap
@@ -111,22 +108,15 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     /**
-     * Sends the provided [ProxyMessage] to the store backing the provided [referenceId].
+     * Sends the [ProxyMessage] to the store backing [muxId].
      *
-     * A new store will be created for the [referenceId], if necessary.
+     * A new store will be created for the [muxId], if necessary.
      */
     suspend fun onProxyMessage(
-        message: ProxyMessage<Data, Op, T>,
-        referenceId: String
+        muxedMessage: MuxedProxyMessage<Data, Op, T>
     ) {
-        val (id, store) = store(referenceId)
-        val deMuxedMessage: ProxyMessage<Data, Op, T> = when (message) {
-            is SyncRequest -> SyncRequest(id)
-            is ModelUpdate -> ModelUpdate(message.model, id)
-            is Operations -> if (message.operations.isNotEmpty()) {
-                Operations(message.operations, id)
-            } else return
-        }
+        val (id, store) = store(muxedMessage.muxId)
+        val deMuxedMessage: ProxyMessage<Data, Op, T> = muxedMessage.message.withId(id)
         store.onProxyMessage(deMuxedMessage)
     }
 

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -108,9 +108,9 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
     }
 
     /**
-     * Sends the [ProxyMessage] to the store backing [muxId].
+     * Sends the [ProxyMessage] to the store backing `muxId`.
      *
-     * A new store will be created for the [muxId], if necessary.
+     * A new store will be created for the `muxId`, if necessary.
      */
     suspend fun onProxyMessage(
         muxedMessage: MuxedProxyMessage<Data, Op, T>

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -29,6 +29,7 @@ import arcs.core.data.SchemaRegistry
 import arcs.core.data.SingletonType
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.DriverFactory
+import arcs.core.storage.MuxedProxyMessage
 import arcs.core.storage.ProxyCallback
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.Reference
@@ -520,7 +521,9 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
         )
 
         activeStore.backingStore
-            .onProxyMessage(ProxyMessage.ModelUpdate(bobCrdt.data, id = 1), "an-id")
+            .onProxyMessage(
+                MuxedProxyMessage("an-id", ProxyMessage.ModelUpdate(bobCrdt.data, id = 1))
+            )
 
         val job = Job(coroutineContext[Job])
         activeStore.on(

--- a/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
+++ b/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
@@ -66,11 +66,23 @@ class DirectStoreMuxerTest {
         // Attempt to trigger a child store setup race
         coroutineScope {
             launch { directStoreMuxer.getLocalData("a") }
-            launch { directStoreMuxer.onProxyMessage(ProxyMessage.ModelUpdate(data, 1), "a") }
+            launch {
+                directStoreMuxer.onProxyMessage(
+                    MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
+                )
+            }
             launch { directStoreMuxer.getLocalData("a") }
-            launch { directStoreMuxer.onProxyMessage(ProxyMessage.ModelUpdate(data, 1), "a") }
+            launch {
+                directStoreMuxer.onProxyMessage(
+                    MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
+                )
+            }
             launch { directStoreMuxer.getLocalData("a") }
-            launch { directStoreMuxer.onProxyMessage(ProxyMessage.ModelUpdate(data, 1), "a") }
+            launch {
+                directStoreMuxer.onProxyMessage(
+                    MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
+                )
+            }
         }
 
         val otherStore = DirectStore.create<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>(

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -482,7 +482,12 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         )
 
         activeStore.backingStore
-            .onProxyMessage(ProxyMessage.ModelUpdate(bobCrdt.data, id = 1), "an-id")
+            .onProxyMessage(
+                MuxedProxyMessage(
+                    "an-id",
+                    ProxyMessage.ModelUpdate(bobCrdt.data, id = 1)
+                )
+            )
 
         val job = Job(coroutineContext[Job])
         activeStore.on(

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -440,7 +440,12 @@ class ReferenceModeStoreTest {
         )
 
         activeStore.backingStore
-            .onProxyMessage(ProxyMessage.ModelUpdate(bobCrdt.data, id = 1), "an-id")
+            .onProxyMessage(
+                MuxedProxyMessage(
+                    "an-id",
+                    ProxyMessage.ModelUpdate(bobCrdt.data, id = 1)
+                )
+            )
 
         val job = Job(coroutineContext[Job.Key])
         activeStore.on(ProxyCallback {
@@ -498,8 +503,10 @@ class ReferenceModeStoreTest {
 
         // Ensure remote entity is stored in backing store.
         activeStore.backingStore.onProxyMessage(
-            ProxyMessage.ModelUpdate(createPersonEntityCrdt().data, id = 2),
-            "another-id"
+            MuxedProxyMessage(
+                "another-id",
+                ProxyMessage.ModelUpdate(createPersonEntityCrdt().data, id = 2)
+            )
         )
 
         val driver = activeStore.containerStore.driver as MockDriver<CrdtSet.Data<Reference>>


### PR DESCRIPTION
The StorageProxyMuxer will be sending MuxedProxyMessage's to the DirectStoreMuxer and therefore the onProxyMessage function in the DSM should have a single parameter: MuxedProxyMessage.