### PR TITLE
Invert logic in MatchFreeHandlesToConnections.

### DIFF
--- a/src/planning/strategies/match-free-handles-to-connections.ts
+++ b/src/planning/strategies/match-free-handles-to-connections.ts
@@ -1,4 +1,13 @@
-import { HandleConnectionSpec } from '../../runtime/arcs-types/particle-spec.js';
+/**
+ * @license
+ * Copyright 2019 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {HandleConnectionSpec} from '../../runtime/arcs-types/particle-spec.js';
 /**
  * @license
  * Copyright (c) 2017 Google Inc. All rights reserved.
@@ -20,7 +29,7 @@ export class MatchFreeHandlesToConnections extends Strategy {
   async generate(inputParams) {
     return StrategizerWalker.over(this.getResults(inputParams), new class extends StrategizerWalker {
       onPotentialHandleConnection(recipe: Recipe, particle: Particle, connectionSpec: HandleConnectionSpec) {
-        const freeHandles = recipe.handles.filter(h => h.connections.length == 0);
+        const freeHandles = recipe.handles.filter(h => h.connections.length === 0);
 
         return freeHandles.map(handle => {
           return (recipe: Recipe, particle: Particle, connectionSpec: HandleConnectionSpec) => {
@@ -28,7 +37,7 @@ export class MatchFreeHandlesToConnections extends Strategy {
             particle.addConnectionName(connectionSpec.name).connectToHandle(cloneHandle);
             return 1;
           };
-        })
+        });
       }
     }(StrategizerWalker.Permuted), this);
   }

--- a/src/planning/strategies/match-free-handles-to-connections.ts
+++ b/src/planning/strategies/match-free-handles-to-connections.ts
@@ -1,3 +1,4 @@
+import { HandleConnectionSpec } from '../../runtime/arcs-types/particle-spec.js';
 /**
  * @license
  * Copyright (c) 2017 Google Inc. All rights reserved.
@@ -8,7 +9,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Recipe, Handle} from '../../runtime/recipe/lib-recipe.js';
+import {Recipe, Particle} from '../../runtime/recipe/lib-recipe.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
 
 /*
@@ -18,21 +19,16 @@ import {StrategizerWalker, Strategy} from '../strategizer.js';
 export class MatchFreeHandlesToConnections extends Strategy {
   async generate(inputParams) {
     return StrategizerWalker.over(this.getResults(inputParams), new class extends StrategizerWalker {
-      onHandle(recipe: Recipe, handle: Handle) {
-        if (handle.connections.length > 0) {
-          return undefined;
-        }
+      onPotentialHandleConnection(recipe: Recipe, particle: Particle, connectionSpec: HandleConnectionSpec) {
+        const freeHandles = recipe.handles.filter(h => h.connections.length == 0);
 
-        const matchingConnections = recipe.getFreeConnections();
-
-        return matchingConnections.map(({particle, connSpec}) => {
-          return (recipe: Recipe, handle: Handle) => {
-            const cloneParticle = recipe.updateToClone({particle}).particle;
-            const newConnection = cloneParticle.addConnectionName(connSpec.name);
-            newConnection.connectToHandle(handle);
+        return freeHandles.map(handle => {
+          return (recipe: Recipe, particle: Particle, connectionSpec: HandleConnectionSpec) => {
+            const cloneHandle = recipe.updateToClone({handle}).handle;
+            particle.addConnectionName(connectionSpec.name).connectToHandle(cloneHandle);
             return 1;
           };
-        });
+        })
       }
     }(StrategizerWalker.Permuted), this);
   }


### PR DESCRIPTION
This used to try permuting mappings from unconnected handles to all
free handleConnections. However, this meant that we were trying to
construct the same handleConnection twice, if there were two
unconnected handles, as both would attempt to map to the same
connection.

Now, we permute mappings from free handleConnections to unconnected
handles instead, which means we only create each handleConnection once.