### PR TITLE
JSON Format DirectStore DevToolsMessages

### DIFF
--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -24,11 +24,15 @@ interface DevToolsMessage {
         const val RAW_MESSAGE = "RawStoreMessage"
         /** A [STORE_SYNC] should be used to notify the client that a store has synced. */
         const val SYNC_MESSAGE = "StoreSyncMessage"
-        /** A [STORE_MESSAGE] should be used when an [Operation] [ProxyMessage] is received. */
-        const val STORE_MESSAGE = "StoreMessage"
+        /** A [MODEL_UPDATE_MESSAGE] is used when a [ModelUpdate] [ProxyMessage] is received. */
+        const val MODEL_UPDATE_MESSAGE = "ModelUpdateMessage"
+        /** A [STORE_OP_MESSAGE] should be used when an [Operation] [ProxyMessage] is received. */
+        const val STORE_OP_MESSAGE = "StoreOperationMessage"
 
         /** A [CLEAR_TYPE] should be used when a clear message is received. */
         const val CLEAR_TYPE = "clear"
+        /** A [CLEAR_ALL_TYPE] should be used when a clear all message is received. */
+        const val CLEAR_ALL_TYPE = "clearAll"
         /** An [UPDATE_TYPE] should be used when a [CrdtSingleton.Operation.Update] is received. */
         const val UPDATE_TYPE = "update"
         /** An [ADD_TYPE] should be used when a [CrdtSet.Operation.Add] is received. */
@@ -61,5 +65,13 @@ interface DevToolsMessage {
         const val OLD_CLOCK = "oldClock"
         /** Json Key for the clock in a [CrdtOperation]. */
         const val CLOCK = "clock"
+        /** Json key for the versionmap. */
+        const val VERSIONMAP = "versionmap"
+        /** Json key for the type of [Store] the message comes from. */
+        const val STORE_TYPE = "storetype"
+        /** To be used as the [STORE_TYPE] for a [ReferenceModeStore]. */
+        const val REFERENCEMODE = "referncemode"
+        /** To be used as the [STORE_TYPE] for a [DirectStore]. */
+        const val DIRECT = "direct"
     }
 }

--- a/java/arcs/android/devtools/DevToolsService.kt
+++ b/java/arcs/android/devtools/DevToolsService.kt
@@ -169,25 +169,23 @@ open class DevToolsService : Service() {
         actualMessage: ProxyMessage<CrdtData, CrdtOperation, Any?>,
         storeType: String
     ) {
-        when (actualMessage) {
+        val message = when (actualMessage) {
             is ProxyMessage.SyncRequest -> {
-                val syncMessage = StoreSyncMessage(
+                StoreSyncMessage(
                     JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0)
                 )
-                devToolsServer.send(syncMessage.toJson())
             }
             is ProxyMessage.Operations -> {
-                val storeMessage = StoreOperationMessage(actualMessage, storeType)
-                devToolsServer.send(storeMessage.toJson())
+                StoreOperationMessage(actualMessage, storeType)
             }
             is ProxyMessage.ModelUpdate -> {
-                val storeMessage = ModelUpdateMessage(actualMessage, storeType)
-                devToolsServer.send(storeMessage.toJson())
+                ModelUpdateMessage(actualMessage, storeType)
             }
         }
         val rawMessage = RawDevToolsMessage(
             JsonValue.JsonString(actualMessage.toString())
         )
+        devToolsServer.send(message.toJson())
         devToolsServer.send(rawMessage.toJson())
     }
 

--- a/java/arcs/android/devtools/DevToolsService.kt
+++ b/java/arcs/android/devtools/DevToolsService.kt
@@ -17,11 +17,15 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import arcs.android.devtools.DevToolsMessage.Companion.DIRECT
+import arcs.android.devtools.DevToolsMessage.Companion.REFERENCEMODE
 import arcs.android.devtools.storage.DevToolsConnectionFactory
 import arcs.android.storage.decodeProxyMessage
 import arcs.android.storage.service.IDevToolsProxy
 import arcs.android.storage.service.IDevToolsStorageManager
 import arcs.android.storage.service.IStorageServiceCallback
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.ProxyMessage
 import arcs.core.util.JsonValue
 import arcs.sdk.android.storage.service.StorageService
@@ -70,19 +74,10 @@ open class DevToolsService : Service() {
                 object : IStorageServiceCallback.Stub() {
                     override fun onProxyMessage(proxyMessage: ByteArray) {
                         scope.launch {
-                            val actualMessage = proxyMessage.decodeProxyMessage()
-                            when (actualMessage) {
-                                is ProxyMessage.SyncRequest -> {
-                                    val syncMessage = StoreSyncMessage(
-                                        JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0)
-                                    )
-                                    devToolsServer.send(syncMessage.toJson())
-                                }
-                                is ProxyMessage.Operations -> {
-                                    val storeMessage = StoreMessage(actualMessage)
-                                    devToolsServer.send(storeMessage.toJson())
-                                }
-                            }
+                            createAndSendProxyMessages(
+                                proxyMessage.decodeProxyMessage(),
+                                REFERENCEMODE
+                            )
                         }
                     }
                 }
@@ -92,11 +87,7 @@ open class DevToolsService : Service() {
                 object : IStorageServiceCallback.Stub() {
                     override fun onProxyMessage(proxyMessage: ByteArray) {
                         scope.launch {
-                            val actualMessage = proxyMessage.decodeProxyMessage()
-                            val rawMessage = RawDevToolsMessage(
-                                JsonValue.JsonString(actualMessage.toString())
-                            )
-                            devToolsServer.send(rawMessage.toJson())
+                            createAndSendProxyMessages(proxyMessage.decodeProxyMessage(), DIRECT)
                         }
                     }
                 }
@@ -172,6 +163,32 @@ open class DevToolsService : Service() {
         return IDevToolsStorageManager.Stub.asInterface(
             serviceConnection?.connectAsync()?.await()
         )
+    }
+
+    private fun createAndSendProxyMessages(
+        actualMessage: ProxyMessage<CrdtData, CrdtOperation, Any?>,
+        storeType: String
+    ) {
+        when (actualMessage) {
+            is ProxyMessage.SyncRequest -> {
+                val syncMessage = StoreSyncMessage(
+                    JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0)
+                )
+                devToolsServer.send(syncMessage.toJson())
+            }
+            is ProxyMessage.Operations -> {
+                val storeMessage = StoreOperationMessage(actualMessage, storeType)
+                devToolsServer.send(storeMessage.toJson())
+            }
+            is ProxyMessage.ModelUpdate -> {
+                val storeMessage = ModelUpdateMessage(actualMessage, storeType)
+                devToolsServer.send(storeMessage.toJson())
+            }
+        }
+        val rawMessage = RawDevToolsMessage(
+            JsonValue.JsonString(actualMessage.toString())
+        )
+        devToolsServer.send(rawMessage.toJson())
     }
 
     companion object {

--- a/java/arcs/android/devtools/ModelUpdateMessage.kt
+++ b/java/arcs/android/devtools/ModelUpdateMessage.kt
@@ -31,19 +31,18 @@ class ModelUpdateMessage(
     /**
      * Transform the [CrdtData] into JSON.
      */
-    private fun getModel(model: CrdtData): JsonValue<*> {
-        when (model) {
-            is CrdtEntity.Data -> {
-                return JsonValue.JsonObject(
-                    VERSIONMAP to model.versionMap.toJson(),
-                    "singletons" to singletonsJson(model.singletons),
-                    "collections" to collectionsJson(model.collections)
-                )
-            }
-            // TODO(heimlich): other types
+    private fun getModel(model: CrdtData) = when (model) {
+        is CrdtEntity.Data -> {
+            JsonValue.JsonObject(
+                VERSIONMAP to model.versionMap.toJson(),
+                "singletons" to singletonsJson(model.singletons),
+                "collections" to collectionsJson(model.collections)
+            )
         }
-        return JsonValue.JsonNull
+        // TODO(heimlich): other types
+        else -> JsonValue.JsonNull
     }
+
 
     /**
      * Transform the map of names to collections into JSON.
@@ -51,14 +50,13 @@ class ModelUpdateMessage(
     private fun collectionsJson(
         collections: Map<FieldName, CrdtSet<CrdtEntity.Reference>>
     ): JsonValue<*> {
-        val myList = mutableListOf<JsonValue<*>>()
-        collections.forEach { (name, collection) ->
-            myList.add(JsonValue.JsonObject(
+        val myList = collections.map { (name, collection) ->
+            JsonValue.JsonObject(
                 name to JsonValue.JsonObject(
                     VERSIONMAP to collection.data.versionMap.toJson(),
                     "values" to getValues(collection.data.values)
                 )
-            ))
+            )
         }
         return JsonValue.JsonArray(myList)
     }
@@ -69,14 +67,13 @@ class ModelUpdateMessage(
     private fun singletonsJson(
         singletons: Map<FieldName, CrdtSingleton<CrdtEntity.Reference>>
     ): JsonValue<*> {
-        val myList = mutableListOf<JsonValue<*>>()
-        singletons.forEach { (name, singleton) ->
-            myList.add(JsonValue.JsonObject(
+        val myList = singletons.map { (name, singleton) ->
+            JsonValue.JsonObject(
                 name to JsonValue.JsonObject(
                     VERSIONMAP to singleton.data.versionMap.toJson(),
                     "values" to getValues(singleton.data.values)
                 )
-            ))
+            )
         }
         return JsonValue.JsonArray(myList)
     }
@@ -87,9 +84,8 @@ class ModelUpdateMessage(
     private fun getValues(
         values: MutableMap<ReferenceId, CrdtSet.DataValue<CrdtEntity.Reference>>
     ): JsonValue<*> {
-        val myMap = mutableMapOf<String, JsonValue<*>>()
-        values.forEach { (ref, value) ->
-            myMap[ref] = getValue(value.value)
+        val myMap = values.mapValues { (ref, value) ->
+            value.value.toJson()
         }
         return JsonValue.JsonObject(myMap)
     }

--- a/java/arcs/android/devtools/ModelUpdateMessage.kt
+++ b/java/arcs/android/devtools/ModelUpdateMessage.kt
@@ -39,10 +39,9 @@ class ModelUpdateMessage(
                 "collections" to collectionsJson(model.collections)
             )
         }
-        // TODO(heimlich): other types
+        // TODO(b/162955831): other types
         else -> JsonValue.JsonNull
     }
-
 
     /**
      * Transform the map of names to collections into JSON.

--- a/java/arcs/android/devtools/ModelUpdateMessage.kt
+++ b/java/arcs/android/devtools/ModelUpdateMessage.kt
@@ -1,0 +1,96 @@
+package arcs.android.devtools
+
+import arcs.android.devtools.DevToolsMessage.Companion.MODEL_UPDATE_MESSAGE
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.VERSIONMAP
+import arcs.core.common.ReferenceId
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtEntity
+import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtSet
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.data.FieldName
+import arcs.core.storage.ProxyMessage
+import arcs.core.util.JsonValue
+
+/**
+ * An implementation of [StoreMessage] to inform DevTools that a [Store] received a
+ * [ModelUpdate].
+ */
+class ModelUpdateMessage(
+    private val actualMessage: ProxyMessage.ModelUpdate<CrdtData, CrdtOperation, Any?>,
+    private val storeType: String
+) : StoreMessage {
+    override val kind: String = MODEL_UPDATE_MESSAGE
+    override val message: JsonValue<*>
+        get() = JsonValue.JsonObject(
+            "model" to getModel(actualMessage.model),
+            STORE_TYPE to JsonValue.JsonString(storeType)
+        )
+
+    /**
+     * Transform the [CrdtData] into JSON.
+     */
+    private fun getModel(model: CrdtData): JsonValue<*> {
+        when (model) {
+            is CrdtEntity.Data -> {
+                return JsonValue.JsonObject(
+                    VERSIONMAP to model.versionMap.toJson(),
+                    "singletons" to singletonsJson(model.singletons),
+                    "collections" to collectionsJson(model.collections)
+                )
+            }
+            // TODO(heimlich): other types
+        }
+        return JsonValue.JsonNull
+    }
+
+    /**
+     * Transform the map of names to collections into JSON.
+     */
+    private fun collectionsJson(
+        collections: Map<FieldName, CrdtSet<CrdtEntity.Reference>>
+    ): JsonValue<*> {
+        val myList = mutableListOf<JsonValue<*>>()
+        collections.forEach { (name, collection) ->
+            myList.add(JsonValue.JsonObject(
+                name to JsonValue.JsonObject(
+                    VERSIONMAP to collection.data.versionMap.toJson(),
+                    "values" to getValues(collection.data.values)
+                )
+            ))
+        }
+        return JsonValue.JsonArray(myList)
+    }
+
+    /**
+     * Transform the map of names to singletons into JSON.
+     */
+    private fun singletonsJson(
+        singletons: Map<FieldName, CrdtSingleton<CrdtEntity.Reference>>
+    ): JsonValue<*> {
+        val myList = mutableListOf<JsonValue<*>>()
+        singletons.forEach { (name, singleton) ->
+            myList.add(JsonValue.JsonObject(
+                name to JsonValue.JsonObject(
+                    VERSIONMAP to singleton.data.versionMap.toJson(),
+                    "values" to getValues(singleton.data.values)
+                )
+            ))
+        }
+        return JsonValue.JsonArray(myList)
+    }
+
+    /**
+     * Transform the values of fields into JSON.
+     */
+    private fun getValues(
+        values: MutableMap<ReferenceId, CrdtSet.DataValue<CrdtEntity.Reference>>
+    ): JsonValue<*> {
+        val myMap = mutableMapOf<String, JsonValue<*>>()
+        values.forEach { (ref, value) ->
+            myMap[ref] = getValue(value.value)
+        }
+        return JsonValue.JsonObject(myMap)
+    }
+}

--- a/java/arcs/android/devtools/StoreMessage.kt
+++ b/java/arcs/android/devtools/StoreMessage.kt
@@ -24,46 +24,44 @@ interface StoreMessage : DevToolsMessage {
     }
 
     /**
-     * Get the primitive value of a [Referencable].
+     * Transform a [Referencable] to Json.
      */
-    fun getValue(value: Referencable?): JsonValue<*> {
-        when (value) {
-            is Reference -> {
-                return JsonValue.JsonObject(
-                    "id" to JsonValue.JsonString(value.id),
-                    "storageKey" to JsonValue.JsonString(value.storageKey.toKeyString()),
-                    "version" to (value.version?.toJson() ?: JsonValue.JsonNull),
-                    "creationTimestamp" to JsonValue.JsonNumber(value.creationTimestamp.toDouble()),
-                    "expirationTimestamp" to JsonValue.JsonNumber(
-                        value.expirationTimestamp.toDouble()
-                    )
+    fun Referencable.toJson(): JsonValue<*> = when (this) {
+        is Reference -> {
+            JsonValue.JsonObject(
+                "id" to JsonValue.JsonString(this.id),
+                "storageKey" to JsonValue.JsonString(this.storageKey.toKeyString()),
+                "version" to (this.version?.toJson() ?: JsonValue.JsonNull),
+                "creationTimestamp" to JsonValue.JsonNumber(this.creationTimestamp.toDouble()),
+                "expirationTimestamp" to JsonValue.JsonNumber(
+                    this.expirationTimestamp.toDouble()
                 )
+            )
+        }
+        is RawEntity -> {
+            val map = mutableMapOf<String, JsonValue<*>>()
+            this.singletons.forEach { name, referenceable ->
+                map[name] = referenceable?.toJson() ?: JsonValue.JsonNull
             }
-            is RawEntity -> {
-                val map = mutableMapOf<String, JsonValue<*>>()
-                value.singletons.forEach { name, referenceable ->
-                    map[name] = getValue(referenceable)
-                }
-                return JsonValue.JsonObject(map)
-            }
-            is ReferencablePrimitive<*> -> {
-                val valueValue = value.value
-                return when (valueValue) {
-                    is String -> JsonValue.JsonString(valueValue)
-                    is Boolean -> JsonValue.JsonBoolean(valueValue)
-                    is Double -> JsonValue.JsonNumber(valueValue)
-                    is Byte -> JsonValue.JsonNumber(valueValue.toDouble())
-                    is Int -> JsonValue.JsonNumber(valueValue.toDouble())
-                    is Long -> JsonValue.JsonNumber(valueValue.toDouble())
-                    is Float -> JsonValue.JsonNumber(valueValue.toDouble())
-                    // TODO(heimlich): ByteArray and BigInt
-                    else -> JsonValue.JsonString(value.valueRepr)
-                }
-            }
-            else -> {
-                return JsonValue.JsonString(value.toString())
+            JsonValue.JsonObject(map)
+        }
+        is ReferencablePrimitive<*> -> {
+            val valueValue = this.value
+            when (valueValue) {
+                is String -> JsonValue.JsonString(valueValue)
+                is Boolean -> JsonValue.JsonBoolean(valueValue)
+                is Double -> JsonValue.JsonNumber(valueValue)
+                is Byte -> JsonValue.JsonNumber(valueValue.toDouble())
+                is Int -> JsonValue.JsonNumber(valueValue.toDouble())
+                is Long -> JsonValue.JsonNumber(valueValue.toDouble())
+                is Float -> JsonValue.JsonNumber(valueValue.toDouble())
+                // TODO(heimlich): ByteArray and BigInt
+                else -> JsonValue.JsonString(valueRepr)
             }
         }
-        return JsonValue.JsonNull
+        else -> {
+            JsonValue.JsonString(this.toString())
+        }
     }
+
 }

--- a/java/arcs/android/devtools/StoreMessage.kt
+++ b/java/arcs/android/devtools/StoreMessage.kt
@@ -1,120 +1,21 @@
 package arcs.android.devtools
 
-import arcs.android.devtools.DevToolsMessage.Companion.ACTOR
-import arcs.android.devtools.DevToolsMessage.Companion.ADDED
-import arcs.android.devtools.DevToolsMessage.Companion.ADD_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.CLEAR_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.CLOCK
-import arcs.android.devtools.DevToolsMessage.Companion.FAST_FORWARD_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.OLD_CLOCK
-import arcs.android.devtools.DevToolsMessage.Companion.OPERATIONS
-import arcs.android.devtools.DevToolsMessage.Companion.REMOVED
-import arcs.android.devtools.DevToolsMessage.Companion.REMOVE_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.STORE_ID
-import arcs.android.devtools.DevToolsMessage.Companion.STORE_MESSAGE
-import arcs.android.devtools.DevToolsMessage.Companion.TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.UPDATE_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.VALUE
 import arcs.core.common.Referencable
-import arcs.core.crdt.CrdtData
-import arcs.core.crdt.CrdtOperation
-import arcs.core.crdt.CrdtSet
-import arcs.core.crdt.CrdtSingleton
 import arcs.core.crdt.VersionMap
 import arcs.core.data.RawEntity
 import arcs.core.data.util.ReferencablePrimitive
-import arcs.core.storage.ProxyMessage
+import arcs.core.storage.Reference
 import arcs.core.util.JsonValue
 
 /**
- * An implementation of [DevToolsMessage] to inform DevTools that a [Store] received a
- * [CrdtOperation].
+ * A child class of [DevToolsMessage] that better represents messages from [Store]s.
  */
-class StoreMessage(
-    private val actualMessage: ProxyMessage.Operations<CrdtData, CrdtOperation, Any?>
-) : DevToolsMessage {
-    override val kind: String = STORE_MESSAGE
-    override val message: JsonValue<*>
-        get() = JsonValue.JsonObject(
-            STORE_ID to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
-            OPERATIONS to JsonValue.JsonArray(getMessageAsList())
-        )
-
-    /**
-     * Turn the ProxyMessage into a List of JsonValues.
-     */
-    private fun getMessageAsList(): List<JsonValue<*>> {
-        val list = mutableListOf<JsonValue<*>>()
-        actualMessage.operations.forEach { op ->
-            when (op) {
-                is CrdtSingleton.Operation.Update<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(UPDATE_TYPE),
-                            VALUE to getValue(op.value),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
-                    )
-                }
-                is CrdtSingleton.Operation.Clear<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
-                    )
-                }
-                is CrdtSet.Operation.Add<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(ADD_TYPE),
-                            ADDED to getValue(op.added),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
-                    )
-                }
-                is CrdtSet.Operation.Clear<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
-                    )
-                }
-                is CrdtSet.Operation.Remove<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(REMOVE_TYPE),
-                            REMOVED to getValue(op.removed),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
-                    )
-                }
-                is CrdtSet.Operation.FastForward<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
-                            ADDED to getAddedListValue(op.added),
-                            REMOVED to getRemovedListValue(op.removed),
-                            OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
-                            CLOCK to op.clock.toJson()
-                        )
-                    )
-                }
-            }
-        }
-        return list
-    }
+interface StoreMessage : DevToolsMessage {
 
     /**
      * Turn the clock [VersionMap] into a [JsonValue.JsonObject].
      */
-    private fun VersionMap.toJson(): JsonValue<*> {
+    fun VersionMap.toJson(): JsonValue<*> {
         val map = mutableMapOf<String, JsonValue<*>>()
         actors.forEach {
             map.put(it, JsonValue.JsonNumber(this[it].toDouble()))
@@ -123,34 +24,21 @@ class StoreMessage(
     }
 
     /**
-     * Return the items in the removed list as a JsonArray
-     */
-    private fun getRemovedListValue(list: MutableList<out Referencable>): JsonValue.JsonArray {
-        val array = mutableListOf<JsonValue<*>>()
-        list.forEach {
-            array.add(getValue(it))
-        }
-        return JsonValue.JsonArray(array)
-    }
-
-    /**
-     * Return the items in the added list as a JsonArray
-     */
-    private fun getAddedListValue(
-        list: MutableList<out CrdtSet.DataValue<out Referencable>>
-    ): JsonValue.JsonArray {
-        val array = mutableListOf<JsonValue<*>>()
-        list.forEach {
-            array.add(getValue(it.value))
-        }
-        return JsonValue.JsonArray(array)
-    }
-
-    /**
      * Get the primitive value of a [Referencable].
      */
-    private fun getValue(value: Referencable?): JsonValue<*> {
+    fun getValue(value: Referencable?): JsonValue<*> {
         when (value) {
+            is Reference -> {
+                return JsonValue.JsonObject(
+                    "id" to JsonValue.JsonString(value.id),
+                    "storageKey" to JsonValue.JsonString(value.storageKey.toKeyString()),
+                    "version" to (value.version?.toJson() ?: JsonValue.JsonNull),
+                    "creationTimestamp" to JsonValue.JsonNumber(value.creationTimestamp.toDouble()),
+                    "expirationTimestamp" to JsonValue.JsonNumber(
+                        value.expirationTimestamp.toDouble()
+                    )
+                )
+            }
             is RawEntity -> {
                 val map = mutableMapOf<String, JsonValue<*>>()
                 value.singletons.forEach { name, referenceable ->
@@ -171,6 +59,9 @@ class StoreMessage(
                     // TODO(heimlich): ByteArray and BigInt
                     else -> JsonValue.JsonString(value.valueRepr)
                 }
+            }
+            else -> {
+                return JsonValue.JsonString(value.toString())
             }
         }
         return JsonValue.JsonNull

--- a/java/arcs/android/devtools/StoreMessage.kt
+++ b/java/arcs/android/devtools/StoreMessage.kt
@@ -55,7 +55,7 @@ interface StoreMessage : DevToolsMessage {
                 is Int -> JsonValue.JsonNumber(valueValue.toDouble())
                 is Long -> JsonValue.JsonNumber(valueValue.toDouble())
                 is Float -> JsonValue.JsonNumber(valueValue.toDouble())
-                // TODO(heimlich): ByteArray and BigInt
+                // TODO(b/162955831): ByteArray and BigInt
                 else -> JsonValue.JsonString(valueRepr)
             }
         }
@@ -63,5 +63,4 @@ interface StoreMessage : DevToolsMessage {
             JsonValue.JsonString(this.toString())
         }
     }
-
 }

--- a/java/arcs/android/devtools/StoreOperationMessage.kt
+++ b/java/arcs/android/devtools/StoreOperationMessage.kt
@@ -45,75 +45,75 @@ class StoreOperationMessage(
     /**
      * Turn the ProxyMessage into a List of JsonValues.
      */
-    private fun ProxyMessage.Operations<CrdtData, CrdtOperation, Any?>.toJson(): JsonValue.JsonArray {
-        val list = operations.map { op ->
-            when (op) {
-                is CrdtSingleton.Operation.Update<*> -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(UPDATE_TYPE),
-                        VALUE to op.value.toJson(),
-                        ACTOR to JsonValue.JsonString(op.actor),
-                        CLOCK to op.clock.toJson()
-                    )
+    private fun ProxyMessage.Operations<CrdtData, CrdtOperation, Any?>.toJson() =
+        JsonValue.JsonArray(
+            operations.map { op ->
+                when (op) {
+                    is CrdtSingleton.Operation.Update<*> -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(UPDATE_TYPE),
+                            VALUE to op.value.toJson(),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    is CrdtSingleton.Operation.Clear<*> -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    is CrdtSet.Operation.Add<*> -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(ADD_TYPE),
+                            ADDED to op.added.toJson(),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    is CrdtSet.Operation.Clear<*> -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    is CrdtSet.Operation.Remove<*> -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(REMOVE_TYPE),
+                            REMOVED to op.removed.toJson(),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    is CrdtSet.Operation.FastForward<*> -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
+                            ADDED to getAddedListValue(op.added),
+                            REMOVED to getRemovedListValue(op.removed),
+                            OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    is CrdtEntity.Operation.ClearAll -> {
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(CLEAR_ALL_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    }
+                    else -> JsonValue.JsonString(op.toString())
                 }
-                is CrdtSingleton.Operation.Clear<*> -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(CLEAR_TYPE),
-                        ACTOR to JsonValue.JsonString(op.actor),
-                        CLOCK to op.clock.toJson()
-                    )
-                }
-                is CrdtSet.Operation.Add<*> -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(ADD_TYPE),
-                        ADDED to op.added.toJson(),
-                        ACTOR to JsonValue.JsonString(op.actor),
-                        CLOCK to op.clock.toJson()
-                    )
-                }
-                is CrdtSet.Operation.Clear<*> -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(CLEAR_TYPE),
-                        ACTOR to JsonValue.JsonString(op.actor),
-                        CLOCK to op.clock.toJson()
-                    )
-                }
-                is CrdtSet.Operation.Remove<*> -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(REMOVE_TYPE),
-                        REMOVED to op.removed.toJson(),
-                        ACTOR to JsonValue.JsonString(op.actor),
-                        CLOCK to op.clock.toJson()
-                    )
-                }
-                is CrdtSet.Operation.FastForward<*> -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
-                        ADDED to getAddedListValue(op.added),
-                        REMOVED to getRemovedListValue(op.removed),
-                        OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
-                        CLOCK to op.clock.toJson()
-                    )
-                }
-                is CrdtEntity.Operation.ClearAll -> {
-                    JsonValue.JsonObject(
-                        TYPE to JsonValue.JsonString(CLEAR_ALL_TYPE),
-                        ACTOR to JsonValue.JsonString(op.actor),
-                        CLOCK to op.clock.toJson()
-                    )
-                }
-                else -> JsonValue.JsonString(op.toString())
             }
-        }
-        return JsonValue.JsonArray(list)
-    }
+        )
 
     /**
      * Return the items in the removed list as a JsonArray
      */
     private fun getRemovedListValue(list: MutableList<out Referencable>): JsonValue.JsonArray {
         val array = list.map {
-           it.toJson()
+            it.toJson()
         }
         return JsonValue.JsonArray(array)
     }

--- a/java/arcs/android/devtools/StoreOperationMessage.kt
+++ b/java/arcs/android/devtools/StoreOperationMessage.kt
@@ -39,96 +39,81 @@ class StoreOperationMessage(
         get() = JsonValue.JsonObject(
             STORE_ID to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
             STORE_TYPE to JsonValue.JsonString(storeType),
-            OPERATIONS to JsonValue.JsonArray(getMessageAsList())
+            OPERATIONS to actualMessage.toJson()
         )
 
     /**
      * Turn the ProxyMessage into a List of JsonValues.
      */
-    private fun getMessageAsList(): List<JsonValue<*>> {
-        val list = mutableListOf<JsonValue<*>>()
-        actualMessage.operations.forEach { op ->
+    private fun ProxyMessage.Operations<CrdtData, CrdtOperation, Any?>.toJson(): JsonValue.JsonArray {
+        val list = operations.map { op ->
             when (op) {
                 is CrdtSingleton.Operation.Update<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(UPDATE_TYPE),
-                            VALUE to getValue(op.value),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(UPDATE_TYPE),
+                        VALUE to op.value.toJson(),
+                        ACTOR to JsonValue.JsonString(op.actor),
+                        CLOCK to op.clock.toJson()
                     )
                 }
                 is CrdtSingleton.Operation.Clear<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                        ACTOR to JsonValue.JsonString(op.actor),
+                        CLOCK to op.clock.toJson()
                     )
                 }
                 is CrdtSet.Operation.Add<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(ADD_TYPE),
-                            ADDED to getValue(op.added),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(ADD_TYPE),
+                        ADDED to op.added.toJson(),
+                        ACTOR to JsonValue.JsonString(op.actor),
+                        CLOCK to op.clock.toJson()
                     )
                 }
                 is CrdtSet.Operation.Clear<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                        ACTOR to JsonValue.JsonString(op.actor),
+                        CLOCK to op.clock.toJson()
                     )
                 }
                 is CrdtSet.Operation.Remove<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(REMOVE_TYPE),
-                            REMOVED to getValue(op.removed),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(REMOVE_TYPE),
+                        REMOVED to op.removed.toJson(),
+                        ACTOR to JsonValue.JsonString(op.actor),
+                        CLOCK to op.clock.toJson()
                     )
                 }
                 is CrdtSet.Operation.FastForward<*> -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
-                            ADDED to getAddedListValue(op.added),
-                            REMOVED to getRemovedListValue(op.removed),
-                            OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
+                        ADDED to getAddedListValue(op.added),
+                        REMOVED to getRemovedListValue(op.removed),
+                        OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
+                        CLOCK to op.clock.toJson()
                     )
                 }
                 is CrdtEntity.Operation.ClearAll -> {
-                    list.add(
-                        JsonValue.JsonObject(
-                            TYPE to JsonValue.JsonString(CLEAR_ALL_TYPE),
-                            ACTOR to JsonValue.JsonString(op.actor),
-                            CLOCK to op.clock.toJson()
-                        )
+                    JsonValue.JsonObject(
+                        TYPE to JsonValue.JsonString(CLEAR_ALL_TYPE),
+                        ACTOR to JsonValue.JsonString(op.actor),
+                        CLOCK to op.clock.toJson()
                     )
                 }
+                else -> JsonValue.JsonString(op.toString())
             }
         }
-        return list
+        return JsonValue.JsonArray(list)
     }
 
     /**
      * Return the items in the removed list as a JsonArray
      */
     private fun getRemovedListValue(list: MutableList<out Referencable>): JsonValue.JsonArray {
-        val array = mutableListOf<JsonValue<*>>()
-        list.forEach {
-            array.add(getValue(it))
+        val array = list.map {
+           it.toJson()
         }
         return JsonValue.JsonArray(array)
     }
@@ -139,9 +124,8 @@ class StoreOperationMessage(
     private fun getAddedListValue(
         list: MutableList<out CrdtSet.DataValue<out Referencable>>
     ): JsonValue.JsonArray {
-        val array = mutableListOf<JsonValue<*>>()
-        list.forEach {
-            array.add(getValue(it.value))
+        val array = list.map {
+            it.value.toJson()
         }
         return JsonValue.JsonArray(array)
     }

--- a/java/arcs/android/devtools/StoreOperationMessage.kt
+++ b/java/arcs/android/devtools/StoreOperationMessage.kt
@@ -1,0 +1,148 @@
+package arcs.android.devtools
+
+import arcs.android.devtools.DevToolsMessage.Companion.ACTOR
+import arcs.android.devtools.DevToolsMessage.Companion.ADDED
+import arcs.android.devtools.DevToolsMessage.Companion.ADD_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.CLEAR_ALL_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.CLEAR_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.CLOCK
+import arcs.android.devtools.DevToolsMessage.Companion.FAST_FORWARD_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.OLD_CLOCK
+import arcs.android.devtools.DevToolsMessage.Companion.OPERATIONS
+import arcs.android.devtools.DevToolsMessage.Companion.REMOVED
+import arcs.android.devtools.DevToolsMessage.Companion.REMOVE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_ID
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_OP_MESSAGE
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.UPDATE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.VALUE
+import arcs.core.common.Referencable
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtEntity
+import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtSet
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.storage.ProxyMessage
+import arcs.core.util.JsonValue
+
+/**
+ * An implementation of [StoreMessage] to inform DevTools that a [Store] received a
+ * [CrdtOperation].
+ */
+class StoreOperationMessage(
+    private val actualMessage: ProxyMessage.Operations<CrdtData, CrdtOperation, Any?>,
+    private val storeType: String
+) : StoreMessage {
+    override val kind: String = STORE_OP_MESSAGE
+    override val message: JsonValue<*>
+        get() = JsonValue.JsonObject(
+            STORE_ID to JsonValue.JsonNumber(actualMessage.id?.toDouble() ?: 0.0),
+            STORE_TYPE to JsonValue.JsonString(storeType),
+            OPERATIONS to JsonValue.JsonArray(getMessageAsList())
+        )
+
+    /**
+     * Turn the ProxyMessage into a List of JsonValues.
+     */
+    private fun getMessageAsList(): List<JsonValue<*>> {
+        val list = mutableListOf<JsonValue<*>>()
+        actualMessage.operations.forEach { op ->
+            when (op) {
+                is CrdtSingleton.Operation.Update<*> -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(UPDATE_TYPE),
+                            VALUE to getValue(op.value),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+                is CrdtSingleton.Operation.Clear<*> -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+                is CrdtSet.Operation.Add<*> -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(ADD_TYPE),
+                            ADDED to getValue(op.added),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+                is CrdtSet.Operation.Clear<*> -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(CLEAR_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+                is CrdtSet.Operation.Remove<*> -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(REMOVE_TYPE),
+                            REMOVED to getValue(op.removed),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+                is CrdtSet.Operation.FastForward<*> -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
+                            ADDED to getAddedListValue(op.added),
+                            REMOVED to getRemovedListValue(op.removed),
+                            OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+                is CrdtEntity.Operation.ClearAll -> {
+                    list.add(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(CLEAR_ALL_TYPE),
+                            ACTOR to JsonValue.JsonString(op.actor),
+                            CLOCK to op.clock.toJson()
+                        )
+                    )
+                }
+            }
+        }
+        return list
+    }
+
+    /**
+     * Return the items in the removed list as a JsonArray
+     */
+    private fun getRemovedListValue(list: MutableList<out Referencable>): JsonValue.JsonArray {
+        val array = mutableListOf<JsonValue<*>>()
+        list.forEach {
+            array.add(getValue(it))
+        }
+        return JsonValue.JsonArray(array)
+    }
+
+    /**
+     * Return the items in the added list as a JsonArray
+     */
+    private fun getAddedListValue(
+        list: MutableList<out CrdtSet.DataValue<out Referencable>>
+    ): JsonValue.JsonArray {
+        val array = mutableListOf<JsonValue<*>>()
+        list.forEach {
+            array.add(getValue(it.value))
+        }
+        return JsonValue.JsonArray(array)
+    }
+}

--- a/javatests/arcs/android/devtools/BUILD
+++ b/javatests/arcs/android/devtools/BUILD
@@ -1,27 +1,19 @@
-load("//third_party/java/arcs/build_defs:build_defs.bzl", "arcs_kt_android_library")
-load("//tools/build_defs/android:rules.bzl", "android_library")
+load(
+    "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_jvm_test_suite",
+)
 
 licenses(["notice"])
 
 package(default_visibility = ["//java/arcs:allowed-packages"])
 
-android_library(
-    name = "aidl",
-    testonly = True,
-    idl_srcs = glob(["*.aidl"]),
-    manifest = "//java/arcs/android/common:AndroidManifest.xml",
-)
-
-arcs_kt_android_library(
-    name = "devtools",
-    testonly = True,
-    srcs = glob([
-        "*.kt",
-    ]),
-    manifest = "AndroidManifest.xml",
-    resource_files = glob(["res/**/*"]),
+arcs_kt_jvm_test_suite(
+    name = "store-message",
+    srcs = glob(["*Test.kt"]),
+    package = "arcs.android.devtools",
     deps = [
-        ":aidl",
+        "//java/arcs/android/devtools",
+        "//java/arcs/android/devtools:aidl",
         "//java/arcs/android/devtools/storage:devtools",
         "//java/arcs/android/storage",
         "//java/arcs/android/storage/service",
@@ -31,12 +23,13 @@ arcs_kt_android_library(
         "//java/arcs/core/data:rawentity",
         "//java/arcs/core/data/util:data-util",
         "//java/arcs/core/storage:proxy",
-        "//java/arcs/core/storage:reference",
-        "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/util",
         "//java/arcs/sdk/android/storage/service",
+        "//third_party/java/junit:junit-android",
         "//third_party/java/nanohttpd",
         "//third_party/java/nanohttpd:nanohttpd_websocket",
+        "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
     ],
 )

--- a/javatests/arcs/android/devtools/DevToolsMessageTests.kt
+++ b/javatests/arcs/android/devtools/DevToolsMessageTests.kt
@@ -1,0 +1,124 @@
+package arcs.android.devtools
+
+import arcs.android.devtools.DevToolsMessage.Companion.ACTOR
+import arcs.android.devtools.DevToolsMessage.Companion.CLOCK
+import arcs.android.devtools.DevToolsMessage.Companion.KIND
+import arcs.android.devtools.DevToolsMessage.Companion.MESSAGE
+import arcs.android.devtools.DevToolsMessage.Companion.MODEL_UPDATE_MESSAGE
+import arcs.android.devtools.DevToolsMessage.Companion.OPERATIONS
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_ID
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_OP_MESSAGE
+import arcs.android.devtools.DevToolsMessage.Companion.STORE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.UPDATE_TYPE
+import arcs.android.devtools.DevToolsMessage.Companion.VALUE
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtEntity
+import arcs.core.crdt.CrdtOperation
+import arcs.core.crdt.CrdtSingleton
+import arcs.core.crdt.VersionMap
+import arcs.core.data.util.ReferencablePrimitive
+import arcs.core.storage.ProxyMessage
+import arcs.core.util.JsonValue
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class DevToolsMessageTests {
+
+    @Test
+    fun storeOperationMessageTest() = runBlockingTest {
+        val expected = JsonValue.JsonObject(
+            KIND to JsonValue.JsonString(STORE_OP_MESSAGE),
+            MESSAGE to JsonValue.JsonObject(
+                STORE_ID to JsonValue.JsonNumber(1.toDouble()),
+                STORE_TYPE to JsonValue.JsonString("Direct"),
+                OPERATIONS to JsonValue.JsonArray(
+                    listOf(
+                        JsonValue.JsonObject(
+                            TYPE to JsonValue.JsonString(UPDATE_TYPE),
+                            VALUE to JsonValue.JsonString("foo"),
+                            ACTOR to JsonValue.JsonString("bar"),
+                            CLOCK to JsonValue.JsonObject(
+                                "fooBar" to JsonValue.JsonNumber(1.toDouble())
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val proxyMessage = ProxyMessage.Operations<CrdtData, CrdtOperation, Any?>(
+            listOf(
+                CrdtSingleton.Operation.Update(
+                    value = ReferencablePrimitive(String::class, "foo"),
+                    actor = "bar",
+                    clock = VersionMap(mapOf("fooBar" to 1))
+                )
+            ),
+            id = 1
+        )
+        val message = StoreOperationMessage(proxyMessage, "Direct").toJson()
+        assertThat(message).isEqualTo(expected.toString())
+    }
+
+    @Test
+    fun ModelUpdateMessageTest() = runBlockingTest {
+        val referenceA: CrdtEntity.Reference = CrdtEntity.ReferenceImpl("AAA")
+        val referenceB: CrdtEntity.Reference = CrdtEntity.ReferenceImpl("BBB")
+        val expected = JsonValue.JsonObject(
+            KIND to JsonValue.JsonString(MODEL_UPDATE_MESSAGE),
+            MESSAGE to JsonValue.JsonObject(
+                "model" to JsonValue.JsonObject(
+                    DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
+                        "Bar" to JsonValue.JsonNumber(2.toDouble())
+                    ),
+                    "singletons" to JsonValue.JsonArray(
+                        listOf(
+                            JsonValue.JsonObject(
+                                "a" to JsonValue.JsonObject(
+                                    DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
+                                        "alice" to JsonValue.JsonNumber(1.toDouble())
+                                    ),
+                                    "values" to JsonValue.JsonObject(
+                                        "AAA" to JsonValue.JsonString("Reference(AAA)")
+                                    )
+                                )
+                            ),
+                            JsonValue.JsonObject(
+                                "b" to JsonValue.JsonObject(
+                                    DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
+                                        "bob" to JsonValue.JsonNumber(1.toDouble())
+                                    ),
+                                    "values" to JsonValue.JsonObject(
+                                        "BBB" to JsonValue.JsonString("Reference(BBB)")
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "collections" to JsonValue.JsonArray()
+                ),
+                STORE_TYPE to JsonValue.JsonString("Direct")
+            )
+        )
+
+        val proxyMessage = ProxyMessage.ModelUpdate<CrdtData, CrdtOperation, Any?>(
+            model = CrdtEntity.Data(
+                singletons = mapOf(
+                    "a" to CrdtSingleton(VersionMap("alice" to 1), referenceA),
+                    "b" to CrdtSingleton(VersionMap("bob" to 1), referenceB)
+                ),
+                collections = mutableMapOf(),
+                versionMap = VersionMap("Bar" to 2),
+                creationTimestamp = 971,
+                expirationTimestamp = -1
+            ),
+            id = 1
+        )
+        val message = ModelUpdateMessage(proxyMessage, "Direct").toJson()
+        assertThat(message).isEqualTo(expected.toString())
+    }
+}


### PR DESCRIPTION
The goal of this PR is to properly format messages sent from the DirectStore to DevTools clients. To accomplish this, some refactoring occurred in parallel to not accumulate tech-debt. A good chunk of the PR is just moving methods to different classes or extracting (now) common behavior into methods. Details below:

- Rename StoreMessage to StoreOperationsMessage
- Factor out common methods into a StoreMessage class
- Add "storetype" field to StoreMessages
- Create ModelUpdateMessage class
- Extract common usage in DevToolsService into `createAndSendProxyMessages` function
- Add DevToolsMessageTests

cc: @piotrswigon 