### PR TITLE
Wrap RamDisk.clear() in runBlocking

### DIFF
--- a/javatests/arcs/android/e2e/testapp/TestApplication.kt
+++ b/javatests/arcs/android/e2e/testapp/TestApplication.kt
@@ -18,6 +18,7 @@ import arcs.android.util.initLogForAndroid
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.util.Log
+import kotlinx.coroutines.runBlocking
 
 /** Application class for Arcs Test. */
 class TestApplication : Application(), Configuration.Provider {
@@ -29,7 +30,7 @@ class TestApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
-        RamDisk.clear()
+        runBlocking { RamDisk.clear() }
         DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(this))
         initLogForAndroid(Log.Level.Debug)
     }


### PR DESCRIPTION
This runBlocking around the call to `RamDisk.clear()` in TestApplication's `onCreate` is necessary to accommodate some changes coming internally where RamDisk and VolatileMemory's operations are becoming suspend functions.