### PR TITLE
Don't use 'return await' to return the result of an async function from an async function

### DIFF
--- a/config/eslintrc.json
+++ b/config/eslintrc.json
@@ -37,6 +37,7 @@
 
     "no-trailing-spaces": "error",
     "eol-last": "error",
+    "no-return-await": "error",
 
     // Things we do, but probably shouldn't.
     "no-console": "off",

--- a/particles/Processing/js/tf.js
+++ b/particles/Processing/js/tf.js
@@ -68,7 +68,7 @@ self.Tf = class {
     };
   }
   async getTopKClasses({ref: yHat}, labels, topK) {
-    return await this.call('tf.getTopKClasses', {yHat, labels: labels.map(l => l.label), topK});
+    return this.call('tf.getTopKClasses', {yHat, labels: labels.map(l => l.label), topK});
   }
 };
 
@@ -86,7 +86,7 @@ self.TfMixin = Base => class extends Base {
       // because Singleton is undefined.
       if (handle.type.isEntity) {
         const entity = value.entityClass ? value : new (handle.entityClass)(value);
-        return await handle.set(entity);
+        return handle.set(entity);
       }
       else if (handle.type.isCollection) {
         if (Array.isArray(value)) {

--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -72,7 +72,7 @@ export class ArcHost {
     return serialization;
   }
   async _spawn(context, composer, storage, id, serialization, portFactories) {
-    return await Runtime.spawnArc({
+    return Runtime.spawnArc({
       id,
       context,
       composer,

--- a/shells/lib/context-listeners.js
+++ b/shells/lib/context-listeners.js
@@ -16,9 +16,7 @@ import {ContextStores} from './context-stores.js';
 import {simpleNameOfType, boxes, crackStorageKey} from './context-utils.js';
 
 // Existence and purpose of launcher arc are Shell conventions
-const getLauncherStore = async storage => {
-  return await SyntheticStores.getStore(storage, Const.DEFAULT.launcherId);
-};
+const getLauncherStore = async storage => SyntheticStores.getStore(storage, Const.DEFAULT.launcherId);
 
 const AbstractListener = class {
   constructor(listener) {

--- a/shells/lib/context-utils.js
+++ b/shells/lib/context-utils.js
@@ -16,7 +16,7 @@ export const listenToStore = (store, onchange) => {
 };
 
 export const getStoreData = async store => {
-  return store.toList ? await store.toList() : await store.get();
+  return store.toList ? store.toList() : store.get();
 };
 
 export const forEachEntity = async (store, fn) => {

--- a/shells/lib/stores.js
+++ b/shells/lib/stores.js
@@ -15,21 +15,17 @@ export class Stores {
   static async create(context, options) {
     const schemaType = Type.fromLiteral(options.schema);
     const typeOf = options.isCollection ? schemaType.collectionOf() : schemaType;
-    const store = await this.requireStore(context, typeOf, options);
-    return store;
+    return this.requireStore(context, typeOf, options);
   }
   static async requireStore(context, type, {name, id, tags, claims, storageKey}) {
     const store = context.findStoreById(id);
-    if (store) {
-      return store;
-    }
-    return await this.createStore(context, type, {name, id, tags, claims, storageKey});
+    return store || this.createStore(context, type, {name, id, tags, claims, storageKey});
   }
   static async createStore(context, type, {name, id, tags, claims, storageKey}) {
     if (context instanceof Arc) {
-      return await context.createStore(type, name, id, tags, claims, storageKey);
+      return context.createStore(type, name, id, tags, claims, storageKey);
     } else {
-      return await ManifestPatch.createStore.call(context, type, name, id, tags, claims, storageKey);
+      return ManifestPatch.createStore.call(context, type, name, id, tags, claims, storageKey);
     }
   }
 }

--- a/shells/lib/synthetic-stores.js
+++ b/shells/lib/synthetic-stores.js
@@ -18,12 +18,12 @@ export class SyntheticStores {
       const handles = await handleStore.toList();
       const handle = handles[0];
       if (handle) {
-        return await SyntheticStores.getHandleStore(handle);
+        return SyntheticStores.getHandleStore(handle);
       }
     }
   }
   static async getStore(storage, arcid) {
-    return await SyntheticStores.connectToKind('handles', storage, arcid);
+    return SyntheticStores.connectToKind('handles', storage, arcid);
   }
   static async connectToKind(kind, storage, arcid) {
     // delimiter problems
@@ -33,7 +33,7 @@ export class SyntheticStores {
     return SyntheticStores.storeConnect(null, `synthetic://arc/${kind}/${storage}/${arcid}`);
   }
   static async getHandleStore(handle) {
-    return await SyntheticStores.storeConnect(handle.type, handle.storageKey);
+    return SyntheticStores.storeConnect(handle.type, handle.storageKey);
   }
   static async storeConnect(type, storageKey) {
     return SyntheticStores.providerFactory.connect(SyntheticStores.makeId(), type, storageKey);

--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -25,7 +25,7 @@ export const busReady = async (bus, {manifest}) => {
     // TODO(sjmiles): config.manifest: allow configuring mainfest via runtime argument
     // for back-compat (deprecated)
     config.manifest = manifest || config.manifest;
-    return await configureRuntime(config, bus);
+    return configureRuntime(config, bus);
   };
   bus.send({message: 'ready'});
 };
@@ -47,7 +47,7 @@ const requireContext = async manifest => {
     requireContext.promise = Runtime.parse(manifest);
     window.context = await requireContext.promise;
   }
-  return await requireContext.promise;
+  return requireContext.promise;
 };
 
 const contextReady = async (bus, context) => {
@@ -61,23 +61,23 @@ const populateDispatcher = (dispatcher, storage, context) => {
   const runtime = Runtime.getRuntime();
   Object.assign(dispatcher, {
     pec: async (msg, bus) => {
-      return await pec(msg, bus);
+      return pec(msg, bus);
     },
     runArc: async (msg, bus) => {
-      const runArcTask = async () => await runArc(msg, bus, runtime, storage);
-      return await serializeVerb('runArc', runArcTask);
+      const runArcTask = async () => runArc(msg, bus, runtime, storage);
+      return serializeVerb('runArc', runArcTask);
     },
     uiEvent: async (msg, bus) => {
-      return await event(msg, runtime);
+      return event(msg, runtime);
     },
     event: async (msg, bus) => {
-      return await event(msg, runtime);
+      return event(msg, runtime);
     },
     stopArc: async (msg, bus) => {
-      return await stopArc(msg, runtime);
+      return stopArc(msg, runtime);
     },
     parse: async (msg, bus) => {
-      return await parse(msg, bus);
+      return parse(msg, bus);
     }
   });
   return dispatcher;

--- a/shells/pipes-shell/source/verbs/pec.js
+++ b/shells/pipes-shell/source/verbs/pec.js
@@ -9,6 +9,4 @@
  */
 import {handlePecMessage} from '../pec-port.js';
 
-export const pec = async (msg, tid, bus) => {
-  return await handlePecMessage(msg, tid, bus);
-};
+export const pec = async (msg, tid, bus) => handlePecMessage(msg, tid, bus);

--- a/shells/tests/specs/pipes-shell-test.js
+++ b/shells/tests/specs/pipes-shell-test.js
@@ -54,6 +54,5 @@ const client = {
   }
 };
 
-const waitForPipeOutput = async msg => {
-  return await waitFor(`[title*="${msg}"]`);
-};
+const waitForPipeOutput = async msg => waitFor(`[title*="${msg}"]`);
+

--- a/src/dataflow/analysis/tests/analysis-test.ts
+++ b/src/dataflow/analysis/tests/analysis-test.ts
@@ -1213,7 +1213,7 @@ describe('FlowGraph validation', () => {
     });
 
     it('fails when the data store identified by name is missing', async () => {
-      await assertThrowsAsync(async () => await buildFlowGraph(`
+      await assertThrowsAsync(async () => buildFlowGraph(`
         particle P
           input: reads Foo {}
           check input is from store MyStore
@@ -1224,7 +1224,7 @@ describe('FlowGraph validation', () => {
     });
 
     it('fails when the data store identified by ID is missing', async () => {
-      await assertThrowsAsync(async () => await buildFlowGraph(`
+      await assertThrowsAsync(async () => buildFlowGraph(`
         particle P
           input: reads Foo {}
           check input is from store 'my-store-id'
@@ -1235,7 +1235,7 @@ describe('FlowGraph validation', () => {
     });
 
     it('fails when the data store is not connected', async () => {
-      await assertThrowsAsync(async () => await buildFlowGraph(`
+      await assertThrowsAsync(async () => buildFlowGraph(`
         schema MyEntity
           text: Text
         resource MyResource

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -115,7 +115,7 @@ describe('remote planificator', () => {
   }
 
   async function delay(ms) {
-    return await new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   async function verifyReplanning(producePlanificator, expectedSuggestions, expectedDescriptions = []) {

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -141,7 +141,7 @@ recipe R3
       const result = new PlanningResult({context: arc.context, loader});
 
       const suggestions: Suggestion[] = await Promise.all(
-          manifest.recipes.map(async plan => await planToSuggestion(plan)) as Promise<Suggestion>[]
+        manifest.recipes.map(async plan => planToSuggestion(plan)) as Promise<Suggestion>[]
       );
       result.merge({suggestions}, arc);
       return result;

--- a/src/planning/strategies/tests/coalesce-recipes-test.ts
+++ b/src/planning/strategies/tests/coalesce-recipes-test.ts
@@ -32,7 +32,7 @@ describe('CoalesceRecipes', () => {
     const arc = StrategyTestHelper.createTestArc(manifest);
     const strategy = new CoalesceRecipes(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = {generated: [], terminal: recipes.map(recipe => ({result: recipe, score: 1}))};
-    return await strategy.generate(inputParams);
+    return strategy.generate(inputParams);
   }
 
   async function doNotCoalesceRecipes(manifestStr: string) {

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -80,7 +80,7 @@ describe('ConvertConstraintsToConnections', () => {
   });
 
   it('can create handle for input and output handle', async () => {
-    const parseManifest = async (constraint1, constraint2) => await Manifest.parse(`
+    const parseManifest = async (constraint1, constraint2) => Manifest.parse(`
       schema S
       particle A
         b: reads S

--- a/src/planning/strategies/tests/match-recipe-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-recipe-by-verb-test.ts
@@ -110,7 +110,7 @@ ${recipesManifest}`);
     const arc = StrategyTestHelper.createTestArc(manifest);
     const generated = [{result: manifest.recipes[manifest.recipes.length-1], score: 1}];
     const mrv = new MatchRecipeByVerb(arc);
-    return await mrv.generateFrom(generated);
+    return mrv.generateFrom(generated);
   };
 
   const slandlesSyntaxBasicHandlesContraintsManifest = `
@@ -143,7 +143,7 @@ ${recipesManifest}`);
     const arc = StrategyTestHelper.createTestArc(manifest);
     const generated = [{result: manifest.recipes[manifest.recipes.length-1], score: 1}];
     const mrv = new MatchRecipeByVerb(arc);
-    return await mrv.generateFrom(generated);
+    return mrv.generateFrom(generated);
   };
 
   it('listens to handle constraints - all recipes', async () => {

--- a/src/platform/dynamic-script-node.ts
+++ b/src/platform/dynamic-script-node.ts
@@ -10,5 +10,5 @@
 
 export async function dynamicScript(src: string): Promise<unknown> {
   // @ts-ignore TS1323 dynamic import
-  return await import(src);
+  return import(src);
 }

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -104,7 +104,7 @@ export class Description {
   }
 
   private static async initDescriptionHandles(allParticles: Particle[], arc?: Arc, relevance?: Relevance): Promise<ParticleDescription[]> {
-    return await Promise.all(
+    return Promise.all(
       allParticles.map(particle => Description._createParticleDescription(particle, arc, relevance)));
   }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -406,20 +406,15 @@ export class Manifest {
     let {registry, memoryProvider} = options;
     registry = registry || {};
     if (registry && registry[fileName]) {
-      return await registry[fileName];
+      return registry[fileName];
     }
     registry[fileName] = (async () => {
       const content: string = await loader.loadResource(fileName);
       // TODO: When does this happen? The loader should probably throw an exception here.
       assert(content !== undefined, `${fileName} unable to be loaded by Manifest parser`);
-      return await Manifest.parse(content, {
-        fileName,
-        loader,
-        registry,
-        memoryProvider
-      });
+      return Manifest.parse(content, {fileName, loader, registry, memoryProvider});
     })();
-    return await registry[fileName];
+    return registry[fileName];
   }
 
   static getErrors(manifest: Manifest): ManifestError[] {

--- a/src/runtime/particle.ts
+++ b/src/runtime/particle.ts
@@ -101,7 +101,7 @@ export class Particle {
   protected async invokeSafely(fun: (p: this) => Promise<any>, err: Consumer<Error>) {
     try {
       this.startBusy();
-      return await fun(this);
+      return fun(this);
     } catch (e) {
       err(e);
     } finally {

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -146,7 +146,7 @@ policy MyPolicy {
   });
 
   it('rejects unknown target types', async () => {
-    await assertThrowsAsync(async () => await parsePolicy(`
+    await assertThrowsAsync(async () => parsePolicy(`
 policy MyPolicy {
   from UnknownType access {}
 }`), `Unknown type name: UnknownType.`);

--- a/src/runtime/reference.ts
+++ b/src/runtime/reference.ts
@@ -121,7 +121,7 @@ export class Reference implements Storable {
     const storageProxyMuxer = await channelConstructor.getStorageProxyMuxer(this.extractBackingKey(storageKey), entityType) as StorageProxyMuxer<CRDTEntityTypeRecord<Identified, Identified>>;
     const proxy = storageProxyMuxer.getStorageProxy(id);
     const handle = new EntityHandle<Entity>(particleId, proxy, channelConstructor.idGenerator, null, true, true, id);
-    return await handle.fetch();
+    return handle.fetch();
   }
 }
 

--- a/src/runtime/services.ts
+++ b/src/runtime/services.ts
@@ -39,7 +39,7 @@ export class Services {
     const service = Services.registry[name];
     if (service) {
       if (service[invoke]) {
-        return await service[invoke](request);
+        return service[invoke](request);
       }
     }
     return null;

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -135,7 +135,7 @@ describe('VolatileStorageDriverProvider', () => {
 
     await provider1.driver(storageKey1, Exists.ShouldCreate);
     await provider2.driver(storageKey2, Exists.ShouldCreate);
-    await assertThrowsAsync(async () => await provider1.driver(storageKey1, Exists.ShouldCreate));
-    await assertThrowsAsync(async () => await provider2.driver(storageKey2, Exists.ShouldCreate));
+    await assertThrowsAsync(async () => provider1.driver(storageKey1, Exists.ShouldCreate));
+    await assertThrowsAsync(async () => provider2.driver(storageKey2, Exists.ShouldCreate));
   });
 });

--- a/src/runtime/storage/tests/reference-mode-store-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-test.ts
@@ -50,7 +50,7 @@ const schema = new Schema(['Thing'], {name: 'Text', age: 'Number'});
 const collectionType = new CollectionType(new EntityType(schema));
 
 async function createReferenceModeStore() {
-  return await ReferenceModeStore.construct({
+  return ReferenceModeStore.construct({
     storageKey: testKey,
     exists: Exists.ShouldCreate,
     type: collectionType,

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -1095,7 +1095,7 @@ describe('Arc storage migration', () => {
     const getStoreByConnectionName = async (connectionName) => {
       const store = arc.findStoreById(
         arc.activeRecipe.particles[0].connections[connectionName].handle.id);
-      return await store.activate();
+      return store.activate();
     };
     const getStoreValue = (storeContents, index, expectedLength) => {
       assert.lengthOf(Object.keys(storeContents['values']), expectedLength);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -449,7 +449,7 @@ describe('Arc', () => {
     /.*unresolved handle-connection: parent connection 'c' missing/);
   });
 
-  it('required provided handles cannot resolve without parent', async () =>
+  it('required provided handles cannot resolve without parent', async () => {
     await assertThrowsAsync(async () => {
       const loader = new Loader();
       const manifest = await Manifest.parse(`
@@ -492,8 +492,8 @@ describe('Arc', () => {
       recipe.normalize();
       await arc.instantiate(recipe);
     },
-    /.*unresolved handle-connection: parent connection 'c' missing/)
-    );
+    /.*unresolved handle-connection: parent connection 'c' missing/);
+  });
 
   it('optional provided handles are not required to resolve with dependencies', async () => {
     const loader = new Loader();
@@ -549,7 +549,7 @@ describe('Arc', () => {
     assert.isNull(await dHandle.fetch());
   });
 
-  it('required provided handles must resolve with dependencies', async () =>
+  it('required provided handles must resolve with dependencies', async () => {
     await assertThrowsAsync(async () => {
       const loader = new Loader();
       const manifest = await Manifest.parse(`
@@ -591,8 +591,8 @@ describe('Arc', () => {
       recipe.normalize();
       await arc.instantiate(recipe);
     },
-        /.*unresolved particle: unresolved connections/)
-    );
+    /.*unresolved particle: unresolved connections/);
+  });
 
   it('optional provided handles can resolve with parent 1', async () => {
     const loader = new Loader();

--- a/src/runtime/tests/capabilities-resolver-test.ts
+++ b/src/runtime/tests/capabilities-resolver-test.ts
@@ -48,15 +48,15 @@ describe('Capabilities Resolver New', () => {
   it('fails creating keys with no factories', Flags.withDefaultReferenceMode(async () => {
     const resolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     // Verify storage keys for none of the capabilities cannot be created.
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         unspecified, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         inMemory, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         inMemoryWithTtls, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         onDisk, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         onDiskWithTtl, entityType, handleId));
   }));
 
@@ -69,11 +69,11 @@ describe('Capabilities Resolver New', () => {
         unspecified, entityType, handleId), VolatileStorageKey);
     verifyReferenceModeStorageKey(await resolver.createStorageKey(
         inMemory, entityType, handleId), VolatileStorageKey);
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         inMemoryWithTtls, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         onDisk, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         onDiskWithTtl, entityType, handleId));
   }));
 
@@ -124,9 +124,9 @@ describe('Capabilities Resolver New', () => {
       inMemory, entityType, handleId), VolatileStorageKey);
     verifyReferenceModeStorageKey(await resolver.createStorageKey(
       inMemoryWithTtls, entityType, handleId), MemoryDatabaseStorageKey);
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         onDisk, entityType, handleId));
-    await assertThrowsAsync(async () => await resolver.createStorageKey(
+    await assertThrowsAsync(async () => resolver.createStorageKey(
         onDiskWithTtl, entityType, handleId));
   }));
 

--- a/src/runtime/tests/capabilities-test.ts
+++ b/src/runtime/tests/capabilities-test.ts
@@ -97,7 +97,7 @@ describe('Persistence Capability', () => {
         recipe
           h0: create @persistent @tiedToArc @ttl('3d')
     `;
-    await assertThrowsAsync(async () => await Manifest.parse(manifestStr));
+    await assertThrowsAsync(async () => Manifest.parse(manifestStr));
   });
 });
 

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -2137,7 +2137,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       const manifest = await parseManifest(manifestStr, {fileName: 'the.manifest', memoryProvider});
       const store = (await manifest.findStoreByName('X').activate()) as ActiveCollectionEntityStore;
       const handle = handleForActiveStore(store, manifest);
-      await assertThrowsAsync(async () => await handle.toList(), msg);
+      await assertThrowsAsync(async () => handle.toList(), msg);
     };
 
     // Incorrect types
@@ -3152,19 +3152,19 @@ resource SomeName
     });
 
     it('rejects invalid fields in field-level claims', async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           output: writes T {foo: Text}
           claim output.bar is something
       `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           output: writes T {foo: &Bar {bar: Number}}
           claim output.foo.baz is something
       `), `Schema 'Bar {bar: Number}' does not contain field 'baz'.`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           output: writes [T {foo: [&Bar {bar: Number}]}]
           claim output.foo.bar.baz is something
@@ -3245,7 +3245,7 @@ resource SomeName
     });
 
     it('rejects invalid fields in field-level "derives from" claims', async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: writes T {foo: Text}
           output: writes T {foo: Text}
@@ -3382,19 +3382,19 @@ resource SomeName
     });
 
     it('rejects invalid fields in field-level checks', async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads T {foo: Text}
           check input.bar is something
       `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads T {foo: &Bar {bar: Number}}
           check input.foo.baz is something
       `), `Schema 'Bar {bar: Number}' does not contain field 'baz'.`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads [T {foo: [&Bar {bar: Number}]}]
           check input.foo.bar.baz is something
@@ -3700,19 +3700,19 @@ resource SomeName
     });
 
     it('rejects unknown fields in type variables', async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads ~a
           check input.foo is trusted
       `), `Type variable ~a does not contain field 'foo'`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           output: writes ~a
           claim output.foo is trusted
       `), `Type variable ~a does not contain field 'foo'`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads ~a
           output: writes Result {foo: Text}
@@ -3721,7 +3721,7 @@ resource SomeName
     });
 
     it('fails to parse concrete types with inline schema field of `*`', async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
           particle Foo
             data: reads {*}
       `), `\
@@ -3729,7 +3729,7 @@ Post-parse processing error caused by 'undefined' line 3.
 Only type variables may have '*' fields.
               data: reads {*}
                           ^^^`);
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
           particle Foo
             data: reads {name: Text, *}
       `), `\
@@ -3821,7 +3821,7 @@ Only type variables may have '*' fields.
     it('rejects invalid fields in field-level claims on stores', async () => {
       const data = '{"root": {}, "locations": {}}';
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         store NobId of NobIdStore {nobId: Text} in NobIdJson
           claim field foo is property1 and is property2
         resource NobIdJson
@@ -3829,7 +3829,7 @@ Only type variables may have '*' fields.
           ${data}
       `), `Schema 'NobIdStore {nobId: Text}' does not contain field 'foo'.`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         store NobId of NobIdStore {nobId: Text, someRef: [&Foo {foo: [Text]}]} in NobIdJson
           claim field someRef.bar is property1 and is property2
         resource NobIdJson
@@ -3839,7 +3839,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow mixing 'and' and 'or' operations without nesting`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads T {}
           check input is property1 or is property2 and is property3
@@ -3912,13 +3912,13 @@ Only type variables may have '*' fields.
    });
 
     it('fails for unknown handle names', async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           output: writes T {}
           claim oops is trusted
       `), `Can't make a claim on unknown handle oops`);
 
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           input: reads T {}
           check oops is trusted
@@ -3926,7 +3926,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow claims on inputs`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           foo: reads T {}
           claim foo is trusted
@@ -3934,7 +3934,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on outputs`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           foo: writes T {}
           check foo is trusted
@@ -3942,7 +3942,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different claims for the same handle`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           foo: writes T {}
           claim foo is trusted
@@ -3951,7 +3951,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different claims for the same field`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           foo: writes T {bar: Text}
           claim foo.bar is trusted
@@ -3960,7 +3960,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different checks for the same handle`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           foo: reads T {}
           check foo is trusted
@@ -3969,7 +3969,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different checks for the same field`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           foo: reads T {bar: Text}
           check foo.bar is trusted
@@ -3978,7 +3978,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on consumed slots`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           someOtherSlot: consumes
             mySlot: provides
@@ -3987,7 +3987,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on unknown slots`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           someOtherSlot: consumes
             mySlot: provides
@@ -3996,7 +3996,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple provided slots with the same name`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           firstSlot: consumes
             mySlot: provides
@@ -4006,7 +4006,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on fields in slots`, async () => {
-      await assertThrowsAsync(async () => await parseManifest(`
+      await assertThrowsAsync(async () => parseManifest(`
         particle A
           someOtherSlot: consumes
             mySlot: provides
@@ -4440,13 +4440,13 @@ recipe Three`;
     }
   });
   it('throws when annotation not defined', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
         @nonexistent
         recipe
     `), `annotation not found: 'nonexistent'`);
   });
   it('throws when wrong annotation target', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
         annotation noParam
           retention: Source
           targets: [Particle]
@@ -4461,38 +4461,38 @@ annotation oneParam(foo: Text)
   retention: Source
   doc: 'doc'`;
   it('throws when wrong annotation param', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
 ${oneParamAnnotation}
 @oneParam(wrong: 'hello')
 recipe
     `), `unexpected annotation param: 'wrong'`);
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: 'hello', wrong: 'world')
 recipe
     `), `unexpected annotation param: 'wrong'`);
   });
   it('throws when annotation param value of incorrect type', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: 5)
 recipe
     `), `expected 'Text' for param 'foo', instead got 5`);
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: false)
 recipe
     `), `expected 'Text' for param 'foo', instead got false`);
   });
   it('parses recipe annotation with text param', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: 'hello', foo: 'world')
 recipe
     `), `annotation 'oneParam' can only have one value for: 'foo'`);
   });
   it('parses recipe annotation with text param', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: 'hello', wrong: 'world')
 recipe
@@ -4555,7 +4555,7 @@ particle Fooer
     assert.equal(manifest.toString(), manifestStr.trim());
   });
   it('fails schema annotations with wrong target', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
       annotation foo(bar: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4635,7 +4635,7 @@ recipe
     assert.equal(connection.getAnnotation('world').params['txt'], 'bye');
   });
   it('fails parsing annotation simple value when multiple params', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
       annotation hello(txt1: Text, txt2: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4644,7 +4644,7 @@ recipe
         foo: reads [* {bar: Text}] @hello('hi')`), `annotation 'hello' has unexpected unnamed param 'hi'`);
   });
   it('fails parsing annotation simple value when wrong type', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
       annotation hello(txt: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4653,15 +4653,15 @@ recipe
         foo: reads [* {bar: Text}] @hello(5)`), `expected 'Text' for param 'txt', instead got 5`);
   });
   it('fails parsing invalid canonical annotation ttl', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
       recipe
         foo: create @persistent @ttl('300')
     `), `Invalid ttl: 300`);
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
       recipe
         foo: create @persistent @ttl(300)
     `), `expected 'Text' for param 'value', instead got 300`);
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
       recipe
         foo: create @persistent @ttl('day')
     `), `Invalid ttl: day`);
@@ -4744,7 +4744,7 @@ recipe
   });
 
   it('fails when the @policy annotation is missing its argument', async () => {
-    assertThrowsAsync(async () => await Manifest.parse(`
+    assertThrowsAsync(async () => Manifest.parse(`
       @policy
       recipe
         foo: create
@@ -4954,7 +4954,7 @@ recipe
     });
   });
   it('fails parsing multiple annotation refs with same name', async () => {
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
         annotation oneParam(value: Text)
           retention: Source
           targets: [Recipe]
@@ -4963,7 +4963,7 @@ recipe
         @oneParam(value: 'world')
         recipe
     `), `annotation 'oneParam' already exists`);
-    await assertThrowsAsync(async () => await Manifest.parse(`
+    await assertThrowsAsync(async () => Manifest.parse(`
         annotation oneParam(value: Text)
           retention: Source
           targets: [Recipe]
@@ -5096,7 +5096,7 @@ recipe
           `Duplicate definition of store named 'Dupe'.`);
     });
     it('reports the correct error when multiple items exist', async () => {
-      assertThrowsAsync(async () => await Manifest.parse(`
+      assertThrowsAsync(async () => Manifest.parse(`
         particle P
           a: reads B {}
           a: reads C {}

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -5013,7 +5013,7 @@ recipe
           import './b.arcs'
         `,
       });
-      return await Manifest.load('/c.arcs', loader, {memoryProvider: new TestVolatileMemoryProvider()});
+      return Manifest.load('/c.arcs', loader, {memoryProvider: new TestVolatileMemoryProvider()});
     }
 
     it('rejects duplicate particle names', async () => {

--- a/src/runtime/tests/recipe-resolver-test.ts
+++ b/src/runtime/tests/recipe-resolver-test.ts
@@ -21,7 +21,7 @@ describe('RecipeResolver', () => {
   const buildManifest = async (content) => {
     const registry = {};
     const loader = new Loader(null, content);
-    return await Manifest.load('./manifest', loader, {registry});
+    return Manifest.load('./manifest', loader, {registry});
   };
 
   const createArc = (manifest) => {

--- a/src/runtime/ui-multiplexer-particle.ts
+++ b/src/runtime/ui-multiplexer-particle.ts
@@ -107,18 +107,17 @@ export class UiMultiplexerParticle extends UiTransformationParticle {
       });
       this.plexeds[index] = promise;
     }
-    return await promise;
+    return promise;
   }
 
   async resolveHosting(item, {arc, hostedParticle, otherConnections, otherMappedHandles}) {
     return hostedParticle ?
       {hostedParticle, otherConnections, otherMappedHandles}
-        : await this.resolveHostedParticle(item, arc);
+      : this.resolveHostedParticle(item, arc);
   }
 
   async acquireItemHandle(index, {arc, item, type}) {
-    const handlePromise = arc.createHandle(type.getContainedType(), `item${index}`);
-    return await handlePromise;
+    return arc.createHandle(type.getContainedType(), `item${index}`);
   }
 
   async resolveHostedParticle(item, arc) {

--- a/src/runtime/ui-particle-base.ts
+++ b/src/runtime/ui-particle-base.ts
@@ -111,7 +111,7 @@ export class UiParticleBase extends Particle {
     if (Array.isArray(value)) {
       throw new Error(`Cannot set an Array to Singleton handle [${handleName}]`);
     }
-    return this.await(async p => await handle.set(this.requireEntity(value, handle.entityClass)));
+    return this.await(async p => handle.set(this.requireEntity(value, handle.entityClass)));
   }
 
   /**

--- a/src/runtime/ui-particle-base.ts
+++ b/src/runtime/ui-particle-base.ts
@@ -97,7 +97,7 @@ export class UiParticleBase extends Particle {
    */
   // tslint:disable-next-line: no-any
   async await(task: (p: this) => Promise<any>) {
-    return await this.invokeSafely(task, this.onError);
+    return this.invokeSafely(task, this.onError);
   }
 
   /**
@@ -186,7 +186,7 @@ export class UiParticleBase extends Particle {
   async derefShares(shares): Promise<Entity[]> {
     return this.await(async p => {
       const derefPromises = shares.map(async share => share.ref.dereference());
-      return await Promise.all(derefPromises);
+      return Promise.all(derefPromises);
     });
   }
 
@@ -198,6 +198,6 @@ export class UiParticleBase extends Particle {
       return [];
     }
     const matches = box.filter(item => userid === item.fromKey);
-    return await this.derefShares(matches);
+    return this.derefShares(matches);
   }
 }

--- a/src/services/tfjs-mobilenet-service.ts
+++ b/src/services/tfjs-mobilenet-service.ts
@@ -144,7 +144,7 @@ const getImage = async (image: MobilenetImageInput | undefined, imageUrl: string
   }
 
   log('loading image...');
-  return !image && imageUrl ? await loadImage(imageUrl): image;
+  return !image && imageUrl ? loadImage(imageUrl) : image;
 };
 
 Services.register('mobilenet', {

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -77,7 +77,7 @@ export class PlanGenerator {
    */
   async createHandleVariable(handle: Handle): Promise<string> {
     handle.type.maybeEnsureResolved();
-    return await ktUtils.property(this.handleVariableName(handle), async ({startIndent}) => {
+    return ktUtils.property(this.handleVariableName(handle), async ({startIndent}) => {
       return ktUtils.applyFun(`Handle`, [
         await this.createStorageKey(handle),
         await generateHandleType(handle.type.resolvedType()),

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -91,7 +91,7 @@ describe('allocator recipe resolver', () => {
 
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `No matching stores found for handle 'my-handle-id' in recipe ReadingRecipe.`
     );
@@ -117,7 +117,7 @@ describe('allocator recipe resolver', () => {
 
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `No matching stores found for handle 'my-handle-id' in recipe ReadingRecipe.`
     );
@@ -231,7 +231,7 @@ describe('allocator recipe resolver', () => {
 
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `No matching stores found for handle 'my-handle-id' in recipe ReadingRecipe.`
     );
@@ -257,7 +257,7 @@ describe('allocator recipe resolver', () => {
       data: reads data`);
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `No matching stores found for handle 'my-handle-id' in recipe ReadingRecipe.`
     );
@@ -290,7 +290,7 @@ describe('allocator recipe resolver', () => {
 
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `More than one handle created with id 'my-handle-id'.`
     );
@@ -364,7 +364,7 @@ describe('allocator recipe resolver', () => {
         data: reads data`);
       const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
       await assertThrowsAsync(
-        async () => await resolver.resolve(),
+        async () => resolver.resolve(),
         AllocatorRecipeResolverError,
         `No matching stores found for handle 'my-handle-id' in recipe ReadingRecipe.`
       );
@@ -391,7 +391,7 @@ describe('allocator recipe resolver', () => {
 
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `No matching stores found for handle 'my-handle-id' in recipe ReadingRecipe.`);
   }));
@@ -560,7 +560,7 @@ describe('allocator recipe resolver', () => {
 
       particle Reader
         data: reads [~a with {name: Text}]
-    
+
       @arcId('writeArcId')
       recipe WritingRecipe
         thing: create 'my-handle-id' @persistent
@@ -597,7 +597,7 @@ describe('allocator recipe resolver', () => {
     `);
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       `Cannot restrict type ranges of [undefined - Thing {a: Text}] and [Thing {a: Text, b: Text} - undefined]`);
   });
   it('fails to resolve recipe handle with fate copy', async () => {
@@ -614,7 +614,7 @@ describe('allocator recipe resolver', () => {
           data: thing`, {memoryProvider: new TestVolatileMemoryProvider()});
     const resolver = new AllocatorRecipeResolver(manifest, randomSalt);
     await assertThrowsAsync(
-      async () => await resolver.resolve(),
+      async () => resolver.resolve(),
       AllocatorRecipeResolverError,
       `Recipe ReaderRecipe has a handle with unsupported 'copy' fate.`);
   });

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -19,7 +19,7 @@ import {assertThrowsAsync} from '../../testing/test-util.js';
 
 const inputManifestPath = 'java/arcs/core/data/testdata/WriterReaderExample.arcs';
 const policiesManifestPath = 'java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs';
-const readManifest = async (manifestPath) => await Runtime.parseFile(manifestPath);
+const readManifest = async (manifestPath) => Runtime.parseFile(manifestPath);
 
 describe('recipe2plan', () => {
   it('generates Kotlin plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
@@ -457,8 +457,8 @@ policy PolicyBarBr2Br3 {
   from Bar access { br2, br3 }
 }
   `;
-  const assertSuccess = async (recipeStr) => await verifyRecipeIngress(recipeStr, true);
-  const assertFailure = async (recipeStr) => await verifyRecipeIngress(recipeStr, false);
+  const assertSuccess = async (recipeStr) => verifyRecipeIngress(recipeStr, true);
+  const assertFailure = async (recipeStr) => verifyRecipeIngress(recipeStr, false);
   const verifyRecipeIngress = async (recipeStr: string, expectedSuccess: boolean) => {
     DriverFactory.clearRegistrationsForTesting();
     const recipesManifest = await Manifest.parse(`
@@ -471,7 +471,7 @@ ${recipeStr}
       assert.isTrue(result.toString().includes(`val MyRecipePlan by lazy {\n    Plan(`));
     } else {
       await assertThrowsAsync(
-          async () => await recipe2plan(recipesManifest, OutputFormat.Kotlin, policiesManifest),
+          async () => recipe2plan(recipesManifest, OutputFormat.Kotlin, policiesManifest),
           'Failed ingress validation for plan MyRecipe');
     }
   };
@@ -498,7 +498,7 @@ recipe MyRecipe
   fooHandle: create 'foos' @inMemory @ttl('10h')
   barHandle: create 'bar' @persistent @ttl('2d')
   quxHandle: create 'qux' @persistent @ttl('20h')
-  bazzzHandle: create 'bazzz' @persistent @ttl('${bazzzTtl}') 
+  bazzzHandle: create 'bazzz' @persistent @ttl('${bazzzTtl}')
   WriteFoo
     foo: fooHandle
   WriteBar

--- a/src/tracelib/tests/trace-test.ts
+++ b/src/tracelib/tests/trace-test.ts
@@ -47,7 +47,7 @@ describe('Tracing', () => {
 
   const promiseResult = 42;
   async function waitABit() {
-    return await new Promise(resolve => {
+    return new Promise(resolve => {
       setTimeout(resolve, 1, promiseResult);
     });
   }


### PR DESCRIPTION
The outer function returns a promise anyway, so we can just pass the inner function's promise up.

There is a single exception in tracelib, which appears to be specific about the wait point.