### PR TITLE
Add error tracing to Parser

### DIFF
--- a/java/arcs/core/util/Parser.kt
+++ b/java/arcs/core/util/Parser.kt
@@ -152,8 +152,8 @@ abstract class Parser<out T>() {
     abstract fun leftTokens(): List<String>
 
     abstract operator fun invoke(
-        string: String,
-        pos: SourcePosition
+      string: String,
+      pos: SourcePosition
     ): ParseResult<T>
 }
 
@@ -202,20 +202,20 @@ sealed class ParseResult<out T>() {
 
     /** Represents a successful parse, containing the parsed value, and unparsed leftover. */
     data class Success<out T>(
-        val value: T,
-        override val start: SourcePosition,
-        override val end: SourcePosition,
-        override val consumed: Int = 1
+      val value: T,
+      override val start: SourcePosition,
+      override val end: SourcePosition,
+      override val consumed: Int = 1
     ) : ParseResult<T>()
 
     /** Represents a parse failure. */
     data class Failure(
-        val error: String,
-        override val start: SourcePosition,
-        override val end: SourcePosition,
-        override val consumed: Int = 0,
-        val parser: String = "",
-        val cause: Failure? = null
+      val error: String,
+      override val start: SourcePosition,
+      override val end: SourcePosition,
+      override val consumed: Int = 0,
+      val parser: String = "",
+      val cause: Failure? = null
     ) : ParseResult<Nothing>() {
         override fun toString() = rootCause(this).let {
             "${it.error} at line ${it.start.line}, column ${it.start.column}"
@@ -286,8 +286,8 @@ class RegexToken(val regexToken: String) : Parser<String>() {
  */
 class Optional<T>(val parser: Parser<T>) : Parser<T?>() {
     override fun invoke(
-        string: String,
-        pos: SourcePosition
+      string: String,
+      pos: SourcePosition
     ): ParseResult<T?> = parser(string, pos).orElse {
         Success<T?>(null, pos, pos, 0)
     }
@@ -392,8 +392,8 @@ class TransformParser<T, R>(val parser: Parser<T>, val transform: (T) -> R) : Pa
     override fun leftTokens(): List<String> = parser.leftTokens()
 
     override fun invoke(
-        string: String,
-        pos: SourcePosition
+      string: String,
+      pos: SourcePosition
     ): ParseResult<R> = parser(string, pos).map { v, start, end, consumed ->
         try {
             Success(transform(v), start, end, consumed)
@@ -412,8 +412,8 @@ class LazyParser<T>(val parser: () -> Parser<T>) : Parser<T>() {
 
 /** A parser that represents three parsers in sequence yielding a [Triple]. */
 class TripleOfParser<T, S, R>(
-    val left: PairOfParser<T, S>,
-    val right: Parser<R>
+  val left: PairOfParser<T, S>,
+  val right: Parser<R>
 ) : Parser<Triple<T, S, R>>() {
 
     override fun leftTokens(): List<String> = left.leftTokens()
@@ -470,14 +470,14 @@ abstract class Grammar<T> : Parser<T>() {
 
     /** Delegate provider that assigns names to parsers. */
     protected operator fun <T> Parser<T>.provideDelegate(
-        thisRef: Grammar<*>,
-        property: KProperty<*>
+      thisRef: Grammar<*>,
+      property: KProperty<*>
     ): Parser<T> = also { it.name = property.name }
 
     /** Allow parser fields to be delegated. */
     protected operator fun <T> Parser<T>.getValue(
-        thisRef: Grammar<*>,
-        property: KProperty<*>
+      thisRef: Grammar<*>,
+      property: KProperty<*>
     ): Parser<T> = this
 
     override fun leftTokens() = topLevel.leftTokens()

--- a/java/arcs/core/util/Parser.kt
+++ b/java/arcs/core/util/Parser.kt
@@ -12,8 +12,8 @@ package arcs.core.util
 
 import arcs.core.util.ParseResult.Failure
 import arcs.core.util.ParseResult.Success
-import java.lang.Integer.max
-import java.lang.Integer.min
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.reflect.KProperty
 
 /**

--- a/java/arcs/core/util/Parser.kt
+++ b/java/arcs/core/util/Parser.kt
@@ -12,6 +12,7 @@ package arcs.core.util
 
 import arcs.core.util.ParseResult.Failure
 import arcs.core.util.ParseResult.Success
+import kotlin.reflect.KProperty
 
 /**
  * # Introduction
@@ -112,96 +113,144 @@ import arcs.core.util.ParseResult.Success
  * val arrayClean = -token("[") + many(term + -optional(token(","))) + -token("]")
  * // arrayClean("[hello,world]") returns Success(List<String>("hello", "world"))
  * ```
+ *
+ * ### Grammars
+ *
+ * For better error messages and optimizations in the future, you can collect your parser rules
+ * into a [Grammar]. [Grammar] provides a property delegate provide that can register parsers,
+ * set debug names, and in the future, separate tokens from non-terminals.
+ *
+ * ```kotlin
+ * object HelloGrammar : Grammar<String>() {
+ *   val hello by token("hello")
+ *   val world by token("world")
+ *   val helloOrWorld by hello / world
+ *   override val topLevel by helloOrWorld
+ * }
+ *
+ * HelloGrammar("hello world").
+ *
+ * Note the use of 'by' instead of '='. This triggers the parsers to be given names like
+ * 'helloOrWorld' or 'hello' which show up in error messages.
+ * ```
  */
 abstract class Parser<out T>() {
-  operator fun invoke(string: String, pos: Int = 0) = invoke(string, SourcePosition(pos, 0, 0))
+    operator fun invoke(string: String, pos: Int = 0) = invoke(string, SourcePosition(pos, 0, 0))
 
-  private var _name: String = ""
+    private var _name: String = ""
 
-  /** Readable debug name for parser, to be used for improved debugging. */
-  var name: String
-    get() = _name
-    internal set(value) {
-      _name = value
-    }
+    /** Readable debug name for parser, to be used for improved debugging. */
+    var name: String
+        get() = _name
+        internal set(value) {
+            _name = value
+        }
 
-  /** Return the leftmost token expected by this Parser, used for error reporting. */
-  abstract fun leftTokens(): List<String>
+    /** Return the leftmost token expected by this Parser, used for error reporting. */
+    abstract fun leftTokens(): List<String>
 
-  abstract operator fun invoke(
-    string: String,
-    pos: SourcePosition
-  ): ParseResult<T>
+    abstract operator fun invoke(
+        string: String,
+        pos: SourcePosition
+    ): ParseResult<T>
 }
 
 data class SourcePosition(val offset: Int, val line: Int, val column: Int) {
-  fun advance(str: String): SourcePosition {
-    var last = 0.toChar()
-    var newOffset = offset
-    var newLine = line
-    var newCol = column
+    fun advance(str: String): SourcePosition {
+        var last = 0.toChar()
+        var newOffset = offset
+        var newLine = line
+        var newCol = column
 
-    for (chr in str) {
-      newOffset += 1
-      if ((last == '\r' && chr == '\n') || chr == '\n' || chr == '\r') {
-        newLine += 1
-        newCol = 1
-      } else {
-        newCol += 1
-      }
-      last = chr
+        for (chr in str) {
+            newOffset += 1
+            if ((last == '\r' && chr == '\n') || chr == '\n' || chr == '\r') {
+                newLine += 1
+                newCol = 1
+            } else {
+                newCol += 1
+            }
+            last = chr
+        }
+        return SourcePosition(newOffset, newLine, newCol)
     }
-    return SourcePosition(newOffset, newLine, newCol)
-  }
 }
 
 /** The result (Functor) of a [Parser] application is a either [Success] or [Failure]. */
 sealed class ParseResult<out T>() {
-  abstract val start: SourcePosition
-  abstract val end: SourcePosition
+    abstract val start: SourcePosition
+    abstract val end: SourcePosition
+    abstract val consumed: Int
 
-  @Suppress("UNCHECKED_CAST")
-  fun <T> orElse(f: (Failure) -> ParseResult<T>): ParseResult<T> {
-    return when (this) {
-      is Success<*> -> this as ParseResult<T>
-      is Failure -> f(this)
+    @Suppress("UNCHECKED_CAST")
+    fun <T> orElse(f: (Failure) -> ParseResult<T>): ParseResult<T> {
+        return when (this) {
+            is Success<*> -> this as ParseResult<T>
+            is Failure -> f(this)
+        }
     }
-  }
 
-  /** Map a function over the contents of this functor returning a new functor. */
-  fun <S> map(f: (T, SourcePosition, SourcePosition) -> ParseResult<S>): ParseResult<S> {
-    return when (this) {
-      is Success<T> -> f(value, start, end)
-      else -> this as Failure
+    /** Map a function over the contents of this functor returning a new functor. */
+    fun <S> map(f: (T, SourcePosition, SourcePosition, Int) -> ParseResult<S>): ParseResult<S> {
+        return when (this) {
+            is Success<T> -> f(value, start, end, consumed)
+            else -> this as Failure
+        }
     }
-  }
 
-  /** Represents a successful parse, containing the parsed value, and unparsed leftover. */
-  data class Success<out T>(
-    val value: T,
-    override val start: SourcePosition,
-    override val end: SourcePosition
-  ) : ParseResult<T>()
+    /** Represents a successful parse, containing the parsed value, and unparsed leftover. */
+    data class Success<out T>(
+        val value: T,
+        override val start: SourcePosition,
+        override val end: SourcePosition,
+        override val consumed: Int = 1
+    ) : ParseResult<T>()
 
-  /** Represents a parse failure. */
-  class Failure(
-    val error: String,
-    override val start: SourcePosition,
-    override val end: SourcePosition
-  ) : ParseResult<Nothing>()
+    /** Represents a parse failure. */
+    data class Failure(
+        val error: String,
+        override val start: SourcePosition,
+        override val end: SourcePosition,
+        override val consumed: Int = 0,
+        val parser: String = "",
+        val cause: Failure? = null
+    ) : ParseResult<Nothing>() {
+        override fun toString() = rootCause(this).let {
+            "${it.error} at line ${it.start.line}, column ${it.start.column}"
+        } + (this.cause?.let { "\n[Traceback]" + traceBack(this) })
+    }
 }
+
+private tailrec fun rootCause(cause: Failure): Failure =
+    if (cause.cause == null) cause else rootCause(cause.cause)
+
+private fun traceBack(cause: Failure?, indent: Int = 1): String = when {
+    cause == null -> ""
+    cause.parser.isBlank() -> traceBack(cause.cause, indent)
+    else -> "\n" + ("--".repeat(indent)) + ">${cause.parser}" + traceBack(cause.cause, indent + 1)
+}
+
+/** Create a parent [Failure] as a copy, labeled with the enclosing parser. */
+private fun Failure.causedBy(parser: String) = this.copy(parser = parser, cause = this)
+
+/** Create a copy of [Failure] with a new value for [consumed]. */
+private fun Failure.consumed(consumed: Int, parser: String, cause: Failure) = this.copy(
+    consumed = consumed,
+    parser = parser,
+    cause = cause)
+
 
 /** Chop off the consumed part of the string. */
 fun String.advance(str: String) = this.substring(str.length)
 
 /** A parser that consumes a prefix of a string. */
 class StringToken(val token: String) : Parser<String>() {
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<String> = when {
-    string.startsWith(token, pos.offset) -> Success(token, pos, pos.advance(token))
-    else -> Failure("Expecting $token", pos, pos)
-  }
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<String> = when {
+        string.startsWith(token, pos.offset) -> Success(token, pos, pos.advance(token))
+        else -> Failure("Expecting $token", pos, pos)
+    }
 
-  override fun leftTokens(): List<String> = listOf(token)
+    override fun leftTokens(): List<String> = listOf(token)
 }
 
 /**
@@ -210,12 +259,12 @@ class StringToken(val token: String) : Parser<String>() {
  */
 class RegexToken(val regexToken: String) : Parser<String>() {
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<String> =
-    Regex("^$regexToken").find(string.substring(pos.offset))?.let { it ->
-      Success(it.groupValues[1], pos, pos.advance(it.groupValues[0]))
-    } ?: Failure("Expecting $regexToken", pos, pos)
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<String> =
+        Regex("^$regexToken").find(string.substring(pos.offset))?.let { it ->
+            Success(it.groupValues[1], pos, pos.advance(it.groupValues[0]))
+        } ?: Failure("Expecting $regexToken", pos, pos)
 
-  override fun leftTokens(): List<String> = listOf(regexToken)
+    override fun leftTokens(): List<String> = listOf(regexToken)
 }
 
 /**
@@ -223,14 +272,14 @@ class RegexToken(val regexToken: String) : Parser<String>() {
  * null.
  */
 class Optional<T>(val parser: Parser<T>) : Parser<T?>() {
-  override fun invoke(
-    string: String,
-    pos: SourcePosition
-  ): ParseResult<T?> = parser(string, pos).orElse {
-    Success<T?>(null, pos, pos)
-  }
+    override fun invoke(
+        string: String,
+        pos: SourcePosition
+    ): ParseResult<T?> = parser(string, pos).orElse {
+        Success<T?>(null, pos, pos, 0)
+    }
 
-  override fun leftTokens(): List<String> = parser.leftTokens()
+    override fun leftTokens(): List<String> = parser.leftTokens()
 }
 
 /**
@@ -238,30 +287,53 @@ class Optional<T>(val parser: Parser<T>) : Parser<T?>() {
  * otherwise the combined results are returned as a [Pair<T, S>].
  */
 class PairOfParser<T, S>(val left: Parser<T>, val right: Parser<S>) : Parser<Pair<T, S>>() {
-  override fun invoke(string: String, pos: SourcePosition) =
-    left(string, pos).map { v1, s1, e1 ->
-      right(string, e1).map { v2, _, e2 ->
-        Success(Pair(v1, v2), s1, e2)
-      }
-    }
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<Pair<T, S>> =
+        when (val outerResult = left(string, pos).map { v1, s1, e1, c1 ->
+            val result = right(string, e1).map { v2, _, e2, c2 ->
+                Success(Pair(v1, v2), s1, e2, c1 + c2)
+            }
+            when (result) {
+                is Success<*> -> result as Success<Pair<T, S>>
+                is Failure -> result.consumed(
+                    result.consumed + c1,
+                    this@PairOfParser.name,
+                    result
+                )
+            }
+        }) {
+            is Success<*> -> outerResult as Success<Pair<T, S>>
+            is Failure -> outerResult.causedBy(name)
+        }
 
-  override fun leftTokens(): List<String> = left.leftTokens()
+    override fun leftTokens(): List<String> = left.leftTokens()
 }
 
 /** A parser that combines two parsers by returning the value of the first one that succeeds. */
 class AnyOfParser<T>(val parsers: List<Parser<T>>) : Parser<T>() {
 
-  override fun leftTokens(): List<String> = parsers.flatMap { it.leftTokens() }
+    override fun leftTokens(): List<String> = parsers.flatMap { it.leftTokens() }
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<T> {
-    for (parser in parsers) {
-      when (val result = parser(string, pos)) {
-        is Success<T> -> return result
-        else -> Unit
-      }
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<T> {
+        var mostConsumed = 0
+        var mostConsumedFailure: Failure? = null
+
+        for (parser in parsers) {
+            when (val result = parser(string, pos)) {
+                is Success<T> -> return result
+                else -> {
+                    if (result.consumed >= mostConsumed) {
+                        mostConsumed = result.consumed
+                        mostConsumedFailure = result as Failure
+                    }
+                }
+            }
+        }
+        if (mostConsumed == 0) {
+            return Failure("Expecting one of " + leftTokens().joinToString(), pos, pos, 0, name)
+        } else {
+            return mostConsumedFailure!!.causedBy(name)
+        }
     }
-    return Failure("Expecting one of " + leftTokens().joinToString(), pos, pos)
-  }
 }
 
 /**
@@ -270,26 +342,27 @@ class AnyOfParser<T>(val parsers: List<Parser<T>>) : Parser<T>() {
  */
 class ManyOfParser<T>(val parser: Parser<T>) : Parser<List<T>>() {
 
-  override fun leftTokens(): List<String> = parser.leftTokens()
+    override fun leftTokens(): List<String> = parser.leftTokens()
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<List<T>> {
-    val result = mutableListOf<T>()
-    // Result could be immutable by mapping and chaining parsers to concatenate a result
-    // but it's overkill.
-    val resultParser = parser.map {
-      result.add(it)
-      it
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<List<T>> {
+        val result = mutableListOf<T>()
+        var consumed = 0
+        // Result could be immutable by mapping and chaining parsers to concatenate a result
+        // but it's overkill.
+        val resultParser = parser.map {
+            result.add(it)
+            it
+        }
+
+        // Stops with first Failure(msg, start, end)
+        // But (start) is actually equal to the last Success's end
+        fun parseUntilFail(pos: SourcePosition): ParseResult<T> =
+            resultParser(string, pos).map { _, _, end, c -> consumed += c; parseUntilFail(end) }
+
+        return parseUntilFail(pos).orElse {
+                failure -> Success(result, pos, failure.start, consumed)
+        }
     }
-
-    // Stops with first Failure(msg, start, end)
-    // But (start) is actually equal to the last Success's end
-    fun parseUntilFail(pos: SourcePosition): ParseResult<T> =
-      resultParser(string, pos).map { _, _, end -> parseUntilFail(end) }
-
-    return parseUntilFail(pos).orElse { failure ->
-      Success(result, pos, failure.start)
-    }
-  }
 }
 
 class ParserException(msg: String, cause: Exception) : Exception(msg, cause)
@@ -297,64 +370,100 @@ class ParserException(msg: String, cause: Exception) : Exception(msg, cause)
 /** A parser which converts the return value of a parser into another value. */
 class TransformParser<T, R>(val parser: Parser<T>, val transform: (T) -> R) : Parser<R>() {
 
-  override fun leftTokens(): List<String> = parser.leftTokens()
+    override fun leftTokens(): List<String> = parser.leftTokens()
 
-  override fun invoke(
-    string: String,
-    pos: SourcePosition
-  ): ParseResult<R> = parser(string, pos).map { v, start, end ->
-    try {
-      Success(transform(v), start, end)
-    } catch (e: ParserException) {
-      Failure(e.message ?: "Parse Exception", start, end)
-    }
-  }
+    override fun invoke(
+        string: String,
+        pos: SourcePosition
+    ): ParseResult<R> = parser(string, pos).map { v, start, end, consumed ->
+        try {
+            Success(transform(v), start, end, consumed)
+        } catch (e: ParserException) {
+            Failure(e.message ?: "Parse Exception", start, end).causedBy(name)
+        }
+    }.orElse { failure -> failure.causedBy(name) }
 }
 
 /** A parser used to refer to parsers that haven't been constructed yet. */
 class LazyParser<T>(val parser: () -> Parser<T>) : Parser<T>() {
-  override fun leftTokens(): List<String> = parser().leftTokens()
+    override fun leftTokens(): List<String> = parser().leftTokens()
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<T> = parser()(string, pos)
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<T> = parser()(string, pos)
 }
 
 /** A parser that represents three parsers in sequence yielding a [Triple]. */
 class TripleOfParser<T, S, R>(
-  val left: PairOfParser<T, S>,
-  val right: Parser<R>
+    val left: PairOfParser<T, S>,
+    val right: Parser<R>
 ) : Parser<Triple<T, S, R>>() {
 
-  override fun leftTokens(): List<String> = left.leftTokens()
+    override fun leftTokens(): List<String> = left.leftTokens()
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<Triple<T, S, R>> =
-    left(string, pos).map { v1, s1, e1 ->
-      right(string, e1).map { v2, _, e2 ->
-        Success(Triple(v1.first, v1.second, v2), s1, e2)
-      }
-    }
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<Triple<T, S, R>> =
+        left(string, pos).map { v1, s1, e1, c1 ->
+            val result = right(string, e1).map { v2, _, e2, c2 ->
+                Success(Triple(v1.first, v1.second, v2), s1, e2, c1 + c2)
+            }
+            when (result) {
+                is Success<*> -> result as Success<Triple<T, S, R>>
+                is Failure -> result.consumed(
+                    result.consumed + c1,
+                    this@TripleOfParser.name,
+                    result
+                )
+            }
+        }
 }
 
 /** A parser which omits its output from the result type. */
 class IgnoringParser<T>(val parser: Parser<T>) : Parser<T>() {
-  override fun leftTokens(): List<String> = parser.leftTokens()
+    override fun leftTokens(): List<String> = parser.leftTokens()
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<T> = parser(string, pos)
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<T> = parser(string, pos)
 }
 
 /** A parser that succeeds by matching the end of the input. */
 object EofParser : Parser<Unit>() {
-  override fun leftTokens(): List<String> = listOf("<eof>")
+    override fun leftTokens(): List<String> = listOf("<eof>")
 
-  init {
-    name = "<eof>"
-  }
+    init {
+        name = "<eof>"
+    }
 
-  override fun invoke(string: String, pos: SourcePosition): ParseResult<Unit> =
-    if (pos.offset == string.length) Success(Unit, pos, pos) else Failure(
-      "Expecting eof",
-      pos,
-      pos
-    )
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<Unit> =
+        if (pos.offset == string.length) Success(Unit, pos, pos) else Failure(
+            "Expecting eof",
+            pos,
+            pos,
+            0,
+            name
+        )
+}
+
+/**
+ * A class to collect all of the parser rules for a language, including designating a
+ * [topLevel] rule to start the parser, and property delegate providers to set helpful debug
+ * names on parsers.
+ */
+abstract class Grammar<T> : Parser<T>() {
+    /** The top level rule for this grammar. */
+    abstract val topLevel: Parser<T>
+
+    /** Delegate provider that assigns names to parsers. */
+    protected operator fun <T> Parser<T>.provideDelegate(
+        thisRef: Grammar<*>,
+        property: KProperty<*>
+    ): Parser<T> = also { it.name = property.name }
+
+    /** Allow parser fields to be delegated. */
+    protected operator fun <T> Parser<T>.getValue(
+        thisRef: Grammar<*>,
+        property: KProperty<*>
+    ): Parser<T> = this
+
+    override fun leftTokens() = topLevel.leftTokens()
+
+    override fun invoke(string: String, pos: SourcePosition): ParseResult<T> = topLevel(string, pos)
 }
 
 /** Combines two parsers via addition operator as [PairOfParser] combinator. */
@@ -362,18 +471,18 @@ operator fun <T, S> Parser<T>.plus(other: Parser<S>) = PairOfParser(this, other)
 
 /** Combines two parsers in sequence with a third as a [TripleOfParser] combinator. */
 operator fun <T, S, R> PairOfParser<T, S>.plus(other: Parser<R>) =
-  TripleOfParser(this, other)
+    TripleOfParser(this, other)
 
 operator fun <T, S, R> PairOfParser<T, S>.plus(other: IgnoringParser<R>) =
-  PairOfParser(this, other).map { (x, _) -> x }
+    PairOfParser(this, other).map { (x, _) -> x }
 
 /** Combines an [IgnoringParser] with a [Parser] ignoring the output of the first. */
 operator fun <T, S> IgnoringParser<T>.plus(other: Parser<S>) =
-  PairOfParser(this, other).map { (_, y) -> y }
+    PairOfParser(this, other).map { (_, y) -> y }
 
 /** Combines an [Parser] with an [IgnoringParser] ignoring the output of the second. */
 operator fun <T, S> Parser<T>.plus(other: IgnoringParser<S>) =
-  PairOfParser(this, other).map { (x, _) -> x }
+    PairOfParser(this, other).map { (x, _) -> x }
 
 /** Unary minus as shorthand for ignoring a parser's output. */
 operator fun <T> Parser<T>.unaryMinus() = IgnoringParser(this)

--- a/javatests/arcs/core/util/ParserTest.kt
+++ b/javatests/arcs/core/util/ParserTest.kt
@@ -176,7 +176,7 @@ class ParserTest {
             Failure("", s, e)
         } as Failure
 
-        assertThat(failure.error).isEqualTo("Expecting eof")
+        assertThat(failure.error).isEqualTo("ello!\n    ^\nExpecting eof")
     }
 
     object HelloGrammar : Grammar<String>() {

--- a/javatests/arcs/core/util/ParserTest.kt
+++ b/javatests/arcs/core/util/ParserTest.kt
@@ -12,170 +12,205 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class ParserTest {
 
-  fun String.rest(pos: SourcePosition) =
-    if (pos.offset >= this.length) "" else this.substring(pos.offset)
+    fun String.rest(pos: SourcePosition) =
+        if (pos.offset >= this.length) "" else this.substring(pos.offset)
 
-  @Test
-  fun parseWithTokenizer() {
-    val hello = token("hello")
-    hello("hello world").map { match, start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
-      assertThat(match).isEqualTo("hello")
-      assertThat("hello world".rest(end)).isEqualTo(" world")
-      Success(match, start, end)
-    }.orElse<Nothing> {
-      fail()
+    @Test
+    fun parseWithTokenizer() {
+        val hello = token("hello")
+        hello("hello world").map { match, start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
+            assertThat(match).isEqualTo("hello")
+            assertThat("hello world".rest(end)).isEqualTo(" world")
+            Success(match, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
+
+        assertThat(hello("world")).isInstanceOf(Failure::class.java)
+
+        val helloregex = regex("(h.ll)o")
+
+        helloregex("hello world").map { match, start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
+            assertThat(match).isEqualTo("hell")
+            assertThat("hello world".rest(end)).isEqualTo(" world")
+            Success(match, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
+
+        assertThat(helloregex("world")).isInstanceOf(Failure::class.java)
     }
 
-    assertThat(hello("world")).isInstanceOf(Failure::class.java)
+    @Test
+    fun parseSequential() {
+        val helloworld = token("hello") + token("world")
+        helloworld("helloworld").map { (hello, world), start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(10, 0, 10))
+            assertThat(hello).isEqualTo("hello")
+            assertThat(world).isEqualTo("world")
+            assertThat("helloworld".rest(end)).isEqualTo("")
+            Success(Pair(hello, world), start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
 
-    val helloregex = regex("(h.ll)o")
+        val helloworld2 = token("hello") + token("world") + token("two")
+        helloworld2("helloworldtwo").map { (hello, world, two), start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(13, 0, 13))
+            assertThat(hello).isEqualTo("hello")
+            assertThat(world).isEqualTo("world")
+            assertThat(two).isEqualTo("two")
+            assertThat("helloworldtwo".rest(end)).isEqualTo("")
+            Success(Triple(hello, world, two), start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
 
-    helloregex("hello world").map { match, start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
-      assertThat(match).isEqualTo("hell")
-      assertThat("hello world".rest(end)).isEqualTo(" world")
-      Success(match, start, end)
-    }.orElse<Nothing> {
-      fail()
+        assertThat(helloworld("hello world")).isInstanceOf(Failure::class.java)
     }
 
-    assertThat(helloregex("world")).isInstanceOf(Failure::class.java)
-  }
+    @Test
+    fun parseParallel() {
+        val helloworld = token("hello") / token("goodbye") / token("foo") / token("bar")
+        helloworld("hello world").map { match, start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
+            assertThat(match).isEqualTo("hello")
+            assertThat("hello world".rest(end)).isEqualTo(" world")
+            Success(match, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
 
-  @Test
-  fun parseSequential() {
-    val helloworld = token("hello") + token("world")
-    helloworld("helloworld").map { (hello, world), start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(10, 0, 10))
-      assertThat(hello).isEqualTo("hello")
-      assertThat(world).isEqualTo("world")
-      assertThat("helloworld".rest(end)).isEqualTo("")
-      Success(Pair(hello, world), start, end)
-    }.orElse<Nothing> {
-      fail()
+        helloworld("goodbye world").map { match, start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(7, 0, 7))
+            assertThat(match).isEqualTo("goodbye")
+            assertThat("goodbye world".rest(end)).isEqualTo(" world")
+            Success(match, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
+
+        assertThat(helloworld("sayonara world")).isInstanceOf(Failure::class.java)
     }
 
-    val helloworld2 = token("hello") + token("world") + token("two")
-    helloworld2("helloworldtwo").map { (hello, world, two), start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(13, 0, 13))
-      assertThat(hello).isEqualTo("hello")
-      assertThat(world).isEqualTo("world")
-      assertThat(two).isEqualTo("two")
-      assertThat("helloworldtwo".rest(end)).isEqualTo("")
-      Success(Triple(hello, world, two), start, end)
-    }.orElse<Nothing> {
-      fail()
+    @Test
+    fun parseMany() {
+        val intro = token("a ") + many(token("long ")) + token("time ago in a far away galaxy")
+        val string = "a long long long time ago in a far away galaxy"
+        intro(string).map { (_, many, _), start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(string.length, 0, string.length))
+            assertThat(many).containsExactly("long ", "long ", "long ")
+            assertThat(string.rest(end)).isEqualTo("")
+            Success(many, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
+
+        assertThat(intro("a time ago")).isInstanceOf(Failure::class.java)
     }
 
-    assertThat(helloworld("hello world")).isInstanceOf(Failure::class.java)
-  }
+    @Test
+    fun parseOptional() {
+        val trailing = token("hello") + optional(token(", "))
+        trailing("hello.").map { (hello, _), start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
+            assertThat(hello).isEqualTo("hello")
+            assertThat("hello.".rest(end)).isEqualTo(".")
+            Success(hello, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
 
-  @Test
-  fun parseParallel() {
-    val helloworld = token("hello") / token("goodbye") / token("foo") / token("bar")
-    helloworld("hello world").map { match, start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
-      assertThat(match).isEqualTo("hello")
-      assertThat("hello world".rest(end)).isEqualTo(" world")
-      Success(match, start, end)
-    }.orElse<Nothing> {
-      fail()
+        trailing("hello, ").map { (hello, opt), start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(7, 0, 7))
+            assertThat(hello).isEqualTo("hello")
+            assertThat(opt).isEqualTo(", ")
+            assertThat("hello, ".rest(end)).isEqualTo("")
+            Success(hello, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
     }
 
-    helloworld("goodbye world").map { match, start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(7, 0, 7))
-      assertThat(match).isEqualTo("goodbye")
-      assertThat("goodbye world".rest(end)).isEqualTo(" world")
-      Success(match, start, end)
-    }.orElse<Nothing> {
-      fail()
+    @Test
+    fun testIgnoring() {
+        val space: IgnoringParser<String> = -token(" ")
+        val ignoring = token("hello") + space + token("world")
+        ignoring("hello world").map { (hello, world), start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(11, 0, 11))
+            assertThat(hello).isEqualTo("hello")
+            assertThat(world).isEqualTo("world")
+            Success(hello, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
     }
 
-    assertThat(helloworld("sayonara world")).isInstanceOf(Failure::class.java)
-  }
+    @Test
+    fun testEof() {
+        val hello = token("hello") + eof
+        hello("hello").map { match, start, end, _ ->
+            assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
+            assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
+            assertThat(match).isEqualTo("hello")
+            assertThat("hello".rest(end)).isEqualTo("")
+            Success(match, start, end)
+        }.orElse<Nothing> {
+            fail()
+        }
 
-  @Test
-  fun parseMany() {
-    val intro = token("a ") + many(token("long ")) + token("time ago in a far away galaxy")
-    val string = "a long long long time ago in a far away galaxy"
-    intro(string).map { (_, many, _), start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(string.length, 0, string.length))
-      assertThat(many).containsExactly("long ", "long ", "long ")
-      assertThat(string.rest(end)).isEqualTo("")
-      Success(many, start, end)
-    }.orElse<Nothing> {
-      fail()
+        val failure = hello("hello!2").map { _, s, e, _ ->
+            require(false) { "Shouldn't be called" }
+            Failure("", s, e)
+        } as Failure
+
+        assertThat(failure.error).isEqualTo("Expecting eof")
     }
 
-    assertThat(intro("a time ago")).isInstanceOf(Failure::class.java)
-  }
-
-  @Test
-  fun parseOptional() {
-    val trailing = token("hello") + optional(token(", "))
-    trailing("hello.").map { (hello, _), start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
-      assertThat(hello).isEqualTo("hello")
-      assertThat("hello.".rest(end)).isEqualTo(".")
-      Success(hello, start, end)
-    }.orElse<Nothing> {
-      fail()
+    object HelloGrammar : Grammar<String>() {
+        val hello by (token("hello") + token("world")).map { (h, w) -> h + w }
+        val world by token("world")
+        val helloOrWorld by hello / world
+        override val topLevel by helloOrWorld + eof
     }
 
-    trailing("hello, ").map { (hello, opt), start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(7, 0, 7))
-      assertThat(hello).isEqualTo("hello")
-      assertThat(opt).isEqualTo(", ")
-      assertThat("hello, ".rest(end)).isEqualTo("")
-      Success(hello, start, end)
-    }.orElse<Nothing> {
-      fail()
+    @Test
+    fun testGrammar() {
+        val failure = HelloGrammar("foo")
+        assertThat(failure.toString()).isEqualTo("""
+                |Expecting one of hello, world at line 0, column 0
+                |[Traceback]
+                |-->topLevel
+                |---->helloOrWorld
+        """.trimMargin())
+
+        val failure2 = HelloGrammar("hello")
+        assertThat(failure2.toString()).isEqualTo("""
+            |Expecting world at line 0, column 5
+            |[Traceback]
+            |-->topLevel
+            |---->helloOrWorld
+            |------>hello
+        """.trimMargin())
+
+        val failure3 = HelloGrammar("world!")
+        assertThat(failure3.toString()).isEqualTo("""
+            |Expecting eof at line 0, column 5
+            |[Traceback]
+            |-->topLevel
+            |----><eof>
+        """.trimMargin())
     }
-  }
-
-  @Test
-  fun testIgnoring() {
-    val space: IgnoringParser<String> = -token(" ")
-    val ignoring = token("hello") + space + token("world")
-    ignoring("hello world").map { (hello, world), start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(11, 0, 11))
-      assertThat(hello).isEqualTo("hello")
-      assertThat(world).isEqualTo("world")
-      Success(hello, start, end)
-    }.orElse<Nothing> {
-      fail()
-    }
-  }
-
-  @Test
-  fun testEof() {
-    val hello = token("hello") + eof
-    hello("hello").map { match, start, end ->
-      assertThat(start).isEqualTo(SourcePosition(0, 0, 0))
-      assertThat(end).isEqualTo(SourcePosition(5, 0, 5))
-      assertThat(match).isEqualTo("hello")
-      assertThat("hello".rest(end)).isEqualTo("")
-      Success(match, start, end)
-    }.orElse<Nothing> {
-      fail()
-    }
-
-    val failure = hello("hello!2").map { _, s, e ->
-      require(false) { "Shouldn't be called" }
-      Failure("", s, e)
-    } as Failure
-
-    assertThat(failure.error).isEqualTo("Expecting eof")
-  }
 }

--- a/javatests/arcs/core/util/ParserTest.kt
+++ b/javatests/arcs/core/util/ParserTest.kt
@@ -190,27 +190,33 @@ class ParserTest {
     fun testGrammar() {
         val failure = HelloGrammar("foo")
         assertThat(failure.toString()).isEqualTo("""
-                |Expecting one of hello, world at line 0, column 0
-                |[Traceback]
-                |-->topLevel
-                |---->helloOrWorld
+            |foo
+            |^
+            |Expecting one of hello, world at line 0, column 0
+            |[Traceback]
+            |  at topLevel
+            |  at helloOrWorld
         """.trimMargin())
 
         val failure2 = HelloGrammar("hello")
         assertThat(failure2.toString()).isEqualTo("""
+            |ello
+            |    ^
             |Expecting world at line 0, column 5
             |[Traceback]
-            |-->topLevel
-            |---->helloOrWorld
-            |------>hello
+            |  at topLevel
+            |  at helloOrWorld
+            |  at hello
         """.trimMargin())
 
         val failure3 = HelloGrammar("world!")
         assertThat(failure3.toString()).isEqualTo("""
+            |orld!
+            |    ^
             |Expecting eof at line 0, column 5
             |[Traceback]
-            |-->topLevel
-            |----><eof>
+            |  at topLevel
+            |  at <eof>
         """.trimMargin())
     }
 }


### PR DESCRIPTION
* Introduce Grammar, a container for parser elements
** has a defined `topLevel` rule
** uses property delegation for automatic naming of rules

** Introduce `consumed` and `cause` fields to `Failure`
*** Allows traceback
*** AnyOfParser now selects parser that consumed the most tokens before failing as the likely error

Partially based off of https://www.microsoft.com/en-us/research/publication/parsec-direct-style-monadic-parser-combinators-for-the-real-world/

Caveats:
* Excessive object creation to do LL(infinity) lookahead
* Fix later by introduce `lazy` parsing, which allows parsers to return partial success after consuming one token
