### PR TITLE
Add check and warning for tests with duplicate names in sigh

### DIFF
--- a/src/dataflow/analysis/tests/graph-internals-test.ts
+++ b/src/dataflow/analysis/tests/graph-internals-test.ts
@@ -14,7 +14,7 @@ import {TestEdge, TestNode} from '../testing/flow-graph-testing.js';
 import {ClaimIsTag} from '../../../runtime/arcs-types/claim.js';
 
 describe('Flow', () => {
-  it('starts empty', () => {
+  it('flow starts empty', () => {
     const flow = new Flow();
     assert.strictEqual(flow.edgeIds.length, 0);
     assert.isEmpty(flow.nodeIds);

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -1256,23 +1256,6 @@ recipe SomeRecipe
     assert.lengthOf(recipe.handleConnections, 2);
     assert.isEmpty(recipe.handles);
   });
-  it('SLANDLES unnamed consume set slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
-        slotA: \`consumes [Slot]
-      particle SomeParticle1 &rest in 'some-particle.js'
-        slotC: \`consumes [Slot]
-
-      recipe
-        SomeParticle
-          slotA: \`consumes
-        SomeParticle1
-          slotC: \`consumes
-    `);
-    const recipe = manifest.recipes[0];
-    assert.lengthOf(recipe.handleConnections, 2);
-    assert.isEmpty(recipe.handles);
-  });
   it('resolves in context with multiple consumed slots', async () => {
     const parseRecipe = async (arg: {label: string, isRequiredSlotA: boolean, isRequiredSlotB: boolean, expectedIsResolved: boolean}) => {
       const recipe = (await parseManifest(`
@@ -1681,36 +1664,6 @@ recipe SomeRecipe
       particle ParticleA in 'some-particle.js'
         slotA1: \`consumes Slot
           slotA2: \`provides Slot
-      recipe
-        ParticleA
-          slotA1: \`consumes
-          slotA2: \`provides
-    `);
-    // Check that the manifest was parsed in the way we expect.
-    assert.lengthOf(manifest.particles, 1);
-    assert.lengthOf(manifest.recipes, 1);
-
-    const recipe = manifest.recipes[0];
-    // Check that the parser found the handleConnections
-    assert.lengthOf(recipe.handleConnections, 2);
-    assert.strictEqual('slotA1', recipe.handleConnections[0].name);
-    assert.strictEqual('slotA2', recipe.handleConnections[1].name);
-
-    // Check that the handle connection
-    // wasn't resolved to a handle (even though it was parsed).
-    assert.isUndefined(recipe.handleConnections[0].handle);
-    assert.isUndefined(recipe.handleConnections[1].handle);
-
-    // The recipe shouldn't resolve (as there is nothing providing slotA1 or
-    // consuming slotA2).
-    recipe.normalize();
-    assert.isFalse(recipe.isResolved());
-  });
-  it('SLANDLES recipe provided set slots with no local name', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
-        slotA1: \`consumes [Slot]
-          slotA2: \`provides [Slot]
       recipe
         ParticleA
           slotA1: \`consumes

--- a/src/types/tests/refiner-test.ts
+++ b/src/types/tests/refiner-test.ts
@@ -818,41 +818,44 @@ describe('refiner', () => {
         });
       });
       describe('for BigInt', () => {
-        it('control (ensure that the test approach works)', () => {
+        it('bigint: control (ensure that the test approach works)', () => {
           triviallyTrue('1n == 1n');
           triviallyTrue('1n != 2n');
         });
-        it('uses millseconds by default', () => {
+        it('bigint: uses millseconds by default', () => {
           triviallyTrue('1n == 1n milliseconds');
         });
-        it('seconds to milliseconds', () => {
+        it('bigint: seconds to milliseconds', () => {
           triviallyTrue('1000n == 1n seconds');
           triviallyTrue('2000n == 2n seconds');
         });
-        it('minutes to seconds', () => {
+        it('bigint: minutes to seconds', () => {
           triviallyTrue('1n minutes == 60n seconds');
           triviallyTrue('2n minutes == 120000n milliseconds');
         });
-        it('hours to minutes', () => {
+        it('bigint: hours to minutes', () => {
           triviallyTrue('1n hours == 60n minutes');
           triviallyTrue('2n hours == 7200n seconds');
         });
-        it('days to hours', () => {
+        it('bigint: days to hours', () => {
           triviallyTrue('1n days == 24n hours');
           triviallyTrue('2n days == 2880n minutes');
         });
-        it('handles singular and plural forms', () => {
+        it('bigint: handles singular and plural forms', () => {
           triviallyTrue('2n * 1n day == 2n days');
           triviallyTrue('1n day == 24n hours');
           triviallyTrue('1n day != 24n hours + 1n second');
         });
-        it('handles simple linear solving', () => {
+        it('bigint: handles simple linear solving', () => {
           triviallyTrue('(num + 1n milliseconds) > num', 'BigInt');
         });
-        it.skip('handles simple polynomial solving', () => {
+        it.skip('bigint: handles simple inequality solving', () => {
           triviallyTrue('num >= 0n or num <= 0n', 'BigInt');
           triviallyTrue('num >= 0n or num < 0n', 'BigInt');
           triviallyTrue('num > 0n or num <= 0n', 'BigInt');
+        });
+        it.skip('bigint: handles simple polynomial solving', () => {
+          triviallyTrue('num * num >= 0n', 'BigInt');
         });
       });
     });
@@ -1313,7 +1316,7 @@ describe('refiner', () => {
             }
           ]);
       });
-      it('tests union operations on a range', () => {
+      it('BigIntRange tests union operations on a range', () => {
           const range1 = new BigIntRange();
           // range1 = [];
           range1.unionWithSeg(BigIntSegment.closedClosed(BigInt(0), BigInt(10)));
@@ -1331,20 +1334,20 @@ describe('refiner', () => {
           // range1 = [-1, -1] U [0, 15) U (15, 19] U (20, 30]
           assert.deepEqual(range1, new BigIntRange([BigIntSegment.closedClosed(-BigInt(1), -BigInt(1)), BigIntSegment.closedOpen(BigInt(0), BigInt(15)), BigIntSegment.openClosed(BigInt(15), BigInt(19)), BigIntSegment.openClosed(BigInt(20), BigInt(30))]));
       });
-      it('tests intersection operations on a range 1', () => {
+      it('BigIntRange tests bigint intersection operations on a range 1', () => {
           const range1 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           // range1 = [0, 10] U [20,30];
           const range2 = range1.intersectWithSeg(BigIntSegment.openOpen(BigInt(5), BigInt(25)));
           // range2 = (5, 10] U [20, 25);
           assert.deepEqual(range2, new BigIntRange([BigIntSegment.openClosed(BigInt(5), BigInt(10)), BigIntSegment.closedOpen(BigInt(20), BigInt(25))]));
       });
-      it('tests intersection operations on a range 2', () => {
+      it('BigIntRange tests bigint intersection operations on a range 2', () => {
           const range1 = new BigIntRange([BigIntSegment.openClosed(BigInt(5), BigInt(10)), BigIntSegment.closedOpen(BigInt(20), BigInt(25))]);
           const range2 = range1.intersectWithSeg(BigIntSegment.closedOpen(BigInt(5), BigInt(15)));
           // range2 = (5, 10];
           assert.deepEqual(range2, new BigIntRange([BigIntSegment.openClosed(BigInt(5), BigInt(10))]));
       });
-      it('tests intersection operations on a range 3', () => {
+      it('BigIntRange tests bigint intersection operations on a range 3', () => {
           const range1 = new BigIntRange([BigIntSegment.openClosed(BigInt(5), BigInt(10))]);
           const range2 = new BigIntRange([BigIntSegment.closedClosed(-BigInt(1), -BigInt(1)), BigIntSegment.closedOpen(BigInt(4), BigInt(10)), BigIntSegment.closedClosed(BigInt(13), BigInt(19))]);
           // range2 = [-1, -1] U [4, 10) U [13,19];
@@ -1352,38 +1355,38 @@ describe('refiner', () => {
           // range3 = (5, 10);
           assert.deepEqual(range3, new BigIntRange([BigIntSegment.openOpen(BigInt(5), BigInt(10))]));
       });
-      it('tests if a range is a subset of another 1', () => {
+      it('BigIntRange tests if a bigint range is a subset of another 1', () => {
           const range1 = BigIntRange.universal('BigInt');
           // range1 = (-inf, +inf)
           const range2 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           // range2 = [0, 10] U [20,30];
           assert.isTrue(range2.isSubsetOf(range1));
       });
-      it('tests if a range is a subset of another 2', () => {
+      it('BigIntRange tests if a bigint range is a subset of another 2', () => {
           const range1 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           const range2 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           // range1 = [0, 10] U [20,30];
           assert.isTrue(range2.isSubsetOf(range1));
       });
-      it('tests if a range is a subset of another 3', () => {
+      it('BigIntRange tests if a bigint range is a subset of another 3', () => {
           const range1 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(22), BigInt(30))]);
           const range2 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           // range1 = [0, 10] U [22,30];
           assert.isFalse(range2.isSubsetOf(range1));
       });
-      it('tests if a range is a subset of another 4', () => {
+      it('BigIntRange tests if a bigint range is a subset of another 4', () => {
           const range1 = new BigIntRange();
           const range2 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           // range1 = [];
           assert.isTrue(range1.isSubsetOf(range2));
       });
-      it('tests if a range is a subset of another 5', () => {
+      it('BigIntRange tests if a bigint range is a subset of another 5', () => {
           const range1 = new BigIntRange([BigIntSegment.closedOpen(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           const range2 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
           // range1 = [0, 10) U [20,30];
           assert.isTrue(range1.isSubsetOf(range2));
       });
-      it('tests the difference of ranges 1', () => {
+      it('BigIntRange tests the difference of ranges 1', () => {
           const range1 = BigIntRange.universal('BigInt');
           // range1 = (-inf, +inf)
           const range2 = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10)), BigIntSegment.closedClosed(BigInt(20), BigInt(30))]);
@@ -1392,7 +1395,7 @@ describe('refiner', () => {
           // diff = (-inf, 0) U (10,20) U (30, inf)
           assert.deepEqual(diff, new BigIntRange([BigIntSegment.closedOpen('NEGATIVE_INFINITY', BigInt(0)), BigIntSegment.openOpen(BigInt(10), BigInt(20)), BigIntSegment.openClosed(BigInt(30), 'POSITIVE_INFINITY')]));
       });
-      it('tests the difference of ranges 2', () => {
+      it('BigIntRange tests the difference of ranges 2', () => {
           const range1 = new BigIntRange([BigIntSegment.closedOpen(BigInt(0), BigInt(20)), BigIntSegment.openClosed(BigInt(40), BigInt(50))]);
           // range1 = [0,20) U (40, 50]
           const range2 = new BigIntRange([BigIntSegment.openOpen(BigInt(0), BigInt(5)), BigIntSegment.closedOpen(BigInt(7), BigInt(12)), BigIntSegment.closedClosed(BigInt(15), BigInt(43)), BigIntSegment.openClosed(BigInt(45), BigInt(50))]);
@@ -1401,14 +1404,14 @@ describe('refiner', () => {
           // diff = [0, 0] U [5,7) U [12,15) U (43, 45]
           assert.deepEqual(diff, new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(0)), BigIntSegment.closedOpen(BigInt(5), BigInt(7)), BigIntSegment.closedOpen(BigInt(12), BigInt(15)), BigIntSegment.openClosed(BigInt(43), BigInt(45))]));
       });
-      it('tests the complement of ranges 1', () => {
+      it('BigIntRange tests the complement of ranges 1', () => {
         const range = new BigIntRange([BigIntSegment.closedClosed(BigInt(0), BigInt(10))]);
         // range =  [0,10]
         const complement = range.complement();
         // complement = (-inf, 0) U (10, inf)
         assert.deepEqual(complement, new BigIntRange([BigIntSegment.closedOpen('NEGATIVE_INFINITY', BigInt(0)), BigIntSegment.openClosed(BigInt(10), 'POSITIVE_INFINITY')]));
       });
-      it('tests the complement of ranges 2', () => {
+      it('BigIntRange tests the complement of ranges 2', () => {
         const range = BigIntRange.unit(BigInt(0), 'Boolean');
         // range = [0,0]
         const complement = range.complement();
@@ -1421,7 +1424,7 @@ describe('refiner', () => {
     const cnst = new BigIntTerm({});
     const a = new BigIntTerm({'a': BigInt(1)});         // a
     const a2 = new BigIntTerm({'a': BigInt(2)});        // a^2
-    it('tests fraction addition works 1', () => {
+    it('BigIntRange tests fraction addition works 1', () => {
       const num1 = new BigIntMultinomial({
           [a2.toKey()]: BigInt(1),                  // a^2
           [a.toKey()]: BigInt(1),                   // a
@@ -1449,7 +1452,7 @@ describe('refiner', () => {
         [a.toKey()]: BigInt(6)                      // 6a
       });
     });
-    it('tests fraction addition works 2', () => {
+    it('BigIntRange tests fraction addition works 2', () => {
       const num1 = new BigIntMultinomial({
         [a.toKey()]: BigInt(1),                     // a
       }); // a
@@ -1470,7 +1473,7 @@ describe('refiner', () => {
         [cnst.toKey()]: BigInt(9)                   // 9
       });
     });
-    it('tests fraction subtraction works', () => {
+    it('BigIntRange tests fraction subtraction works', () => {
       const num1 = new BigIntMultinomial({
           [a2.toKey()]: BigInt(1),                          // a^2
           [a.toKey()]: BigInt(1),                           // a
@@ -1498,7 +1501,7 @@ describe('refiner', () => {
         [a.toKey()]: BigInt(6),                             // 6a
       });
     });
-    it('tests fraction negation works', () => {
+    it('BigIntRange tests fraction negation works', () => {
       const num1 = new BigIntMultinomial({
           [a2.toKey()]: BigInt(1),                          // a^2
           [a.toKey()]: BigInt(1),                           // a
@@ -1518,7 +1521,7 @@ describe('refiner', () => {
         [a.toKey()]: BigInt(2),  // 2a
       });
     });
-    it('tests fraction multiplication works', () => {
+    it('BigIntRange tests fraction multiplication works', () => {
       const num1 = new BigIntMultinomial({
           [a.toKey()]: BigInt(1),                           // a
           [cnst.toKey()]: BigInt(9)                         // 9
@@ -1556,7 +1559,7 @@ describe('refiner', () => {
         [cnst.toKey()]: BigInt(1)                           // 1
       });
     });
-    it('tests fraction division works', () => {
+    it('BigIntRange tests fraction division works', () => {
       const num1 = new BigIntMultinomial({
           [a.toKey()]: BigInt(1),                           // a
           [cnst.toKey()]: BigInt(9)                         // 9
@@ -1586,7 +1589,7 @@ describe('refiner', () => {
   });
 
   describe('Terms', () => {
-    it('tests to and from key', () => {
+    it('BigIntRange tests to and from key', () => {
       const term1 = new BigIntTerm({'b': BigInt(1), 'a': BigInt(1)});
       const term2 = new BigIntTerm({'a': BigInt(1), 'b': BigInt(1)});
       assert.strictEqual(term1.toKey(), term2.toKey());
@@ -1595,7 +1598,7 @@ describe('refiner', () => {
   });
 
   describe('BigIntMultinomials', () => {
-    it('tests multinomial setters and getters work', () => {
+    it('tests bigint multinomial setters and getters work', () => {
       const aIb = new BigIntTerm({'b': BigInt(1), 'a': BigInt(1)});  // ab
       const aIb2 = new BigIntTerm({'b': BigInt(2), 'a': BigInt(1)}); // ab^2
       const cnst = new BigIntTerm({});
@@ -1610,7 +1613,7 @@ describe('refiner', () => {
           [aIb.toKey()]: BigInt(2),   // 2ab
       });
     });
-    it('tests multinomial addition works', () => {
+    it('tests bigint multinomial addition works', () => {
       const aIb = new BigIntTerm({'b': BigInt(1), 'a': BigInt(1)}); // ab
       const aIb2 = new BigIntTerm({'b': BigInt(2), 'a': BigInt(1)}); // ab^2
       const cnst = new BigIntTerm({});
@@ -1630,7 +1633,7 @@ describe('refiner', () => {
         [cnst.toKey()]: BigInt(6)   // 6
       });
     });
-    it('tests multinomial negation works', () => {
+    it('tests bigint multinomial negation works', () => {
       const aIb2 = new BigIntTerm({'b': BigInt(2), 'a': BigInt(1)}); // ab^2
       const cnst = new BigIntTerm({});
       const num1 = new BigIntMultinomial({
@@ -1643,7 +1646,7 @@ describe('refiner', () => {
         [cnst.toKey()]: -BigInt(1)   // -1
       });
     });
-    it('tests multinomial subtraction works', () => {
+    it('tests bigint multinomial subtraction works', () => {
       const aIb = new BigIntTerm({'b': BigInt(1), 'a': BigInt(1)}); // ab
       const aIb2 = new BigIntTerm({'b': BigInt(2), 'a': BigInt(1)}); // ab^2
       const cnst = new BigIntTerm({});
@@ -1662,7 +1665,7 @@ describe('refiner', () => {
         [cnst.toKey()]: -BigInt(4)   // -4
       });
     });
-    it('tests multinomial multiplication works', () => {
+    it('tests bigint multinomial multiplication works', () => {
       const aIb = new BigIntTerm({'b': BigInt(1), 'a': BigInt(1)}); // ab
       const aIb2 = new BigIntTerm({'b': BigInt(2), 'a': BigInt(1)}); // ab^2
       const cnst = new BigIntTerm({});

--- a/src/types/tests/type-test.ts
+++ b/src/types/tests/type-test.ts
@@ -38,7 +38,7 @@ describe('types', () => {
       assert.deepEqual(JSON.parse(JSON.stringify(a)), JSON.parse(JSON.stringify(b)));
     }
 
-    it('Entity', () => {
+    it('EntityType makes expected literal', async () => {
       const entity = EntityType.make(['Foo'], {value: 'Text'});
       deepEqual(entity.toLiteral(), {
         tag: 'Entity',
@@ -48,7 +48,7 @@ describe('types', () => {
       deepEqual(entity, entity.clone(new Map()));
     });
 
-    it('Entity with refinement', () => {
+    it('EntityType with refinement makes expected literal', async () => {
       const ref = Refinement.fromAst({
         kind: 'refinement',
         location: null,

--- a/src/utils/tests/indenting-string-builder-test.ts
+++ b/src/utils/tests/indenting-string-builder-test.ts
@@ -18,7 +18,7 @@ describe('IndentingStringBuilder', () => {
     builder = new IndentingStringBuilder();
   });
 
-  it('starts empty', () => {
+  it('builder starts empty', () => {
     assert.strictEqual(builder.toString(), '');
   });
 

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -827,7 +827,7 @@ function runTests(args: string[]): boolean {
                 header = false;
                 console.warn(\`WARNING: Test names re-used:\`);
               }
-              console.warn(\`    \${title}\`);
+              console.warn(\`    \${title} x\${testTitles.get(title)}\`);
             }
           }
         });

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -814,6 +814,23 @@ function runTests(args: string[]): boolean {
           runner.abort();
           throw reason;
         });
+        const testTitles = new Map();
+        beforeEach(function () {
+          const title = this.currentTest.title;
+          testTitles.set(title, (testTitles.get(title) || 0) + 1);
+        });
+        after(function () {
+          let header = true;
+          for (let title of testTitles.keys()) {
+            if (testTitles.get(title) > 1) {
+              if (header) {
+                header = false;
+                console.warn(\`WARNING: Test names re-used:\`);
+              }
+              console.warn(\`    \${title}\`);
+            }
+          }
+        });
       })();
     `;
     const runnerFile = path.join(tempDir, 'runner.js');


### PR DESCRIPTION
I've noticed that a few times when making large changes or making tests based on other tests that I have accidentally created duplicate tests or tests with the same name that, cannot then be uniquely referenced by name.

I'm not sure this is a serious issue but created a small patch that makes a record of all test names just before they run and then, after all tests have run, checks for any duplicates.

This has helped me catch a few duplicate tests and rename others tests that actually test different things.

Happy for discussion to decide whether this is worth landing. The log noise that it introduces while we have tests that share a name is fairly small but still represents a regression, though renaming the tests will fix that issue.

Alternatively we could introduce a counter so that the lint only shows up when new duplicates are created and aim to reduce the counter to zero, like we have done for cycle checking.