### PR TITLE
use StoreInfo instead of Store in methods in Arc and Manifest. 

### DIFF
--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -17,7 +17,7 @@ import {Runtime} from '../../runtime/runtime.js';
 import {SingletonType} from '../../types/lib-types.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {Entity} from '../../runtime/entity.js';
-import {SingletonEntityStore, ActiveSingletonEntityStore, handleForStore} from '../../runtime/storage/storage.js';
+import {ActiveSingletonEntityStore, handleForStoreInfo} from '../../runtime/storage/storage.js';
 
 describe('ArcStoresFetcher', () => {
   before(() => DevtoolsForTests.ensureStub());
@@ -32,7 +32,7 @@ describe('ArcStoresFetcher', () => {
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
     const fooStore = await arc.createStore(new SingletonType(foo.type), 'fooStoreName', 'fooStoreId', ['awesome', 'arcs']);
-    const fooHandle = await handleForStore(fooStore, arc);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
     const fooEntity = new foo({value: 'persistence is useful'});
     await fooHandle.set(fooEntity);
 
@@ -130,7 +130,7 @@ describe('ArcStoresFetcher', () => {
     assert.lengthOf(results, 1);
 
     const sessionId = arc.idGenerator.currentSessionIdForTesting;
-    const store = await arc.findStoreById(arc.activeRecipe.handles[0].id).activate() as ActiveSingletonEntityStore;
+    const store = await arc.findActiveStoreById(arc.activeRecipe.handles[0].id).activate() as ActiveSingletonEntityStore;
     // TODO(mmandlis): there should be a better way!
     const creationTimestamp = Object.values((await store.serializeContents()).values)[0]['value']['creationTimestamp'];
     assert.deepEqual(results[0].messageBody, {

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -151,7 +151,8 @@ export class Planificator {
   private _listenToArcStores() {
     this.arc.onDataChange(this.dataChangeCallback, this);
     this.storeCallbackIds = new Map();
-    this.arc.context.allStores.forEach(async store => {
+    this.arc.context.allStores.forEach(async storeInfo => {
+      const store = this.arc.context.getActiveStore(storeInfo);
       const callbackId = (await store.activate()).on(async () => this.replanQueue.addChange());
       this.storeCallbackIds.set(store, callbackId);
     });
@@ -159,7 +160,8 @@ export class Planificator {
 
   private _unlistenToArcStores() {
     this.arc.clearDataChange(this);
-    this.arc.context.allStores.forEach(async store => {
+    this.arc.context.allStores.forEach(async storeInfo => {
+      const store = this.arc.context.getActiveStore(storeInfo);
       const callbackId = this.storeCallbackIds.get(store);
       (await store.activate()).off(callbackId);
     });

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -51,7 +51,7 @@ export class Planificator {
     debug = debug || (Boolean(storageKeyBase) && isVolatile(storageKeyBase));
     const store = await Planificator._initSuggestStore(arc, storageKeyBase);
     const searchStore = await Planificator._initSearchStore(arc);
-    const result = new PlanningResult({context: arc.context, loader: arc.loader}, store);
+    const result = new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}, store);
     await result.load();
     const planificator = new Planificator(arc, result, searchStore, onlyConsumer, debug, inspectorFactory, noSpecEx);
     await planificator._storeSearch(); // Reset search value for the current arc.
@@ -152,7 +152,7 @@ export class Planificator {
     this.arc.onDataChange(this.dataChangeCallback, this);
     this.storeCallbackIds = new Map();
     this.arc.context.allStores.forEach(async storeInfo => {
-      const store = this.arc.context.getActiveStore(storeInfo);
+      const store = this.arc.getActiveStore(storeInfo);
       const callbackId = (await store.activate()).on(async () => this.replanQueue.addChange());
       this.storeCallbackIds.set(store, callbackId);
     });
@@ -161,7 +161,7 @@ export class Planificator {
   private _unlistenToArcStores() {
     this.arc.clearDataChange(this);
     this.arc.context.allStores.forEach(async storeInfo => {
-      const store = this.arc.context.getActiveStore(storeInfo);
+      const store = this.arc.getActiveStore(storeInfo);
       const callbackId = this.storeCallbackIds.get(store);
       (await store.activate()).off(callbackId);
     });

--- a/src/planning/plan/planning-result.ts
+++ b/src/planning/plan/planning-result.ts
@@ -49,9 +49,10 @@ export class PlanningResult {
     this.envOptions = envOptions;
     assert(envOptions.context, `context cannot be null`);
     assert(envOptions.loader, `loader cannot be null`);
+    assert(envOptions.storageService, `storageService cannot be null`);
     this.store = store;
     if (this.store) {
-      this.handle = handleForActiveStore(store, envOptions.context);
+      this.handle = handleForActiveStore(store, {...envOptions.context, storageService: envOptions.storageService});
       this.storeCallbackId = this.store.on(() => this.load());
     }
   }

--- a/src/planning/plan/suggestion.ts
+++ b/src/planning/plan/suggestion.ts
@@ -21,6 +21,7 @@ import {Recipe, Search} from '../../runtime/recipe/lib-recipe.js';
 import {Relevance} from '../../runtime/relevance.js';
 import {SuggestFilter} from './suggest-filter.js';
 import {isRoot} from '../../runtime/arcs-types/particle-spec.js';
+import {StorageService} from '../../runtime/storage/storage-service.js';
 
 
 export type DescriptionProperties = {
@@ -46,6 +47,7 @@ export type FromLiteralOptions = {
 export type EnvOptions = {
   context: Manifest;
   loader: Loader;
+  storageService: StorageService;
 };
 
 export type SuggestionVisibilityOptions = {reasons?: string[]};

--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -29,7 +29,7 @@ import {ActiveSingletonEntityStore} from '../../../runtime/storage/storage.js';
 async function createPlanConsumer(arc: Arc) {
   const store: ActiveSingletonEntityStore = await Planificator['_initSuggestStore'](arc);
   assert.isNotNull(store);
-  const result = new PlanningResult({context: arc.context, loader: arc.loader}, store);
+  const result = new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}, store);
   return new PlanConsumer(arc, result);
 }
 

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -34,7 +34,7 @@ class TestPlanProducer extends PlanProducer {
   plannerPromise = null;
 
   constructor(arc, store) {
-    super(arc, new PlanningResult({context: arc.context, loader: arc.loader}, store));
+    super(arc, new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}, store));
   }
 
   async produceSuggestions(options = {}) {
@@ -152,7 +152,7 @@ describe('plan producer - search', () => {
     produceSuggestionsCalled = 0;
 
     constructor(arc: Arc, searchStore: ActiveSingletonEntityStore) {
-      super(arc, new PlanningResult({context: arc.context, loader: arc.loader}, searchStore), searchStore);
+      super(arc, new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}, searchStore), searchStore);
     }
 
     async produceSuggestions(options = {}) {

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -63,11 +63,10 @@ describe('remote planificator', () => {
   async function createArc(options, storageKey) {
     const {manifestString, manifestFilename} = options;
     const loader = new Loader();
-    const storageService = new StorageServiceImpl();
     const context = manifestString
-        ? await Manifest.parse(manifestString, {loader, fileName: '', memoryProvider, storageService})
-        : await Manifest.load(manifestFilename, loader, {memoryProvider, storageService});
-    const runtime = new Runtime({loader, context, memoryProvider, storageService});
+        ? await Manifest.parse(manifestString, {loader, fileName: '', memoryProvider})
+        : await Manifest.load(manifestFilename, loader, {memoryProvider});
+    const runtime = new Runtime({loader, context, memoryProvider, storageService: new StorageServiceImpl()});
     return runtime.newArc('demo', storageKey);
   }
   async function createConsumePlanificator(manifestFilename) {
@@ -77,7 +76,7 @@ describe('remote planificator', () => {
   }
 
   function createPlanningResult(arc, store) {
-    return new PlanningResult({context: arc.context, loader: arc.loader}, store);
+    return new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}, store);
   }
 
   async function createProducePlanificator(manifestFilename, store, searchStore) {

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -63,10 +63,11 @@ describe('remote planificator', () => {
   async function createArc(options, storageKey) {
     const {manifestString, manifestFilename} = options;
     const loader = new Loader();
+    const storageService = new StorageServiceImpl();
     const context = manifestString
-        ? await Manifest.parse(manifestString, {loader, fileName: '', memoryProvider})
-        : await Manifest.load(manifestFilename, loader, {memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+        ? await Manifest.parse(manifestString, {loader, fileName: '', memoryProvider, storageService})
+        : await Manifest.load(manifestFilename, loader, {memoryProvider, storageService});
+    const runtime = new Runtime({loader, context, memoryProvider, storageService});
     return runtime.newArc('demo', storageKey);
   }
   async function createConsumePlanificator(manifestFilename) {

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -32,15 +32,16 @@ describe('planning result', () => {
     const context = await Manifest.load(manifestFilename, loader, {memoryProvider});
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const storageService = arc.storageService;
     const suggestions = await StrategyTestHelper.planForArc(arc);
 
     assert.isNotEmpty(suggestions);
-    const result = new PlanningResult({context, loader});
+    const result = new PlanningResult({context, loader, storageService});
     result.merge({suggestions}, arc);
 
     const serialization = result.toLiteral();
     assert(serialization.suggestions);
-    const resultNew = new PlanningResult({context, loader});
+    const resultNew = new PlanningResult({context, loader, storageService});
     assert.isEmpty(resultNew.suggestions);
     await resultNew.fromLiteral({suggestions: serialization.suggestions});
     assert.isTrue(resultNew.isEquivalent(suggestions));
@@ -54,9 +55,10 @@ describe('planning result', () => {
     const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const storageService = arc.storageService;
     const suggestions = await StrategyTestHelper.planForArc(arc);
 
-    const result = new PlanningResult({loader, context});
+    const result = new PlanningResult({loader, context, storageService});
     // Appends new suggestion.
     assert.isTrue(result.merge({suggestions}, arc));
     assert.lengthOf(result.suggestions, 1);
@@ -138,7 +140,7 @@ recipe R3
     };
     const manifestToResult = async (manifestStr) =>  {
       const manifest = await Manifest.parse(manifestStr, {loader, fileName: '', memoryProvider});
-      const result = new PlanningResult({context: arc.context, loader});
+      const result = new PlanningResult({context: arc.context, loader, storageService: arc.storageService});
 
       const suggestions: Suggestion[] = await Promise.all(
         manifest.recipes.map(async plan => planToSuggestion(plan)) as Promise<Suggestion>[]

--- a/src/planning/plan/tests/replan-queue-test.ts
+++ b/src/planning/plan/tests/replan-queue-test.ts
@@ -22,7 +22,7 @@ class TestPlanProducer extends PlanProducer {
   produceSuggestionsCalled = 0;
 
   constructor(arc: Arc) {
-    super(arc, new PlanningResult({context: arc.context, loader: arc.loader}));
+    super(arc, new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}));
   }
 
   async produceSuggestions(options = {}) {

--- a/src/planning/plan/tests/suggestion-test.ts
+++ b/src/planning/plan/tests/suggestion-test.ts
@@ -12,6 +12,7 @@ import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {Suggestion} from '../../plan/suggestion.js';
 import {newRecipe, newSearch} from '../../../runtime/recipe/lib-recipe.js';
+import {StorageServiceImpl} from '../../../runtime/storage/storage-service.js';
 
 describe('suggestion', () => {
   function createSuggestion(hash, descriptionText) {
@@ -63,7 +64,7 @@ describe('suggestion', () => {
   });
 
   it('deserialize empty', async () => {
-    const envOptions = {loader: new Loader(), context: new Manifest({id: 'test'})};
+    const envOptions = {loader: new Loader(), context: new Manifest({id: 'test'}), storageService: new StorageServiceImpl()};
     const plan = newRecipe();
     const suggestion1 = await Suggestion.fromLiteral({plan: plan.toString(), hash: '123', rank: 1}, envOptions);
     assert.isTrue(Boolean(suggestion1.plan));

--- a/src/planning/strategies/assign-handles.ts
+++ b/src/planning/strategies/assign-handles.ts
@@ -10,9 +10,9 @@
 
 import {assert} from '../../platform/assert-web.js';
 import {StrategizerWalker, Strategy} from '../strategizer.js';
-import {Store} from '../../runtime/storage/store.js';
 import {directionCounts, DirectionCounts} from '../../runtime/recipe/lib-recipe.js';
-import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
+import {StoreInfo} from '../../runtime/storage/store-info.js';
+import {Type} from '../../types/lib-types.js';
 
 export class AssignHandles extends Strategy {
   async generate(inputParams) {
@@ -95,8 +95,8 @@ export class AssignHandles extends Strategy {
     }(StrategizerWalker.Permuted), this);
   }
 
-  getMappableStores(fate, type, tags: string[], counts: DirectionCounts): Map<Store<CRDTTypeRecord>, string> {
-    const stores: Map<Store<CRDTTypeRecord>, string> = new Map();
+  getMappableStores(fate, type, tags: string[], counts: DirectionCounts): Map<StoreInfo<Type>, string> {
+    const stores: Map<StoreInfo<Type>, string> = new Map();
 
     if (fate === 'use' || fate === '?') {
       this.arc.findStoresByType(type, {tags}).forEach(store => stores.set(store, 'use'));

--- a/src/planning/strategies/search-tokens-to-handles.ts
+++ b/src/planning/strategies/search-tokens-to-handles.ts
@@ -9,9 +9,10 @@
  */
 
 import {StrategizerWalker, Strategy} from '../strategizer.js';
-import {Store} from '../../runtime/storage/store.js';
 import {directionCounts} from '../../runtime/recipe/lib-recipe.js';
 import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
+import {StoreInfo} from '../../runtime/storage/store-info.js';
+import {Type} from '../../types/lib-types.js';
 
 export class SearchTokensToHandles extends Strategy {
 
@@ -21,7 +22,7 @@ export class SearchTokensToHandles extends Strategy {
     // which are not already mapped into the provided handle's recipe
     const findMatchingStores = (token, handle) => {
       const counts = directionCounts(handle);
-      let stores: Store<CRDTTypeRecord>[];
+      let stores: StoreInfo<Type>[];
       stores = arc.findStoresByType(handle.type, {tags: [`${token}`]});
       let fate = 'use';
       if (stores.length === 0) {

--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -17,7 +17,7 @@ import {InterfaceType} from '../../../types/lib-types.js';
 import {FindHostedParticle} from '../../strategies/find-hosted-particle.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {ArcId} from '../../../runtime/id.js';
-import {SingletonInterfaceHandle, handleForStore} from '../../../runtime/storage/storage.js';
+import {handleForStoreInfo} from '../../../runtime/storage/storage.js';
 import {isSingletonInterfaceStore} from '../../../runtime/storage/store.js';
 import {Runtime} from '../../../runtime/runtime.js';
 
@@ -176,7 +176,7 @@ describe('FindHostedParticle', () => {
     assert.isEmpty(arc.stores);
     await arc.instantiate(outRecipe);
     const particleSpecStore = arc.stores.find(isSingletonInterfaceStore);
-    const handle = await handleForStore(particleSpecStore, arc);
+    const handle = await handleForStoreInfo(particleSpecStore, arc);
     const particleSpec = await handle.fetch();
     // TODO(shans): fix this by putting an id field on particleSpec, or by having a ParticleSpec subclass
     // for storing.

--- a/src/planning/strategies/tests/match-particle-by-verb-test.ts
+++ b/src/planning/strategies/tests/match-particle-by-verb-test.ts
@@ -18,8 +18,8 @@ import {MatchParticleByVerb} from '../../strategies/match-particle-by-verb.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 
 import {Entity} from '../../../runtime/entity.js';
-import {Store} from '../../../runtime/storage/store.js';
 import {CRDTTypeRecord} from '../../../crdt/lib-crdt.js';
+import {StoreInfo} from '../../../runtime/storage/store-info.js';
 
 describe('MatchParticleByVerb', () => {
   const manifestStr = `
@@ -71,8 +71,8 @@ describe('MatchParticleByVerb', () => {
   it('particles by verb recipe fully resolved', async () => {
     const manifest = (await Manifest.parse(manifestStr));
     const recipe = manifest.recipes[0];
-    recipe.handles[0].mapToStorage({id: 'test1', type: Entity.createEntityClass(manifest.findSchemaByName('Height'), null).type} as unknown as Store<CRDTTypeRecord>);
-    recipe.handles[1].mapToStorage({id: 'test2', type: Entity.createEntityClass(manifest.findSchemaByName('Energy'), null).type} as unknown as Store<CRDTTypeRecord>);
+    recipe.handles[0].mapToStorage(new StoreInfo({id: 'test1', type: Entity.createEntityClass(manifest.findSchemaByName('Height'), null).type}));
+    recipe.handles[1].mapToStorage(new StoreInfo({id: 'test2', type: Entity.createEntityClass(manifest.findSchemaByName('Energy'), null).type}));
 
     const arc = StrategyTestHelper.createTestArc(manifest, {modality: Modality.dom});
 

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -40,7 +40,7 @@ describe('SearchTokensToHandles', () => {
     `, {memoryProvider}));
 
     const arc = StrategyTestHelper.createTestArc(manifest);
-    await arc._registerStore(arc.context.getStoreById('thing-id'), ['mything']);
+    await arc._registerStore(arc.context.findStoreById('thing-id'), ['mything']);
 
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/api-channel.ts
+++ b/src/runtime/api-channel.ts
@@ -14,7 +14,7 @@ import {ArcInspector} from './arc-inspector.js';
 import {ParticleSpec} from './arcs-types/particle-spec.js';
 import {Particle} from './particle.js';
 import * as libRecipe from './recipe/lib-recipe.js';
-import {StorageProxy as StorageProxyNG} from './storage/storage-proxy.js';
+import {StorageProxy} from './storage/storage-proxy.js';
 import {Type} from '../types/lib-types.js';
 import {PropagatedException, reportGlobalException} from './arc-exceptions.js';
 import {Consumer, Literal, Literalizable, floatingPromiseToAudit} from '../utils/lib-utils.js';
@@ -27,8 +27,6 @@ import {Ttl} from './capabilities.js';
 import {Handle} from './storage/handle.js';
 import {StorageProxyMuxer} from './storage/storage-proxy-muxer.js';
 import {CRDTMuxEntity} from './storage/storage.js';
-
-type StorageProxy = StorageProxyNG<CRDTTypeRecord>;
 
 enum MappingType {Mapped, LocalMapped, RemoteMapped, Direct, ObjectMap, List, ByLiteral}
 
@@ -586,7 +584,7 @@ export abstract class PECInnerPort extends APIPort {
   abstract onStop();
   abstract onDefineHandle(identifier: string, type: Type, name: string, storageKey: string, ttl: Ttl);
   abstract onDefineHandleFactory(identifier: string, type: Type, name: string, storageKey: string, ttl: Ttl);
-  abstract onInstantiateParticle(id: string, spec: ParticleSpec, proxies: Map<string, StorageProxy|StorageProxyNG<CRDTTypeRecord>>, proxyMuxers: Map<string, StorageProxyMuxer<CRDTMuxEntity>>, reinstantiate: boolean);
+  abstract onInstantiateParticle(id: string, spec: ParticleSpec, proxies: Map<string, StorageProxy<CRDTTypeRecord>>, proxyMuxers: Map<string, StorageProxyMuxer<CRDTMuxEntity>>, reinstantiate: boolean);
   abstract onReloadParticles(ids: string[]);
 
   abstract onUIEvent(particle: Particle, slotName: string, event: {});
@@ -596,14 +594,14 @@ export abstract class PECInnerPort extends APIPort {
   Output(@Mapped particle: Particle, @Direct content: {}) {}
 
   Register(
-    @Mapped handle: StorageProxy,
+    @Mapped handle: StorageProxy<CRDTTypeRecord>,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
     @LocalMapped idCallback: Consumer<number>): void {}
   DirectStoreMuxerRegister(
     @Mapped handle: StorageProxyMuxer<CRDTTypeRecord>,
     @LocalMapped messagesCallback: ProxyCallback<CRDTTypeRecord>,
     @LocalMapped idCallback: Consumer<number>): void {}
-  ProxyMessage(@Mapped handle: StorageProxy, @Direct message: ProxyMessage<CRDTTypeRecord>): void {}
+  ProxyMessage(@Mapped handle: StorageProxy<CRDTTypeRecord>, @Direct message: ProxyMessage<CRDTTypeRecord>): void {}
   StorageProxyMuxerMessage(@Mapped handle: StorageProxyMuxer<CRDTTypeRecord>, @Direct message: ProxyMessage<CRDTTypeRecord>): void {}
 
   Idle(@Direct version: number, @ObjectMap(MappingType.Mapped, MappingType.Direct) relevance: Map<Particle, number[]>) {}
@@ -614,8 +612,8 @@ export abstract class PECInnerPort extends APIPort {
   ConstructInnerArc(@LocalMapped callback: Consumer<string>, @Mapped particle: Particle) {}
   abstract onConstructArcCallback(callback: Consumer<string>, arc: string);
 
-  ArcCreateHandle(@LocalMapped callback: Consumer<StorageProxy>, @RemoteMapped arc: {}, @ByLiteral(Type) type: Type, @Direct name: string) {}
-  abstract onCreateHandleCallback(callback: Consumer<StorageProxy>, type: Type, name: string, id: string);
+  ArcCreateHandle(@LocalMapped callback: Consumer<StorageProxy<CRDTTypeRecord>>, @RemoteMapped arc: {}, @ByLiteral(Type) type: Type, @Direct name: string) {}
+  abstract onCreateHandleCallback(callback: Consumer<StorageProxy<CRDTTypeRecord>>, type: Type, name: string, id: string);
   ArcMapHandle(@LocalMapped callback: Consumer<string>, @RemoteMapped arc: {}, @Mapped handle: Handle<CRDTTypeRecord>) {}
   abstract onMapHandleCallback(callback: Consumer<string>, id: string);
 

--- a/src/runtime/arc-serializer.ts
+++ b/src/runtime/arc-serializer.ts
@@ -8,7 +8,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Store} from './storage/store.js';
 import {InterfaceType} from '../types/lib-types.js';
 import {StorageKey} from './storage/storage-key.js';
 import {ParticleSpec} from './arcs-types/particle-spec.js';
@@ -18,6 +17,8 @@ import {Id} from './id.js';
 import {VolatileMemory, VolatileStorageKey} from './storage/drivers/volatile.js';
 import {IndentingStringBuilder, Dictionary} from '../utils/lib-utils.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
+import {StoreInfo} from './storage/store-info.js';
+import {Type} from '../types/lib-types.js';
 
 /**
  * @license
@@ -34,7 +35,7 @@ export interface ArcInterface {
   id: Id;
   storeTagsById: Dictionary<Set<string>>;
   context: Manifest;
-  stores: Store<CRDTTypeRecord>[];
+  stores: StoreInfo<Type>[];
   storageKey?: string | StorageKey;
   volatileMemory: VolatileMemory;
 }
@@ -86,7 +87,7 @@ ${this.arc.activeRecipe.toString()}`;
     return builder.toString();
   }
 
-  private async _serializeStore(store: Store<CRDTTypeRecord>, name: string): Promise<void> {
+  private async _serializeStore(store: StoreInfo<Type>, name: string): Promise<void> {
     const type = store.type.getContainedType() || store.type;
     if (type instanceof InterfaceType) {
       this.interfaces += type.interfaceInfo.toManifestString() + '\n';

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -90,7 +90,7 @@ export class Arc implements ArcInterface {
   // Map from each store ID to a set of tags. public for debug access
   public readonly storeTagsById: Dictionary<Set<string>> = {};
   // Map from each store to its description (originating in the manifest).
-  private readonly storeDescriptions = new Map<Store<CRDTTypeRecord>, string>();
+  private readonly storeDescriptions = new Map<StoreInfo<Type>, string>();
   private waitForIdlePromise: Promise<void> | null;
   private readonly inspectorFactory?: ArcInspectorFactory;
   public readonly inspector?: ArcInspector;
@@ -265,11 +265,10 @@ export class Arc implements ArcInterface {
     await Promise.all(manifest.stores.map(async storeStub => {
       const tags = [...manifest.storeTagsById[storeStub.id]];
       if (storeStub.storageKey instanceof VolatileStorageKey) {
-        arc.volatileMemory.deserialize(storeStub.storeInfo.model, storeStub.storageKey.unique);
+        arc.volatileMemory.deserialize(storeStub.model, storeStub.storageKey.unique);
       }
-      const store = await storeStub.activate();
-      await arc._registerStore(store.baseStore, tags);
-      arc.addStoreToRecipe(store.baseStore);
+      await arc._registerStore(storeStub, tags);
+      arc.addStoreToRecipe(storeStub);
     }));
     const recipe = manifest.activeRecipe.clone();
     const options: IsValidOptions = {errors: new Map()};
@@ -311,6 +310,7 @@ export class Arc implements ArcInterface {
     this.peh.instantiate(recipeParticle, info.stores, info.storeMuxers, reinstantiate);
   }
 
+  // TODO: return value should contain StoreInfos instead!
   async _getParticleInstantiationInfo(recipeParticle: Particle): Promise<{spec: ParticleSpec, stores: Map<string, Store<CRDTTypeRecord>>, storeMuxers: Map<string, Store<CRDTTypeRecord>>}> {
     const info = {spec: recipeParticle.spec, stores: new Map<string, Store<CRDTTypeRecord>>(), storeMuxers: new Map<string, Store<CRDTTypeRecord>>()};
     this.loadedParticleInfo.set(recipeParticle.id.toString(), info);
@@ -325,10 +325,11 @@ export class Arc implements ArcInterface {
         const store = this.findStoreById(connection.handle.id);
         assert(store, `can't find store of id ${connection.handle.id}`);
         assert(info.spec.handleConnectionMap.get(name) !== undefined, 'can\'t connect handle to a connection that doesn\'t exist');
+        const theStore = this.getActiveStore(store);
         if (isMuxEntityStore(store)) {
-          info.storeMuxers.set(name, store as Store<CRDTTypeRecord>);
+          info.storeMuxers.set(name, theStore);
         } else {
-          info.stores.set(name, store as Store<CRDTTypeRecord>);
+          info.stores.set(name, theStore);
         }
       }
     }
@@ -351,11 +352,23 @@ export class Arc implements ArcInterface {
     return this.idGenerator.newChildId(this.id, component);
   }
 
-  get stores(): Store<CRDTTypeRecord>[] {
-    const stores = [...this.storesByKey.values()];
-    assert(stores.length === Object.keys(this.storeInfoById).length);
-    assert(stores.every(s => !!this.storeInfoById[s.id]));
-    return stores;
+  get stores(): StoreInfo<Type>[] {
+    return Object.values(this.storeInfoById);
+  }
+
+  findActiveStoreById(id: string): Store<CRDTTypeRecord> {
+    const storeInfo = this.findStoreById(id);
+    if (!storeInfo) {
+      throw new Error(`No store info for id ${storeInfo.id}`);
+    }
+    return this.getActiveStore(storeInfo);
+  }
+
+  getActiveStore<T extends Type>(storeInfo: StoreInfo<T>): ToStore<T> {
+    if (!this.storesByKey.has(storeInfo.storageKey)) {
+      this.storesByKey.set(storeInfo.storageKey, newStore(storeInfo));
+    }
+    return this.storesByKey.get(storeInfo.storageKey) as ToStore<T>;
   }
 
   // Makes a copy of the arc used for speculative execution.
@@ -380,8 +393,8 @@ export class Arc implements ArcInterface {
         await (await clone.activate()).cloneFrom(await store.activate());
 
         storeMap.set(store, clone);
-        if (this.storeDescriptions.has(store)) {
-          arc.storeDescriptions.set(clone, this.storeDescriptions.get(store));
+        if (this.storeDescriptions.has(store.storeInfo)) {
+          arc.storeDescriptions.set(clone.storeInfo, this.storeDescriptions.get(store.storeInfo));
         }
       }
     }
@@ -408,7 +421,7 @@ export class Arc implements ArcInterface {
 
     for (const v of storeMap.values()) {
       // FIXME: Tags
-      await arc._registerStore(v, []);
+      await arc._registerStore(v.storeInfo, []);
     }
     return arc;
   }
@@ -484,19 +497,19 @@ export class Arc implements ArcInterface {
           const type = recipeHandle.type;
           if (isSingletonInterfaceStore(newStore)) {
             assert(type instanceof InterfaceType && type.interfaceInfo.particleMatches(particleSpec));
-            const handle: SingletonInterfaceHandle = await handleForStore(newStore, this, {ttl: recipeHandle.getTtl()});
+            const handle: SingletonInterfaceHandle = await handleForStore(this.getActiveStore(newStore), this, {ttl: recipeHandle.getTtl()}) as SingletonInterfaceHandle;
             await handle.set(particleSpec.clone());
           } else {
             throw new Error(`Can't currently store immediate values in non-singleton stores`);
           }
         } else if (['copy', 'map'].includes(recipeHandle.fate)) {
           const copiedStoreRef = this.context.findStoreById(recipeHandle.id);
-          const copiedActiveStore = await copiedStoreRef.activate();
+          const copiedActiveStore = await this.getActiveStore(copiedStoreRef).activate();
           assert(copiedActiveStore, `Cannot find store ${recipeHandle.id}`);
-          const activeStore = await newStore.activate();
+          const activeStore = await this.getActiveStore(newStore).activate();
           await activeStore.cloneFrom(copiedActiveStore);
           this._tagStore(newStore, this.context.findStoreTags(copiedStoreRef));
-          newStore.storeInfo.name = copiedStoreRef.name && `Copy of ${copiedStoreRef.name}`;
+          newStore.name = copiedStoreRef.name && `Copy of ${copiedStoreRef.name}`;
           const copiedStoreDesc = this.getStoreDescription(copiedStoreRef);
           if (copiedStoreDesc) {
             this.storeDescriptions.set(newStore, copiedStoreDesc);
@@ -527,8 +540,8 @@ export class Arc implements ArcInterface {
         if (!type.isSingleton && !type.isCollectionType()) {
           type = new SingletonType(type);
         }
-        const store = new Store(new StoreInfo({storageKey, exists: Exists.ShouldExist, type, id: recipeHandle.id}));
-        assert(store, `store '${recipeHandle.id}' was not found (${storageKey})`);
+        const store =
+            new StoreInfo({storageKey, exists: Exists.ShouldExist, type, id: recipeHandle.id});
         await this._registerStore(store, recipeHandle.tags);
       }
     }
@@ -545,23 +558,29 @@ export class Arc implements ArcInterface {
     }
   }
 
-  private addStoreToRecipe(store: Store<CRDTTypeRecord>) {
+  private addStoreToRecipe(storeInfo: StoreInfo<Type>) {
     const handle = this.activeRecipe.newHandle();
-    handle.mapToStorage(store);
+    handle.mapToStorage(storeInfo);
     handle.fate = 'use';
     // TODO(shans): is this the right thing to do? This seems not to be the right thing to do!
     handle['_type'] = handle.mappedType;
   }
 
   // TODO(shanestephens): Once we stop auto-wrapping in singleton types below, convert this to return a well-typed store.
-  async createStore<T extends Type>(type: T, name?: string, id?: string, tags?: string[], storageKey?: StorageKey, capabilities?: Capabilities): Promise<ToStore<T>> {
+  // async createStore<T extends Type>(type: T, name?: string, id?: string, tags?: string[], storageKey?: StorageKey, capabilities?: Capabilities): Promise<ToStore<T>> {
+  //   const store = await this.createStoreInternal(type, name, id, tags, storageKey, capabilities);
+  //   this.addStoreToRecipe(store.storeInfo);
+  //   return store;
+  // }
+  async createStore<T extends Type>(type: T, name?: string, id?: string, tags?: string[], storageKey?: StorageKey,
+        capabilities?: Capabilities): Promise<StoreInfo<T>> {
     const store = await this.createStoreInternal(type, name, id, tags, storageKey, capabilities);
     this.addStoreToRecipe(store);
     return store;
   }
 
   private async createStoreInternal<T extends Type>(type: T, name?: string, id?: string, tags?: string[],
-      storageKey?: StorageKey, capabilities?: Capabilities): Promise<ToStore<T>> {
+      storageKey?: StorageKey, capabilities?: Capabilities): Promise<StoreInfo<T>> { //Promise<ToStore<T>> {
     assert(type instanceof Type, `can't createStore with type ${type} that isn't a Type`);
     if (type instanceof TupleType) {
       throw new Error('Tuple type is not yet supported');
@@ -589,11 +608,13 @@ export class Arc implements ArcInterface {
     if (type.isEntity || type.isInterface || type.isReference) {
       throw new Error('unwrapped type provided to arc.createStore');
     }
-    if (this.storesByKey.has(storageKey)) {
-      return this.storesByKey.get(storageKey) as ToStore<T>;
+    const existingStore = Object.values(this.storeInfoById).find(store => store.storageKey === storageKey);
+    if (existingStore) {
+      assert(existingStore.id === id, `Different store ids for same storage key? Is this an error?`);
+      return existingStore as StoreInfo<T>;
     }
 
-    const store = newStore(new StoreInfo({storageKey, type, exists: Exists.MayExist, id, name}));
+    const store = new StoreInfo({storageKey, type, exists: Exists.MayExist, id, name});
 
     await this._registerStore(store, tags);
     if (storageKey instanceof ReferenceModeStorageKey) {
@@ -605,7 +626,7 @@ export class Arc implements ArcInterface {
     return store;
   }
 
-  async _registerStore(store: Store<CRDTTypeRecord>, tags?: string[]): Promise<void> {
+  async _registerStore(store: StoreInfo<Type>, tags?: string[]): Promise<void> {
     assert(!this.storeInfoById[store.id], `Store already registered '${store.id}'`);
     tags = tags || [];
     tags = Array.isArray(tags) ? tags : [tags];
@@ -613,17 +634,16 @@ export class Arc implements ArcInterface {
     if (!(store.type.handleConstructor())) {
       throw new Error(`Type not supported by storage: '${store.type.tag}'`);
     }
-    this.storeInfoById[store.id] = store.storeInfo;
-    this.storesByKey.set(store.storageKey, store);
+    this.storeInfoById[store.id] = store;
     this.storeTagsById[store.id] = new Set(tags);
 
-    const activeStore = await store.activate();
+    const activeStore = await this.getActiveStore(store).activate();
     activeStore.on(async () => this._onDataChange());
 
     this.context.registerStore(store, tags);
   }
 
-  _tagStore(store: Store<CRDTTypeRecord>, tags: Set<string> = new Set()): void {
+  _tagStore(store: StoreInfo<Type>, tags: Set<string> = new Set()): void {
     assert(this.storeInfoById[store.id] && this.storeTagsById[store.id], `Store not registered '${store.id}'`);
     tags.forEach(tag => this.storeTagsById[store.id].add(tag));
   }
@@ -670,9 +690,9 @@ export class Arc implements ArcInterface {
     return null;
   }
 
-  findStoresByType<T extends Type>(type: T, options?: {tags: string[]}): ToStore<T>[] {
+  findStoresByType<T extends Type>(type: T, options?: {tags: string[]}): StoreInfo<T>[] {
     const typeKey = Arc._typeToKey(type);
-    let stores = [...this.storesByKey.values()].filter(handle => {
+    let stores = Object.values(this.storeInfoById).filter(handle => {
       if (typeKey) {
         const handleKey = Arc._typeToKey(handle.type);
         if (typeKey === handleKey) {
@@ -701,32 +721,20 @@ export class Arc implements ArcInterface {
     return stores.filter(s => {
       const isInterface = s.type.getContainedType() ? s.type.getContainedType() instanceof InterfaceType : s.type instanceof InterfaceType;
       return !!effectiveTypeForHandle(type, [{type: s.type, direction: isInterface ? 'hosts' : 'reads writes'}]);
-    }) as ToStore<T>[];
+    }) as StoreInfo<T>[];
   }
 
-  hasStoreById(id: string): boolean {
-    return !!this.storeInfoById[id];
+  findStoreById(id: string): StoreInfo<Type> {
+    return this.storeInfoById[id];
   }
 
-  getStoreById(id: string): Store<CRDTTypeRecord> {
-    const storeInfo = this.storeInfoById[id];
-    return storeInfo ? this.storesByKey.get(storeInfo.storageKey) : null;
+  findStoreTags(storeInfo: StoreInfo<Type>): Set<string> {
+    return this.storeTagsById[storeInfo.id] || this._context.findStoreTags(storeInfo);
   }
 
-  findStoreById(id: string): Store<CRDTTypeRecord> {
-    if (this.hasStoreById(id)) {
-      return this.getStoreById(id);
-    }
-    return this._context.findStoreById(id);
-  }
-
-  findStoreTags(store: Store<CRDTTypeRecord>): Set<string> {
-    return this.storeTagsById[store.id] || this._context.findStoreTags(store);
-  }
-
-  getStoreDescription(store: Store<CRDTTypeRecord>): string {
-    assert(store, 'Cannot fetch description for nonexistent store');
-    return this.storeDescriptions.get(store) || store.description;
+  getStoreDescription(storeInfo: StoreInfo<Type>): string {
+    assert(storeInfo, 'Cannot fetch description for nonexistent store');
+    return this.storeDescriptions.get(storeInfo) || storeInfo.description;
   }
 
   getVersionByStore({includeArc=true, includeContext=false}) {

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -16,8 +16,9 @@ import {Relevance} from './relevance.js';
 import {EntityType, InterfaceType, SingletonType, CollectionType} from '../types/lib-types.js';
 import {Recipe, Particle, Handle} from './recipe/lib-recipe.js';
 import {Dictionary} from '../utils/lib-utils.js';
-import {handleForStore, CollectionEntityStore, SingletonEntityStore, SingletonInterfaceStore} from './storage/storage.js';
+import {handleForStoreInfo, CollectionEntityType, SingletonInterfaceType, SingletonEntityType} from './storage/storage.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
+import {StoreInfo} from './storage/store-info.js';
 
 export class Description {
   private constructor(
@@ -25,11 +26,6 @@ export class Description {
     // TODO(mmandlis): replace Particle[] with serializable json objects.
     private readonly arcRecipes: {patterns: string[], particles: Particle[]}[],
     private readonly particleDescriptions: ParticleDescription[] = []) {
-  }
-
-  static async XcreateForPlan(plan: Recipe): Promise<Description> {
-    const particleDescriptions = await Description.initDescriptionHandles(plan.particles);
-    return new Description({}, [{patterns: plan.patterns, particles: plan.particles}], particleDescriptions);
   }
 
   static async createForPlan(arc: Arc, plan: Recipe): Promise<Description> {
@@ -125,12 +121,11 @@ export class Description {
     for (const handleConn of Object.values(particle.connections)) {
       const specConn = particle.spec.handleConnectionMap.get(handleConn.name);
       const pattern = descByName[handleConn.name] || specConn.pattern;
-      const store = arc ? arc.findStoreById(handleConn.handle.id) : null;
 
       pDesc._connections[handleConn.name] = {
         pattern,
         _handleConn: handleConn,
-        value: await Description._prepareStoreValue(store)
+        value: await Description._prepareStoreValue(handleConn.handle.id, arc)
       };
     }
     return pDesc;
@@ -139,9 +134,9 @@ export class Description {
   private static async _getPatternByNameFromDescriptionHandle(particle: Particle, arc: Arc): Promise<Dictionary<string>> {
     const descriptionConn = particle.connections['descriptions'];
     if (descriptionConn && descriptionConn.handle && descriptionConn.handle.id) {
-      const descStore = arc.findStoreById(descriptionConn.handle.id) as CollectionEntityStore;
+      const descStore = arc.findStoreById(descriptionConn.handle.id) as StoreInfo<CollectionEntityType>;
       if (descStore) {
-        const descHandle = await handleForStore(descStore, arc);
+        const descHandle = await handleForStoreInfo(descStore, arc);
         const descByName: Dictionary<string> = {};
         for (const d of await descHandle.toList()) {
           descByName[d.key] = d.value;
@@ -152,12 +147,16 @@ export class Description {
     return {};
   }
 
-  private static async _prepareStoreValue(store: Store<CRDTTypeRecord>): Promise<DescriptionValue|undefined> {
+  private static async _prepareStoreValue(storeId: string, arc: Arc): Promise<DescriptionValue|undefined> {
+    if (!arc) {
+      return null;
+    }
+    const store = arc.findStoreById(storeId);
     if (!store) {
       return undefined;
     }
     if (store.type instanceof SingletonType && store.type.getContainedType() instanceof EntityType) {
-      const handle = await handleForStore(store as SingletonEntityStore, {generateID: null, idGenerator: null});
+      const handle = await handleForStoreInfo(store as StoreInfo<SingletonEntityType>, arc);
       const entityValue = await handle.fetch();
       if (entityValue) {
         const schema = store.type.getEntitySchema();
@@ -165,13 +164,13 @@ export class Description {
         return {entityValue, valueDescription};
       }
     } else if (store.type instanceof SingletonType && store.type.getContainedType() instanceof InterfaceType) {
-      const handle = await handleForStore(store as SingletonInterfaceStore, {generateID: null, idGenerator: null});
+      const handle = await handleForStoreInfo(store as StoreInfo<SingletonInterfaceType>, arc);
       const interfaceValue = await handle.fetch();
       if (interfaceValue) {
         return {interfaceValue};
       }
     } else if (store.type instanceof CollectionType) {
-      const handle = await handleForStore(store as CollectionEntityStore, {generateID: null, idGenerator: null});
+      const handle = await handleForStoreInfo(store as StoreInfo<CollectionEntityType>, arc);
       const values = await handle.toList();
       if (values && values.length > 0) {
         return {collectionValues: values};

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -417,7 +417,7 @@ export class Manifest {
       const content: string = await loader.loadResource(fileName);
       // TODO: When does this happen? The loader should probably throw an exception here.
       assert(content !== undefined, `${fileName} unable to be loaded by Manifest parser`);
-      return await Manifest.parse(content, {
+      return Manifest.parse(content, {
         fileName,
         loader,
         registry,

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -303,7 +303,7 @@ class PECOuterPortImpl extends PECOuterPort {
               // TODO: pass tags through too, and reconcile with similar logic
               // in Arc.deserialize.
               for (const store of manifest.stores) {
-                await this.arc._registerStore(store, []); //manifest.getActiveStore(store), []);
+                await this.arc._registerStore(store, []);
               }
               // TODO: Awaiting this promise causes tests to fail...
               const instantiateAndCaptureError = async () => {

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -222,7 +222,7 @@ class PECOuterPortImpl extends PECOuterPort {
     const store = await arc.createStore(type, name, null, [], storageKey);
     // Store belongs to the inner arc, but the transformation particle,
     // which itself is in the outer arc gets access to it.
-    this.CreateHandleCallback(store, callback, store.type, name, store.id);
+    this.CreateHandleCallback(arc.getActiveStore(store), callback, store.type, name, store.id);
   }
 
   onArcMapHandle(callback: number, arc: Arc, handle: Handle) {
@@ -303,7 +303,7 @@ class PECOuterPortImpl extends PECOuterPort {
               // TODO: pass tags through too, and reconcile with similar logic
               // in Arc.deserialize.
               for (const store of manifest.stores) {
-                await this.arc._registerStore(store, []);
+                await this.arc._registerStore(store, []); //manifest.getActiveStore(store), []);
               }
               // TODO: Awaiting this promise causes tests to fail...
               const instantiateAndCaptureError = async () => {

--- a/src/runtime/recipe-resolver.ts
+++ b/src/runtime/recipe-resolver.ts
@@ -13,8 +13,9 @@ import {Action, GenerateParams, WalkerTactic, Continuation} from '../utils/lib-u
 import {ConsumeSlotConnectionSpec} from './arcs-types/particle-spec.js';
 import {Recipe, Handle, Particle, SlotConnection, IsValidOptions, RecipeWalker, ConnectionConstraint,
         InstanceEndPoint, directionCounts, findAllSlotCandidates, connectSlotConnection} from './recipe/lib-recipe.js';
-import {Store} from './storage/store.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
+import {StoreInfo} from './storage/store-info.js';
+import {Type} from '../types/lib-types.js';
 
 export class ResolveWalker extends RecipeWalker {
   private options: IsValidOptions;
@@ -67,7 +68,7 @@ export class ResolveWalker extends RecipeWalker {
       }
     } else if (!handle.storageKey) {
       // Handle specified by the ID, but not yet mapped to storage.
-      let storeById: Store<CRDTTypeRecord>;
+      let storeById: StoreInfo<Type>;
       switch (handle.fate) {
         case 'use':
           storeById = arc.findStoreById(handle.id);

--- a/src/runtime/recipe/internal/handle.ts
+++ b/src/runtime/recipe/internal/handle.ts
@@ -199,7 +199,7 @@ export class Handle implements Comparable<Handle>, PublicHandle {
     }
     this._id = id;
   }
-  mapToStorage(storage: StoreInfo<Type>) { //{id: string, type: Type, originalId?: string, storageKey?: StorageKey, claims?: StoreClaims}) {
+  mapToStorage(storage: StoreInfo<Type>) {
     if (!storage) {
       throw new Error(`Cannot map to undefined storage`);
     }

--- a/src/runtime/recipe/internal/handle.ts
+++ b/src/runtime/recipe/internal/handle.ts
@@ -24,7 +24,7 @@ import {Direction} from '../../arcs-types/enums.js';
 import {StorageKey} from '../../storage/storage-key.js';
 import {Capabilities, Ttl, Queryable} from '../../capabilities.js';
 import {AnnotationRef} from '../../arcs-types/annotation.js';
-import {StoreClaims} from '../../storage/store-info.js';
+import {StoreClaims, StoreInfo} from '../../storage/store-info.js';
 
 export class Handle implements Comparable<Handle>, PublicHandle {
   private readonly _recipe: Recipe;
@@ -199,7 +199,7 @@ export class Handle implements Comparable<Handle>, PublicHandle {
     }
     this._id = id;
   }
-  mapToStorage(storage: {id: string, type: Type, originalId?: string, storageKey?: StorageKey, claims?: StoreClaims}) {
+  mapToStorage(storage: StoreInfo<Type>) { //{id: string, type: Type, originalId?: string, storageKey?: StorageKey, claims?: StoreClaims}) {
     if (!storage) {
       throw new Error(`Cannot map to undefined storage`);
     }

--- a/src/runtime/recipe/internal/recipe-interface.ts
+++ b/src/runtime/recipe/internal/recipe-interface.ts
@@ -17,12 +17,12 @@ import {Ttl, Capabilities} from '../../capabilities.js';
 import {Id} from '../../id.js';
 import {Type} from '../../../types/lib-types.js';
 import {StorageKey} from '../../storage/storage-key.js';
-import {Store} from '../../storage/store.js';
 import {AnnotationRef} from '../../arcs-types/annotation.js';
 import {ParticleHandleDescription} from '../../manifest-ast-types/manifest-ast-nodes.js';
 import {Policy} from '../../policy/policy.js';
 import {Handle as HandleImpl} from './handle.js';
 import {CRDTTypeRecord} from '../../../crdt/lib-crdt.js';
+import {StoreInfo} from '../../storage/store-info.js';
 
 export type IsValidOptions = {errors?: Map<Recipe | RecipeComponent, string>, typeErrors?: string[]};
 export type RecipeComponent = Particle | Handle | HandleConnection | Slot | SlotConnection | EndPoint;
@@ -121,7 +121,7 @@ export interface Handle {
   toSlot(): Slot | undefined;
 
   // TODO(shanestephens): should these be on a separate constructor interface?
-  mapToStorage(store: Store<CRDTTypeRecord>): void;
+  mapToStorage(store: StoreInfo<Type>): void;
   joinDataFromHandle(handle: Handle): void;
 
   findConnectionByDirection(direction: Direction): HandleConnection;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -79,7 +79,7 @@ export class Runtime {
   private loader: Loader | null;
   private composerClass: typeof SlotComposer | null;
   private memoryProvider: VolatileMemoryProvider;
-  private storageService: StorageService;
+  readonly storageService: StorageService;
   readonly arcById = new Map<string, Arc>();
 
   /**

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -263,13 +263,13 @@ export class Runtime {
     // we could eliminate it if the Manifest object takes care of this.
     const id = `in-memory-${Math.floor((Math.random()+1)*1e6)}.manifest`;
     // TODO(sjmiles): this is a virtual manifest, the fileName is invented
-    const opts = {id, fileName: `./${id}`, loader, memoryProvider: this.memoryProvider, ...options};
+    const opts = {id, fileName: `./${id}`, loader, memoryProvider: this.memoryProvider, storageService: this.storageService, ...options};
     return Manifest.parse(content, opts);
   }
 
   async parseFile(path: string, options?): Promise<Manifest> {
     const content = await this.loader.loadResource(path);
-    const opts = {id: path, fileName: path, loader: this.loader, memoryProvider: this.memoryProvider, ...options};
+    const opts = {id: path, fileName: path, loader: this.loader, memoryProvider: this.memoryProvider, storageService: this.storageService, ...options};
     return this.parse(content, opts);
   }
 

--- a/src/runtime/storage/direct-store.ts
+++ b/src/runtime/storage/direct-store.ts
@@ -82,7 +82,7 @@ export class DirectStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
     if (me.driver == null) {
       throw new CRDTError(`No driver exists to support storage key ${options.storageKey}`);
     }
-    me.driver.registerReceiver(me.onReceive.bind(me), me.baseStore.versionToken);
+    me.driver.registerReceiver(me.onReceive.bind(me), me.storeInfo.versionToken);
     return me;
   }
   // The driver will invoke this method when it has an updated remote model

--- a/src/runtime/storage/reference-mode-store.ts
+++ b/src/runtime/storage/reference-mode-store.ts
@@ -15,15 +15,15 @@ import {StorageKey} from './storage-key.js';
 import {Type, CollectionType, ReferenceType, SingletonType, MuxType, EntityType} from '../../types/lib-types.js';
 import {Producer, Consumer, Runnable, Dictionary, noAwait} from '../../utils/lib-utils.js';
 import {PropagatedException} from '../arc-exceptions.js';
-import {Store} from './store.js';
 import {SerializedEntity} from '../entity.js';
 import {ReferenceModeStorageKey} from './reference-mode-storage-key.js';
-import {CRDTTypeRecordToType} from './storage.js';
+import {CRDTTypeRecordToType, MuxEntityType} from './storage.js';
 import {CRDTCollectionTypeRecord, Referenceable, CollectionOpTypes, CollectionOperation, CRDTCollection,
         CollectionOperationAdd, CollectionOperationRemove, CRDTEntityTypeRecord, CRDTEntity, EntityData,
         EntityOperation, EntityOpTypes, Identified, VersionMap, CRDTTypeRecord, CRDTSingletonTypeRecord,
         SingletonOperation, SingletonOpTypes, CRDTSingleton, SingletonOperationSet,
         SingletonOperationClear} from '../../crdt/lib-crdt.js';
+import {StoreInfo} from './store-info.js';
 
 // ReferenceMode store uses an expanded notion of Reference that also includes a version. This allows stores to block on
 // receiving an update to contained Entities, which keeps remote versions of the store in sync with each other.
@@ -133,7 +133,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity,
       storageKey: storageKey.backingKey,
       type: new MuxType(type.getContainedType() as EntityType),
       exists: options.exists,
-      baseStore: options.baseStore as unknown as Store<CRDTEntityTypeRecord<S, C>>,
+      storeInfo: options.storeInfo as unknown as StoreInfo<MuxEntityType>,
     });
     let refType: Type;
     if (type.isCollectionType()) {
@@ -146,7 +146,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity,
       storageKey: storageKey.storageKey,
       type: refType as CRDTTypeRecordToType<ReferenceContainer>,
       exists: options.exists,
-      baseStore: options.baseStore as unknown as Store<ReferenceContainer>,
+      storeInfo: options.storeInfo as unknown as StoreInfo<CRDTTypeRecordToType<ReferenceContainer>>,
     });
     result.registerStoreCallbacks();
     return result;

--- a/src/runtime/storage/storage-proxy.ts
+++ b/src/runtime/storage/storage-proxy.ts
@@ -69,7 +69,7 @@ export class StorageProxy<T extends CRDTTypeRecord> {
 
   // TODO: remove this after migration.
   get pec(): ParticleExecutionContext {
-    throw new Error('StorageProxyNG does not have a pec.');
+    throw new Error('StorageProxy does not have a pec.');
   }
 
   async idle(): Promise<void> {

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -165,8 +165,8 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
   arc: ArcLike,
   options: HandleOptions = {}
 ): ToHandle<T> {
-  const type = options.type || store.baseStore.type;
-  const storageKey = store.baseStore.storageKey.toString();
+  const type = options.type || store.storeInfo.type;
+  const storageKey = store.storeInfo.storageKey.toString();
 
   const idGenerator = arc.idGenerator;
   const particle = options.particle || null;
@@ -178,7 +178,7 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
     const proxyMuxer = new StorageProxyMuxer<CRDTMuxEntity>(store, type, storageKey);
     return new EntityHandleFactory(proxyMuxer) as ToHandle<T>;
   } else {
-    const proxy = new StorageProxy<T>(store.baseStore.id, store, type, storageKey, options.ttl);
+    const proxy = new StorageProxy<T>(store.storeInfo.id, store, type, storageKey, options.ttl);
     if (type instanceof SingletonType) {
       // tslint:disable-next-line: no-any
       return new SingletonHandle(generateID(), proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<T>;

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -25,6 +25,7 @@ import {EntityHandleFactory} from './entity-handle-factory.js';
 import {StorageProxyMuxer} from './storage-proxy-muxer.js';
 import {DirectStoreMuxer} from './direct-store-muxer.js';
 import {StoreInfo} from './store-info.js';
+import {StorageService} from './storage-service.js';
 
 type HandleOptions = {
   type?: Type;
@@ -38,7 +39,7 @@ type HandleOptions = {
 type ArcLike = {
   generateID: () => Id;
   idGenerator: IdGenerator;
-  getActiveStore: <T extends Type>(storeInfo: StoreInfo<T>) => ToStore<T>;
+  storageService: StorageService;
 };
 
 export type SingletonEntityType = SingletonType<EntityType>;
@@ -194,5 +195,5 @@ export async function handleForStore<T extends CRDTTypeRecord>(store: Store<T>, 
 }
 
 export async function handleForStoreInfo<T extends Type>(storeInfo: StoreInfo<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<TypeToCRDTTypeRecord<T>>> {
-  return handleForActiveStore(await arc.getActiveStore(storeInfo).activate(), arc, options) as ToHandle<TypeToCRDTTypeRecord<T>>;
+  return handleForActiveStore(await arc.storageService.getActiveStore(storeInfo).activate(), arc, options) as ToHandle<TypeToCRDTTypeRecord<T>>;
 }

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -38,6 +38,7 @@ type HandleOptions = {
 type ArcLike = {
   generateID: () => Id;
   idGenerator: IdGenerator;
+  getActiveStore: <T extends Type>(storeInfo: StoreInfo<T>) => ToStore<T>;
 };
 
 export type SingletonEntityType = SingletonType<EntityType>;
@@ -190,4 +191,8 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
 
 export async function handleForStore<T extends CRDTTypeRecord>(store: Store<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<T>> {
   return handleForActiveStore(await store.activate(), arc, options) as ToHandle<T>;
+}
+
+export async function handleForStoreInfo<T extends Type>(storeInfo: StoreInfo<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<TypeToCRDTTypeRecord<T>>> {
+  return handleForActiveStore(await arc.getActiveStore(storeInfo).activate(), arc, options) as ToHandle<TypeToCRDTTypeRecord<T>>;
 }

--- a/src/runtime/storage/store-info.ts
+++ b/src/runtime/storage/store-info.ts
@@ -11,10 +11,7 @@
 import {Comparable, compareStrings, IndentingStringBuilder} from '../../utils/lib-utils.js';
 import {Type} from '../../types/lib-types.js';
 import {StorageKey} from './storage-key.js';
-import {PropagatedException} from '../arc-exceptions.js';
 import {ClaimIsTag} from '../arcs-types/claim.js';
-import {SingletonInterfaceStore, SingletonEntityStore, SingletonReferenceStore, CollectionEntityStore, CollectionReferenceStore, MuxEntityStore} from './storage.js';
-import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
 import {AnnotationRef} from '../arcs-types/annotation.js';
 import {ReferenceModeStorageKey} from './reference-mode-storage-key.js';
 import {Exists} from './drivers/driver.js';
@@ -23,7 +20,7 @@ import {StorageMode} from './store-interface.js';
 /** Assorted properties about a store. */
 export class StoreInfo<T extends Type> implements Comparable<StoreInfo<T>> {
   readonly id: string;
-  name?: string;  // TODO: Find a way to make this readonly.
+  name: string;  // TODO: Find a way to make this readonly.
   readonly originalId?: string;
   readonly source?: string;
   readonly origin?: 'file' | 'resource' | 'storage' | 'inline';
@@ -103,8 +100,11 @@ export class StoreInfo<T extends Type> implements Comparable<StoreInfo<T>> {
   }
 
   // TODO: Make these tags live inside StoreInfo.
-  toManifestString(opts?: {handleTags?: string[]}) : string {
+  toManifestString(opts?: {handleTags?: string[], overrides?: Partial<StoreInfo<T>>}) : string {
     opts = opts || {};
+    if (opts.overrides) {
+      return this.clone(opts.overrides).toManifestString({handleTags: opts.handleTags});
+    }
     const builder = new IndentingStringBuilder();
     if ((this.annotations || []).length > 0) {
       builder.push(...this.annotations.map(a => a.toString()));

--- a/src/runtime/storage/store-interface.ts
+++ b/src/runtime/storage/store-interface.ts
@@ -20,6 +20,7 @@ import {StorageProxyMuxer} from './storage-proxy-muxer.js';
 import {Store} from './store.js';
 import {CRDTTypeRecordToType, CRDTMuxEntity} from './storage.js';
 import {StoreRecord} from './direct-store-muxer.js';
+import {StoreInfo} from './store-info.js';
 
 /**
  * This file exists to break a circular dependency between Store and the ActiveStore implementations.
@@ -49,7 +50,7 @@ export type StoreConstructorOptions<T extends CRDTTypeRecord> = {
   storageKey: StorageKey,
   exists: Exists,
   type: CRDTTypeRecordToType<T>,
-  baseStore: Store<T>,
+  storeInfo?: StoreInfo<CRDTTypeRecordToType<T>>;
 };
 
 export type StoreConstructor = {
@@ -75,16 +76,15 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
   readonly storageKey: StorageKey;
   exists: Exists;
   readonly type: CRDTTypeRecordToType<T>;
-  readonly baseStore: Store<T>;
+  readonly storeInfo: StoreInfo<CRDTTypeRecordToType<T>>;
 
-  // TODO: Lots of these params can be pulled from baseStore.
   constructor(options: StoreConstructorOptions<T>) {
     this.storageKey = options.storageKey;
     this.type = options.type;
-    this.baseStore = options.baseStore;
+    this.storeInfo = options.storeInfo;
   }
 
-  get mode(): StorageMode { return this.baseStore.mode; }
+  get mode(): StorageMode { return this.storeInfo.mode; }
 
   async idle() {
     return Promise.resolve();

--- a/src/runtime/storage/store.ts
+++ b/src/runtime/storage/store.ts
@@ -100,7 +100,7 @@ export class Store<T extends CRDTTypeRecord> implements StoreInterface<T> {
       storageKey: this.storageKey,
       exists: this.exists,
       type: this.type,
-      baseStore: this,
+      storeInfo: this.storeInfo,
     }) as ActiveStore<T>;
     this.exists = Exists.ShouldExist;
     return this.activeStore;

--- a/src/runtime/storage/store.ts
+++ b/src/runtime/storage/store.ts
@@ -15,7 +15,7 @@ import {StorageKey} from './storage-key.js';
 import {StoreInterface, StorageMode, ActiveStore, ProxyMessageType, ProxyMessage, ProxyCallback, StorageCommunicationEndpoint, StorageCommunicationEndpointProvider, StoreConstructor} from './store-interface.js';
 import {CRDTTypeRecordToType, SingletonInterfaceStore, SingletonEntityStore, CollectionEntityStore, SingletonReferenceStore, CollectionReferenceStore, MuxEntityStore} from './storage.js';
 import {StoreInfo} from './store-info.js';
-import {Type} from '../../types/lib-types.js';
+import {CollectionType, EntityType, SingletonType, InterfaceType, ReferenceType, MuxType, Type} from '../../types/lib-types.js';
 
 export {
   ActiveStore,
@@ -27,33 +27,33 @@ export {
   StorageMode
 };
 
-export function isSingletonInterfaceStore(store: Store<CRDTTypeRecord>): store is SingletonInterfaceStore {
-  return (store.storeInfo.type.isSingleton && store.storeInfo.type.getContainedType().isInterface);
+export function isSingletonInterfaceStore(store: StoreInfo<Type>): store is StoreInfo<SingletonType<InterfaceType>> {
+  return (store.type.isSingleton && store.type.getContainedType().isInterface);
 }
 
-export function isSingletonEntityStore(store: Store<CRDTTypeRecord>): store is SingletonEntityStore {
-  return (store.storeInfo.type.isSingleton && store.storeInfo.type.getContainedType().isEntity);
+export function isSingletonEntityStore(store: StoreInfo<Type>): store is StoreInfo<SingletonType<EntityType>> {
+  return (store.type.isSingleton && store.type.getContainedType().isEntity);
 }
 
-export function isCollectionEntityStore(store: Store<CRDTTypeRecord>): store is CollectionEntityStore {
-  return (store.storeInfo.type.isCollection && store.storeInfo.type.getContainedType().isEntity);
+export function isCollectionEntityStore(store: StoreInfo<Type>): store is StoreInfo<CollectionType<EntityType>> {
+  return (store.type.isCollection && store.type.getContainedType().isEntity);
 }
 
-export function isSingletonReferenceStore(store: Store<CRDTTypeRecord>): store is SingletonReferenceStore {
-  return (store.storeInfo.type.isSingleton && store.storeInfo.type.getContainedType().isReference);
+export function isSingletonReferenceStore(store: StoreInfo<Type>): store is StoreInfo<SingletonType<ReferenceType<EntityType>>> {
+  return (store.type.isSingleton && store.type.getContainedType().isReference);
 }
 
-export function isCollectionReferenceStore(store: Store<CRDTTypeRecord>): store is CollectionReferenceStore {
-  return (store.storeInfo.type.isCollection && store.storeInfo.type.getContainedType().isReference);
+export function isCollectionReferenceStore(store: StoreInfo<Type>): store is StoreInfo<CollectionType<ReferenceType<EntityType>>> {
+  return (store.type.isCollection && store.type.getContainedType().isReference);
 }
 
-export function isMuxEntityStore(store: Store<CRDTTypeRecord>): store is MuxEntityStore {
-  return (store.storeInfo.type.isMuxType());
+export function isMuxEntityStore(store: StoreInfo<Type>): store is StoreInfo<MuxType<EntityType>> {
+  return (store.type.isMuxType());
 }
 
 export function entityHasName(name: string) {
-  return (store: Store<CRDTTypeRecord>) =>
-    store.storeInfo.type.getContainedType().isEntity && store.storeInfo.type.getContainedType().getEntitySchema().names.includes(name);
+  return <T extends Type>(store: StoreInfo<T>) =>
+    store.type.getContainedType().isEntity && store.type.getContainedType().getEntitySchema().names.includes(name);
 }
 
 // A representation of a store. Note that initially a constructed store will be

--- a/src/runtime/storage/store.ts
+++ b/src/runtime/storage/store.ts
@@ -105,9 +105,4 @@ export class Store<T extends CRDTTypeRecord> implements StoreInterface<T> {
     this.exists = Exists.ShouldExist;
     return this.activeStore;
   }
-
-  toManifestString(opts?: {handleTags?: string[], overrides?: Partial<StoreInfo<CRDTTypeRecordToType<T>>>}): string {
-    const overrides = (opts && opts.overrides ? opts.overrides : new StoreInfo({id: this.id, type: this.storeInfo.type}));
-    return this.storeInfo.clone(overrides).toManifestString({handleTags: opts ? opts.handleTags : []});
-  }
 }

--- a/src/runtime/storage/testing/test-storage.ts
+++ b/src/runtime/storage/testing/test-storage.ts
@@ -59,7 +59,7 @@ export class MockStore<T extends CRDTTypeRecord> extends ActiveStore<T> {
       storageKey: new MockStorageKey(),
       exists: Exists.ShouldCreate,
       type: null,
-      baseStore: null,
+      storeInfo: null,
     });
     this.crdtData = crdtData;
   }
@@ -100,7 +100,7 @@ export class MockDirectStoreMuxer<T extends CRDTMuxEntity> extends DirectStoreMu
       storageKey: new MockStorageKey(),
       exists: Exists.ShouldCreate,
       type: null,
-      baseStore: null,
+      storeInfo: null,
     });
   }
 

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -164,9 +164,7 @@ describe('entity handle factory', () => {
     const entity = await handleForEntity.setFromData({value: 'val1'});
     await arc.idle;
 
-    // tslint:disable-next-line: no-any
     const inputStore = arc.findStoreById('input:1') as StoreInfo<SingletonReferenceType>;
-    // tslint:disable-next-line: no-any
     const outputStore = arc.findStoreById('output:1') as StoreInfo<SingletonEntityType>;
 
     const handleForInput = await handleForStoreInfo(inputStore, arc);

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -15,7 +15,7 @@ import {CRDTEntityTypeRecord, Identified, CRDTEntity, EntityOpTypes, CRDTSinglet
 import {StorageProxyMuxer} from '../storage-proxy-muxer.js';
 import {DirectStoreMuxer} from '../direct-store-muxer.js';
 import {EntityHandleFactory} from '../entity-handle-factory.js';
-import {ProxyMessageType, Store} from '../store.js';
+import {ProxyMessageType} from '../store.js';
 import {assert} from '../../../platform/chai-web.js';
 import {Entity} from '../../entity.js';
 import {ArcId} from '../../id.js';
@@ -24,8 +24,9 @@ import {VolatileStorageKey} from '../drivers/volatile.js';
 import {Loader} from '../../../platform/loader.js';
 import {TestVolatileMemoryProvider} from '../../testing/test-volatile-memory-provider.js';
 import {Runtime} from '../../runtime.js';
-import {CRDTMuxEntity, handleForStore, storeType, CRDTReferenceSingleton, CRDTEntitySingleton} from '../storage.js';
+import {CRDTMuxEntity, SingletonReferenceType, SingletonEntityType, handleForStoreInfo} from '../storage.js';
 import {Reference} from '../../reference.js';
+import {StoreInfo} from '../store-info.js';
 
 describe('entity handle factory', () => {
   it('can produce entity handles upon request', async () => {
@@ -159,20 +160,20 @@ describe('entity handle factory', () => {
     await arc.instantiate(recipe);
     await arc.idle;
 
-    const handleForEntity = await handleForStore(refModeStore, arc);
+    const handleForEntity = await handleForStoreInfo(refModeStore, arc);
     const entity = await handleForEntity.setFromData({value: 'val1'});
     await arc.idle;
 
     // tslint:disable-next-line: no-any
-    const inputStore = arc.getStoreById('input:1') as any as Store<CRDTReferenceSingleton>;
+    const inputStore = arc.findStoreById('input:1') as StoreInfo<SingletonReferenceType>;
     // tslint:disable-next-line: no-any
-    const outputStore = arc.getStoreById('output:1') as any as Store<CRDTEntitySingleton>;
+    const outputStore = arc.findStoreById('output:1') as StoreInfo<SingletonEntityType>;
 
-    const handleForInput = await handleForStore(inputStore, arc);
-    await handleForInput.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, storeType(inputStore).getContainedType(), null));
+    const handleForInput = await handleForStoreInfo(inputStore, arc);
+    await handleForInput.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, inputStore.type.getContainedType(), null));
     await arc.idle;
 
-    const handleForOutput = await handleForStore(outputStore, arc);
+    const handleForOutput = await handleForStoreInfo(outputStore, arc);
     const output = await handleForOutput.fetch();
     assert.equal(output.value, 'val1');
   });
@@ -241,20 +242,20 @@ describe('entity handle factory', () => {
     await arc.idle;
 
     // create and store an entity in the reference mode store.
-    const handleForEntity = await handleForStore(refModeStore, arc);
+    const handleForEntity = await handleForStoreInfo(refModeStore, arc);
     const entity = await handleForEntity.setFromData({colour: 'red'});
     await arc.idle;
 
     // fetch the entity from dsmForVerifying store
-    const entityHandleFactory = await handleForStore(dsmForVerifying, arc);
+    const entityHandleFactory = await handleForStoreInfo(dsmForVerifying, arc);
     const entityHandle = entityHandleFactory.getHandle(Entity.id(entity));
     let output = await entityHandle.fetch();
     assert.equal(output.colour, 'red');
 
     // create and store a reference to the entity in the input
-    const inResultStore = arc.getStoreById('input:1') as Store<CRDTReferenceSingleton>;
-    const inputForInResultStore = await handleForStore(inResultStore, arc);
-    await inputForInResultStore.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, storeType(inResultStore).getContainedType(), null));
+    const inResultStore = arc.findStoreById('input:1') as StoreInfo<SingletonReferenceType>;
+    const inputForInResultStore = await handleForStoreInfo(inResultStore, arc);
+    await inputForInResultStore.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, inResultStore.type.getContainedType(), null));
     await arc.idle;
 
     // fetch the entity again and check it has been mutated.
@@ -370,20 +371,20 @@ describe('entity handle factory', () => {
     await arc.idle;
 
     // create and store an entity in the reference mode store.
-    const handleForEntity = await handleForStore(refModeStore, arc);
+    const handleForEntity = await handleForStoreInfo(refModeStore, arc);
     const entity = await handleForEntity.setFromData({colour: 'red'});
     await arc.idle;
 
     // fetch the entity from dsmForVerifying store
-    const handleFactoryForMutatedEntity = await handleForStore(dsmForVerifying, arc);
+    const handleFactoryForMutatedEntity = await handleForStoreInfo(dsmForVerifying, arc);
     const handleForMutatedEntity = handleFactoryForMutatedEntity.getHandle(Entity.id(entity));
     let output = await handleForMutatedEntity.fetch();
     assert.equal(output.colour, 'red');
 
     // create and store a reference to the entity in the input store for the entityMutator1 particle
-    const entityMutator1Store = arc.getStoreById('input:0') as Store<CRDTReferenceSingleton>;
-    const inputHandleForEntityMutator1 = await handleForStore(entityMutator1Store, arc);
-    await inputHandleForEntityMutator1.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, storeType(entityMutator1Store).getContainedType(), null));
+    const entityMutator1Store = arc.findStoreById('input:0') as StoreInfo<SingletonReferenceType>;
+    const inputHandleForEntityMutator1 = await handleForStoreInfo(entityMutator1Store, arc);
+    await inputHandleForEntityMutator1.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, entityMutator1Store.type.getContainedType(), null));
     await arc.idle;
 
     // fetch the entity from dsmForVerifying store and check it has been mutated.
@@ -391,9 +392,9 @@ describe('entity handle factory', () => {
     assert.equal(output.colour, 'purple');
 
     // create and store a reference to the entity in the input store for the entityMutator2 particle
-    const entityMutator2Store = arc.getStoreById('input:1') as Store<CRDTReferenceSingleton>;
-    const handleForEntityMutator2 = await handleForStore(entityMutator2Store, arc);
-    await handleForEntityMutator2.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, storeType(entityMutator1Store).getContainedType(), null));
+    const entityMutator2Store = arc.findStoreById('input:1') as StoreInfo<SingletonReferenceType>;
+    const handleForEntityMutator2 = await handleForStoreInfo(entityMutator2Store, arc);
+    await handleForEntityMutator2.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, entityMutator1Store.type.getContainedType(), null));
     await arc.idle;
 
     // fetch the entity from dsmForVerifying store and check it has been mutated again.

--- a/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
@@ -17,7 +17,7 @@ import {Runtime} from '../../runtime.js';
 import {DirectStoreMuxer} from '../direct-store-muxer.js';
 import {EntityType, MuxType} from '../../../types/lib-types.js';
 import {Manifest} from '../../manifest.js';
-import {CRDTMuxEntity, newStore} from '../storage.js';
+import {CRDTMuxEntity} from '../storage.js';
 import {Identified, CRDTEntity, EntityOpTypes, CRDTSingleton} from '../../../crdt/lib-crdt.js';
 import {StoreInfo} from '../store-info.js';
 
@@ -45,13 +45,13 @@ describe('RamDisk + Direct Store Muxer Integration', async () => {
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const type = new MuxType(new EntityType(simpleSchema));
-    const baseStore = newStore(new StoreInfo<MuxType<EntityType>>({
-        storageKey, exists: Exists.ShouldCreate, type, id: 'base-store-id'}));
+    const storeInfo = new StoreInfo<MuxType<EntityType>>({
+        storageKey, exists: Exists.ShouldCreate, type, id: 'base-store-id'});
     const store = await DirectStoreMuxer.construct<Identified, Identified, CRDTMuxEntity>({
       storageKey,
       exists: Exists.ShouldCreate,
       type: new MuxType(new EntityType(simpleSchema)),
-      baseStore,
+      storeInfo,
     });
 
 

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -14,7 +14,7 @@ import {DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 import {EntityType, Schema} from '../../../types/lib-types.js';
 import {ReferenceModeStorageKey} from '../reference-mode-storage-key.js';
-import {newHandle, handleForStore, newStore} from '../storage.js';
+import {newHandle, handleForStoreInfo, newStore} from '../storage.js';
 import {Particle} from '../../particle.js';
 import {Exists} from '../drivers/driver.js';
 import {StorageProxy} from '../storage-proxy.js';
@@ -72,9 +72,9 @@ describe('ReferenceModeStore Integration', async () => {
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
     // Set up a common store and host both handles on top. This will result in one store but two different proxies.
-    const store = newStore(new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'}));
-    const writeHandle = await handleForStore(store, arc);
-    const readHandle = await handleForStore(store, arc);
+    const store = new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'});
+    const writeHandle = await handleForStoreInfo(store, arc);
+    const readHandle = await handleForStoreInfo(store, arc);
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -185,9 +185,9 @@ describe('ReferenceModeStore Integration', async () => {
     const type = new EntityType(new Schema(['AnEntity'], {foo: {kind: 'schema-ordered-list', schema: {kind: 'schema-primitive', type: 'Text'}}})).collectionOf();
 
     // Set up a common store and host both handles on top. This will result in one store but two different proxies.
-    const store = newStore(new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'}));
-    const writeHandle = await handleForStore(store, arc);
-    const readHandle = await handleForStore(store, arc);
+    const store = new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'});
+    const writeHandle = await handleForStoreInfo(store, arc);
+    const readHandle = await handleForStoreInfo(store, arc);
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {

--- a/src/runtime/storage/tests/reference-mode-store-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-test.ts
@@ -19,13 +19,14 @@ import {CountType, CollectionType, EntityType, SingletonType, Schema} from '../.
 import {SerializedEntity} from '../../entity.js';
 import {ReferenceModeStorageKey} from '../reference-mode-storage-key.js';
 import {CRDTEntity, EntityOpTypes, CRDTEntityTypeRecord, CRDTCollection, CollectionOpTypes, CollectionData,
-        CollectionOperation, CRDTCollectionTypeRecord, CRDTSingleton} from '../../../crdt/lib-crdt.js';
+        CollectionOperation, CRDTSingleton} from '../../../crdt/lib-crdt.js';
 import {StoreInfo} from '../store-info.js';
+import {CollectionEntityType} from '../storage.js';
 
 /* eslint-disable no-async-promise-executor */
 
 let testKey: ReferenceModeStorageKey;
-let baseStore: Store<CRDTCollectionTypeRecord<SerializedEntity>>;
+let storeInfo: StoreInfo<CollectionEntityType>;
 
 class MyEntityModel extends CRDTEntity<{name: {id: string, value: string}, age: {id: string, value: number}}, {}> {
   constructor() {
@@ -54,7 +55,7 @@ async function createReferenceModeStore() {
     storageKey: testKey,
     exists: Exists.ShouldCreate,
     type: collectionType,
-    baseStore,
+    storeInfo
   });
 }
 
@@ -84,8 +85,8 @@ describe('Reference Mode Store', async () => {
 
   beforeEach(() => {
     testKey = new ReferenceModeStorageKey(new MockHierarchicalStorageKey(), new MockHierarchicalStorageKey());
-    baseStore = new Store(new StoreInfo({
-        storageKey: testKey, type: collectionType, exists: Exists.ShouldCreate, id: 'base-store-id'}));
+    storeInfo = new StoreInfo({
+        storageKey: testKey, type: collectionType, exists: Exists.ShouldCreate, id: 'base-store-id'});
     DriverFactory.clearRegistrationsForTesting();
   });
 

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -33,9 +33,10 @@ import {Entity} from '../entity.js';
 import {RamDiskStorageDriverProvider} from '../storage/drivers/ramdisk.js';
 import {ReferenceModeStorageKey} from '../storage/reference-mode-storage-key.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
-import {SingletonEntityStore, CollectionEntityStore, handleForStore} from '../storage/storage.js';
+import {handleForStoreInfo, SingletonEntityType, CollectionEntityType} from '../storage/storage.js';
 import {Capabilities, Ttl, Queryable, Persistence} from '../capabilities.js';
 import {StorageServiceImpl} from '../storage/storage-service.js';
+import {StoreInfo} from '../storage/store-info.js';
 
 async function setup(storageKeyPrefix:  (arcId: ArcId) => StorageKey) {
   const loader = new Loader();
@@ -108,9 +109,9 @@ describe('Arc new storage', () => {
     const refVarKey  = new ReferenceModeStorageKey(new VolatileStorageKey(id, 'colVar'), new VolatileStorageKey(id, 'refVar'));
     const refVarStore = await arc.createStore(new SingletonType(dataClass.type), undefined, 'test:2', [], refVarKey);
 
-    const varHandle = await handleForStore(varStore, arc);
-    const colHandle = await handleForStore(colStore, arc);
-    const refVarHandle = await handleForStore(refVarStore, arc);
+    const varHandle = await handleForStoreInfo(varStore, arc);
+    const colHandle = await handleForStoreInfo(colStore, arc);
+    const refVarHandle = await handleForStoreInfo(refVarStore, arc);
 
     // Populate the stores, run the arc and get its serialization.
     const d1 = new dataClass({value: 'v1'});
@@ -138,19 +139,19 @@ describe('Arc new storage', () => {
     await refVarHandle.clear();
 
     const arc2 = await Arc.deserialize({serialization, loader, fileName: '', context: manifest, storageService: new StorageServiceImpl()});
-    const varStore2 = arc2.findStoreById(varStore.id) as SingletonEntityStore;
-    const colStore2 = arc2.findStoreById(colStore.id) as CollectionEntityStore;
-    const refVarStore2 = arc2.findStoreById(refVarStore.id) as SingletonEntityStore;
+    const varStore2 = arc2.findStoreById(varStore.id) as StoreInfo<SingletonEntityType>;
+    const colStore2 = arc2.findStoreById(colStore.id) as StoreInfo<CollectionEntityType>;
+    const refVarStore2 = arc2.findStoreById(refVarStore.id) as StoreInfo<SingletonEntityType>;
 
-    const varHandle2 = await handleForStore(varStore2, arc2);
+    const varHandle2 = await handleForStoreInfo(varStore2, arc2);
     const varData = await varHandle2.fetch();
     assert.deepEqual(varData, d1);
 
-    const colHandle2 = await handleForStore(colStore2, arc2);
+    const colHandle2 = await handleForStoreInfo(colStore2, arc2);
     const colData = await colHandle2.toList();
     assert.deepEqual(colData, [d2, d3]);
 
-    const refVarHandle2 = await handleForStore(refVarStore2, arc2);
+    const refVarHandle2 = await handleForStoreInfo(refVarStore2, arc2);
     const refVarData = await refVarHandle2.fetch();
     assert.deepEqual(refVarData, d4);
   });
@@ -206,8 +207,8 @@ describe('Arc', () => {
     const {arc, recipe, Foo, Bar} = await doSetup();
     const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
     const barStore = await arc.createStore(new SingletonType(Bar.type), undefined, 'test:2');
-    const fooHandle = await handleForStore(fooStore, arc);
-    const barHandle = await handleForStore(barStore, arc);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
+    const barHandle = await handleForStoreInfo(barStore, arc);
 
     await fooHandle.set(new Foo({value: 'a Foo'}));
     recipe.handles[0].mapToStorage(fooStore);
@@ -222,8 +223,8 @@ describe('Arc', () => {
     const {arc, recipe, Foo, Bar} = await doSetup();
     const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
     const barStore = await arc.createStore(new SingletonType(Bar.type), undefined, 'test:2');
-    const fooHandle = await handleForStore(fooStore, arc);
-    const barHandle = await handleForStore(barStore, arc);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
+    const barHandle = await handleForStoreInfo(barStore, arc);
 
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
@@ -266,10 +267,10 @@ describe('Arc', () => {
     const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
     const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
     const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStore(aStore, arc);
-    const bHandle = await handleForStore(bStore, arc);
-    const cHandle = await handleForStore(cStore, arc);
-    const dHandle = await handleForStore(dStore, arc);
+    const aHandle = await handleForStoreInfo(aStore, arc);
+    const bHandle = await handleForStoreInfo(bStore, arc);
+    const cHandle = await handleForStoreInfo(cStore, arc);
+    const dHandle = await handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
@@ -384,10 +385,10 @@ describe('Arc', () => {
     const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
     const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
     const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStore(aStore, arc);
-    const bHandle = await handleForStore(bStore, arc);
-    const cHandle = await handleForStore(cStore, arc);
-    const dHandle = await handleForStore(dStore, arc);
+    const aHandle = await handleForStoreInfo(aStore, arc);
+    const bHandle = await handleForStoreInfo(bStore, arc);
+    const cHandle = await handleForStoreInfo(cStore, arc);
+    const dHandle = await handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
@@ -527,10 +528,10 @@ describe('Arc', () => {
     const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
     const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
     const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStore(aStore, arc);
-    const bHandle = await handleForStore(bStore, arc);
-    const cHandle = await handleForStore(cStore, arc);
-    const dHandle = await handleForStore(dStore, arc);
+    const aHandle = await handleForStoreInfo(aStore, arc);
+    const bHandle = await handleForStoreInfo(bStore, arc);
+    const cHandle = await handleForStoreInfo(cStore, arc);
+    const dHandle = await handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
@@ -627,10 +628,10 @@ describe('Arc', () => {
     const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
     const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
     const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStore(aStore, arc);
-    const bHandle = await handleForStore(bStore, arc);
-    const cHandle = await handleForStore(cStore, arc);
-    const dHandle = await handleForStore(dStore, arc);
+    const aHandle = await handleForStoreInfo(aStore, arc);
+    const bHandle = await handleForStoreInfo(bStore, arc);
+    const cHandle = await handleForStoreInfo(cStore, arc);
+    const dHandle = await handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
@@ -680,10 +681,10 @@ describe('Arc', () => {
     const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
     const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
     const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStore(aStore, arc);
-    const bHandle = await handleForStore(bStore, arc);
-    const cHandle = await handleForStore(cStore, arc);
-    const dHandle = await handleForStore(dStore, arc);
+    const aHandle = await handleForStoreInfo(aStore, arc);
+    const bHandle = await handleForStoreInfo(bStore, arc);
+    const cHandle = await handleForStoreInfo(cStore, arc);
+    const dHandle = await handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
@@ -723,12 +724,12 @@ describe('Arc', () => {
   it('deserializing a simple serialized arc produces that arc', async () => {
     const {arc, context, recipe, Foo, Bar, loader} = await  doSetup();
     let fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
-    const fooHandle = await handleForStore(fooStore, arc);
-    const fooStoreCallbacks = await CallbackTracker.create(fooStore, 1);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
+    const fooStoreCallbacks = await CallbackTracker.create(arc.getActiveStore(fooStore), 1);
     await fooHandle.set(new Foo({value: 'a Foo'}));
 
     let barStore = await arc.createStore(new SingletonType(Bar.type), undefined, 'test:2', ['tag1', 'tag2']);
-    const barHandle = await handleForStore(barStore, arc);
+    const barHandle = await handleForStoreInfo(barStore, arc);
 
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
@@ -743,8 +744,8 @@ describe('Arc', () => {
 
     const newArc = await Arc.deserialize({serialization, loader, fileName: '', slotComposer: new SlotComposer(), context, storageService: new StorageServiceImpl()});
     await newArc.idle;
-    fooStore = newArc.findStoreById(fooStore.id) as SingletonEntityStore;
-    barStore = newArc.findStoreById(barStore.id) as SingletonEntityStore;
+    fooStore = newArc.findStoreById(fooStore.id) as StoreInfo<SingletonEntityType>;
+    barStore = newArc.findStoreById(barStore.id) as StoreInfo<SingletonEntityType>;
     assert(fooStore);
     assert(barStore);
     assert.lengthOf(newArc.findStoresByType(new SingletonType(Bar.type), {tags: ['tag1']}), 1);
@@ -787,8 +788,8 @@ describe('Arc', () => {
 
     const newArc = await Arc.deserialize({serialization, loader, slotComposer, fileName: './manifest.manifest', context: manifest, storageService: new StorageServiceImpl()});
     await newArc.idle;
-    store = newArc.findStoreById(store.id) as CollectionEntityStore;
-    const handle = await handleForStore(store, newArc);
+    store = newArc.findStoreById(store.id) as StoreInfo<CollectionEntityType>;
+    const handle = await handleForStoreInfo(store, newArc);
     await handle.add(new handle.entityClass({value: 'one'}));
     await newArc.idle;
 
@@ -1026,8 +1027,8 @@ describe('Arc storage migration', () => {
   it('supports new StorageKey type', Flags.withDefaultReferenceMode(async () => {
     const {arc, Foo} = await setup(arcId => new VolatileStorageKey(arcId, ''));
     const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
-    assert.instanceOf(fooStore, Store);
-    const activeStore = await fooStore.activate();
+    assert.instanceOf(fooStore, StoreInfo);
+    const activeStore = await arc.getActiveStore(fooStore).activate();
     assert.instanceOf(activeStore, ReferenceModeStore);
     assert.instanceOf(activeStore['backingStore'], DirectStoreMuxer);
     const backingStore = activeStore['containerStore'] as DirectStore<CRDTTypeRecord>;
@@ -1095,7 +1096,7 @@ describe('Arc storage migration', () => {
     const getStoreByConnectionName = async (connectionName) => {
       const store = arc.findStoreById(
         arc.activeRecipe.particles[0].connections[connectionName].handle.id);
-      return store.activate();
+      return await arc.getActiveStore(store).activate();
     };
     const getStoreValue = (storeContents, index, expectedLength) => {
       assert.lengthOf(Object.keys(storeContents['values']), expectedLength);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -1096,7 +1096,7 @@ describe('Arc storage migration', () => {
     const getStoreByConnectionName = async (connectionName) => {
       const store = arc.findStoreById(
         arc.activeRecipe.particles[0].connections[connectionName].handle.id);
-      return await arc.getActiveStore(store).activate();
+      return arc.getActiveStore(store).activate();
     };
     const getStoreValue = (storeContents, index, expectedLength) => {
       assert.lengthOf(Object.keys(storeContents['values']), expectedLength);

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -16,7 +16,7 @@ import {SlotComposer} from '../slot-composer.js';
 import {EntityType, Schema} from '../../types/lib-types.js';
 import {Entity} from '../entity.js';
 import {ArcId} from '../id.js';
-import {handleForStore} from '../storage/storage.js';
+import {handleForStoreInfo} from '../storage/storage.js';
 import {isCollectionEntityStore, entityHasName} from '../storage/store.js';
 import {Runtime} from '../runtime.js';
 
@@ -31,11 +31,11 @@ describe('entity', () => {
     const collectionType = new EntityType(schema).collectionOf();
 
     const storage = await arc.createStore(collectionType);
-    const handle = await handleForStore(storage, arc);
+    const handle = await handleForStoreInfo(storage, arc);
     await handle.add(entity);
 
     const store = arc.stores.filter(isCollectionEntityStore).find(entityHasName('TestSchema'));
-    const collection = await handleForStore(store, arc);
+    const collection = await handleForStoreInfo(store, arc);
     const list = await collection.toList();
     const clone = list[0];
     assert.isDefined(clone);

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -2141,7 +2141,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       const manifest = await parseManifest(manifestStr, {fileName: 'the.manifest', memoryProvider, storageService});
       const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
       const handle = await handleForStoreInfo(store, manifest);
-      await assertThrowsAsync(async () => await handle.toList(), msg);
+      await assertThrowsAsync(async () => handle.toList(), msg);
     };
 
     // Incorrect types

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -33,8 +33,9 @@ import {mockFirebaseStorageKeyOptions} from '../storage/testing/mock-firebase.js
 import {Flags} from '../flags.js';
 import {TupleType, CollectionType, EntityType, TypeVariable, Schema, BinaryExpression,
         FieldNamePrimitive, NumberPrimitive, PrimitiveField} from '../../types/lib-types.js';
-import {ActiveCollectionEntityStore, handleForActiveStore} from '../storage/storage.js';
+import {ActiveCollectionEntityStore, handleForActiveStore, handleForStoreInfo, CollectionEntityType} from '../storage/storage.js';
 import {Ttl} from '../capabilities.js';
+import {StoreInfo} from '../storage/store-info.js';
 
 function verifyPrimitiveType(field, type) {
   assert(field instanceof PrimitiveField, `Got ${field.constructor.name}, but expected a primitive field.`);
@@ -1939,7 +1940,7 @@ recipe SomeRecipe
     const manifest = await Manifest.load('./the.manifest', loader, {memoryProvider});
     const storageStub = manifest.findStoreByName('Store0');
     assert(storageStub);
-    const store = await storageStub.activate() as ActiveCollectionEntityStore;
+    const store = await manifest.getActiveStore(storageStub).activate() as ActiveCollectionEntityStore;
     assert(store);
     const handle = handleForActiveStore(store, manifest);
 
@@ -1995,9 +1996,9 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
 
       store Store0 of [Thing] in EntityList
     `, {fileName: 'the.manifest', memoryProvider});
-    const store = (await manifest.findStoreByName('Store0').activate()) as ActiveCollectionEntityStore;
-    assert(store);
-    const handle = handleForActiveStore(store, manifest);
+    const storeInfo = manifest.findStoreByName('Store0') as StoreInfo<CollectionEntityType>;
+    assert(storeInfo);
+    const handle = await handleForStoreInfo(storeInfo, manifest);
 
     // TODO(shans): address as part of storage refactor
     assert.deepEqual((await handle.toList()).map(Entity.serialize), [
@@ -2021,8 +2022,8 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         {n: 4.5, t: 'abc', u: 'site', f: true, b: |5a, 7, d|, r: <'i2', 'reference-mode://{volatile://!3:test/backing2@}{volatile://!4:test/container2@}'>},
       }
     `, {fileName: 'the.manifest', memoryProvider});
-    const store = (await manifest.findStoreByName('X').activate()) as ActiveCollectionEntityStore;
-    const handle = handleForActiveStore(store, manifest);
+    const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
+    const handle = await handleForStoreInfo(store, manifest);
     const entities = (await handle.toList()).map(Entity.serialize);
     assert.lengthOf(entities, 2);
 
@@ -2055,8 +2056,8 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         }
       }
     `, {fileName: 'the.manifest', memoryProvider});
-    const store = (await manifest.findStoreByName('X').activate()) as ActiveCollectionEntityStore;
-    const handle = handleForActiveStore(store, manifest);
+    const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
+    const handle = await handleForStoreInfo(store, manifest);
     const entities = (await handle.toList()).map(Entity.serialize);
     assert.lengthOf(entities, 2);
 
@@ -2092,8 +2093,8 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         },
       }
     `, {fileName: 'the.manifest', memoryProvider});
-    const store = (await manifest.findStoreByName('X').activate()) as ActiveCollectionEntityStore;
-    const handle = handleForActiveStore(store, manifest);
+    const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
+    const handle = await handleForStoreInfo(store, manifest);
     const entities = (await handle.toList()).map(Entity.serialize);
     assert.lengthOf(entities, 2);
 
@@ -2119,8 +2120,8 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         {u: |1e, e7|},
       }
     `, {fileName: 'the.manifest', memoryProvider});
-    const store = (await manifest.findStoreByName('X').activate()) as ActiveCollectionEntityStore;
-    const handle = handleForActiveStore(store, manifest);
+    const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
+    const handle = await handleForStoreInfo(store, manifest);
     const entities = (await handle.toList()).map(e => Entity.serialize(e).rawData);
 
     assert.deepStrictEqual(entities, [
@@ -2135,9 +2136,9 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
   it('throws an error when inline entities do not match the store schema', async () => {
     const check = async (manifestStr, msg) => {
       const manifest = await parseManifest(manifestStr, {fileName: 'the.manifest', memoryProvider});
-      const store = (await manifest.findStoreByName('X').activate()) as ActiveCollectionEntityStore;
-      const handle = handleForActiveStore(store, manifest);
-      await assertThrowsAsync(async () => handle.toList(), msg);
+      const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
+      const handle = await handleForStoreInfo(store, manifest);
+      await assertThrowsAsync(async () => await handle.toList(), msg);
     };
 
     // Incorrect types
@@ -4357,7 +4358,7 @@ resource NobIdJson
     assert.lengthOf(manifest.stores, 1);
     const store = manifest.stores[0];
 
-    assert.instanceOf(store, Store);
+    assert.instanceOf(store, StoreInfo);
     assert.strictEqual(store.name, 'NobId');
     assert.instanceOf(store.storageKey, RamDiskStorageKey);
     const schema = store.type.getEntitySchema();
@@ -4597,7 +4598,7 @@ annotation baz(qux: Number)
 store Store0 of [Thing {blah: Text}] 'my-things' in 'Things.json'
     `;
     const manifest = await Manifest.parse(manifestStr, {loader, memoryProvider});
-    const annotations = manifest.stores[0].storeInfo.annotations;
+    const annotations = manifest.stores[0].annotations;
     assert.lengthOf(annotations, 2);
     assert.equal(annotations.find(a => a.name === 'foo').params['bar'], 'hello');
     assert.equal(annotations.find(a => a.name === 'baz').params['qux'], 123);

--- a/src/runtime/tests/multiplexer-test.ts
+++ b/src/runtime/tests/multiplexer-test.ts
@@ -15,7 +15,7 @@ import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
 import {checkDefined} from '../testing/preconditions.js';
 import {SlotComposer} from '../slot-composer.js';
-import {handleForStore} from '../storage/storage.js';
+import {handleForStoreInfo} from '../storage/storage.js';
 import {EntityType} from '../../types/lib-types.js';
 import {Runtime} from '../runtime.js';
 
@@ -41,7 +41,7 @@ describe('Multiplexer', () => {
     const runtime = new Runtime({context: manifest, loader: new Loader()});
     const arc = runtime.newArc('test');
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
-    const barHandle = await handleForStore(barStore, arc);
+    const barHandle = await handleForStoreInfo(barStore, arc);
     recipe.handles[0].mapToStorage(barStore);
     assert(recipe.normalize(), 'normalize');
     assert(recipe.isResolved());

--- a/src/runtime/tests/particle-api-more-test.ts
+++ b/src/runtime/tests/particle-api-more-test.ts
@@ -14,25 +14,26 @@ import {Manifest} from '../manifest.js';
 import {Runtime} from '../runtime.js';
 import {Arc} from '../arc.js';
 import {storageKeyPrefixForTest} from '../testing/handle-for-test.js';
-import {SingletonEntityStore, CollectionEntityStore, SingletonEntityHandle, CollectionEntityHandle, handleForStore} from '../storage/storage.js';
+import {SingletonEntityHandle, CollectionEntityHandle, SingletonEntityType, handleForStoreInfo, CollectionEntityType} from '../storage/storage.js';
+import {StoreInfo} from '../storage/store-info.js';
 
 //
 // TODO(sjmiles): deref'ing stores by index is brittle, but `id` provided to create syntax
 // doesn't end up on the store, and searching by type or tags is hard (?)
 //
 const getSingletonData = async (arc: Arc, index: number) => {
-  const store = arc.stores[index] as SingletonEntityStore;
+  const store = arc.stores[index] as StoreInfo<SingletonEntityType>;
   assert.ok(store, `failed to find store[${index}]`);
-  const handle: SingletonEntityHandle = await handleForStore(store, arc);
+  const handle: SingletonEntityHandle = await handleForStoreInfo(store, arc);
   const data = await handle.fetch();
   assert.ok(data, `store[${index}] was empty`);
   return data;
 };
 
 const getCollectionData = async (arc: Arc, index: number) => {
-  const store = arc.stores[index] as CollectionEntityStore;
+  const store = arc.stores[index] as StoreInfo<CollectionEntityType>;
   assert.ok(store, `failed to find store[${index}]`);
-  const handle: CollectionEntityHandle = await handleForStore(store, arc);
+  const handle: CollectionEntityHandle = await handleForStoreInfo(store, arc);
   const data = await handle.toList();
   assert.ok(data, `store[${index}] was empty`);
   return data;

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -17,7 +17,7 @@ import {ParticleSpec} from '../arcs-types/particle-spec.js';
 import {ArcId} from '../id.js';
 import {VolatileStorageKey} from '../storage/drivers/volatile.js';
 import {Entity} from '../entity.js';
-import {handleForStore} from '../storage/storage.js';
+import {handleForStoreInfo} from '../storage/storage.js';
 import {isSingletonEntityStore} from '../storage/store.js';
 import {newRecipe} from '../recipe/lib-recipe.js';
 import {Runtime} from '../runtime.js';
@@ -25,7 +25,7 @@ import {StorageServiceImpl} from '../storage/storage-service.js';
 
 async function mapHandleToStore(arc: Arc, recipe, classType: {type: EntityType}, id) {
   const store = await arc.createStore(new SingletonType(classType.type), undefined, `test:${id}`);
-  const handle = await handleForStore(store, arc);
+  const handle = await handleForStoreInfo(store, arc);
   recipe.handles[id].mapToStorage(store);
   return handle;
 }
@@ -96,9 +96,9 @@ describe('particle interface loading', () => {
     const ifaceStore = await arc.createStore(new SingletonType(ifaceType));
     const outStore = await arc.createStore(new SingletonType(barType));
     const inStore = await arc.createStore(new SingletonType(fooType));
-    const ifaceHandle = await handleForStore(ifaceStore, arc);
+    const ifaceHandle = await handleForStoreInfo(ifaceStore, arc);
     await ifaceHandle.set(manifest.particles[0]);
-    const inHandle = await handleForStore(inStore, arc);
+    const inHandle = await handleForStoreInfo(inStore, arc);
     await inHandle.set(new inHandle.entityClass({value: 'a foo'}));
 
     const recipe = newRecipe();
@@ -125,7 +125,7 @@ describe('particle interface loading', () => {
 
     await arc.instantiate(recipe);
     await arc.idle;
-    const outHandle = await handleForStore(outStore, arc);
+    const outHandle = await handleForStoreInfo(outStore, arc);
     assert.deepStrictEqual(await outHandle.fetch() as {}, {value: 'a foo1'});
   });
 
@@ -157,13 +157,13 @@ describe('particle interface loading', () => {
     await arc.instantiate(recipe);
 
     const fooStore = arc.findStoresByType(new SingletonType(fooType))[0];
-    const fooHandle = await handleForStore(fooStore, arc);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
     await fooHandle.setFromData({value: 'a foo'});
 
     await arc.idle;
 
     const barStore = arc.findStoresByType(new SingletonType(barType))[0];
-    const barHandle = await handleForStore(barStore, arc);
+    const barHandle = await handleForStoreInfo(barStore, arc);
     assert.deepEqual(await barHandle.fetch() as {}, {value: 'a foo1'});
   });
 
@@ -238,7 +238,7 @@ describe('particle interface loading', () => {
 
     await arc.instantiate(recipe);
     await arc.idle;
-    const fooHandle = await handleForStore(fooStore, arc);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
     assert.deepStrictEqual(await fooHandle.fetch() as {}, {value: 'hello world!!!'});
   });
 
@@ -281,7 +281,7 @@ describe('particle interface loading', () => {
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooStore = await arc.createStore(new SingletonType(fooClass.type), undefined, 'test:0');
-    const fooHandle = await handleForStore(fooStore, arc);
+    const fooHandle = await handleForStoreInfo(fooStore, arc);
     recipe.handles[0].mapToStorage(fooStore);
 
     recipe.normalize();
@@ -295,7 +295,7 @@ describe('particle interface loading', () => {
     const arc2 = await Arc.deserialize({serialization, loader, fileName: '', context: manifest, storageService: new StorageServiceImpl()});
     await arc2.idle;
 
-    const fooHandle2 = await handleForStore(arc2.stores.find(isSingletonEntityStore), arc2);
+    const fooHandle2 = await handleForStoreInfo(arc2.stores.find(isSingletonEntityStore), arc2);
     assert.deepStrictEqual(await fooHandle2.fetch(), new fooClass({value: 'Not created!'}));
   });
 

--- a/src/runtime/tests/particle-interface-loading-with-slots-test.ts
+++ b/src/runtime/tests/particle-interface-loading-with-slots-test.ts
@@ -17,8 +17,9 @@ import {SlotComposer} from '../slot-composer.js';
 import {SlotTestObserver} from '../testing/slot-test-observer.js';
 import {Recipe} from '../recipe/lib-recipe.js';
 import {Entity} from '../entity.js';
-import {CollectionEntityStore, handleForStore, CollectionEntityHandle} from '../storage/storage.js';
+import {CollectionEntityHandle, handleForStoreInfo, CollectionEntityType} from '../storage/storage.js';
 import {Runtime} from '../runtime.js';
+import {StoreInfo} from '../storage/store-info.js';
 
 describe('particle interface loading with slots', () => {
   async function initializeManifestAndArc(contextContainer?):
@@ -50,8 +51,8 @@ describe('particle interface loading with slots', () => {
   // tslint:disable-next-line: no-any
   async function instantiateRecipeAndStore(arc: Arc, recipe: Recipe, manifest: Manifest): Promise<CollectionEntityHandle> {
     await arc.instantiate(recipe);
-    const inStore = arc.findStoresByType(manifest.findTypeByName('Foo').collectionOf())[0] as CollectionEntityStore;
-    const inHandle = await handleForStore(inStore, arc);
+    const inStore = arc.findStoresByType(manifest.findTypeByName('Foo').collectionOf())[0] as StoreInfo<CollectionEntityType>;
+    const inHandle = await handleForStoreInfo(inStore, arc);
     await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo1'}), 'subid-1', null));
     await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo2'}), 'subid-2', null));
     return inHandle;

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -10,7 +10,8 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
-import {SingletonEntityStore, handleForStore} from '../storage/storage.js';
+import {handleForStoreInfo, SingletonEntityType} from '../storage/storage.js';
+import {StoreInfo} from '../storage/store-info.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
@@ -18,9 +19,9 @@ describe('runtime manifest integration', () => {
     await arc.instantiate(recipe);
     await arc.idle;
     const type = recipe.handles[0].type;
-    const [store] = arc.findStoresByType(type) as SingletonEntityStore[];
+    const storeInfo = arc.findStoresByType(type)[0] as StoreInfo<SingletonEntityType>;
 
-    const handle = await handleForStore(store, arc);
+    const handle = await handleForStoreInfo(storeInfo, arc);
     // TODO: This should not be necessary.
     type.maybeEnsureResolved();
     const result = await handle.fetch();

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -29,12 +29,16 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
   // Delete the IdGenerator before comparing that the manifests are the same, since the IdGenerator will contain a different random session ID
   // for each Manifest instantiation.
   unsafe(expected).idGenerator = null;
+  unsafe(expected).generateID = null;
   unsafe(actual).idGenerator = null;
+  unsafe(actual).generateID = null;
   for (const canonicalManfiest of unsafe(expected).canonicalImports) {
     canonicalManfiest.idGenerator = null;
+    canonicalManfiest.generateID = null;
   }
   for (const canonicalManfiest of unsafe(actual).canonicalImports) {
     canonicalManfiest.idGenerator = null;
+    canonicalManfiest.generateID = null;
   }
 
   assert.deepEqual(expected, actual);

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -15,7 +15,7 @@ import {ArcId} from '../runtime/id.js';
 import {Loader} from '../platform/loader.js';
 import {SlotComposer} from '../runtime/slot-composer.js';
 import {FakePecFactory} from '../runtime/fake-pec-factory.js';
-import {handleForStore} from '../runtime/storage/storage.js';
+import {handleForStoreInfo} from '../runtime/storage/storage.js';
 import {SingletonType, EntityType} from '../types/lib-types.js';
 import {Runtime} from '../runtime/runtime.js';
 
@@ -130,8 +130,8 @@ describe('Hot Code Reload for JS Particle', async () => {
 
     const personStoreIn = await arc.createStore(new SingletonType(personType));
     const personStoreOut = await arc.createStore(new SingletonType(personType));
-    const personHandleIn = await handleForStore(personStoreIn, arc);
-    const personHandleOut = await handleForStore(personStoreOut, arc);
+    const personHandleIn = await handleForStoreInfo(personStoreIn, arc);
+    const personHandleOut = await handleForStoreInfo(personStoreOut, arc);
     await personHandleIn.setFromData({name: 'Jack', age: 15});
 
     const recipe = context.recipes[0];
@@ -212,8 +212,8 @@ describe('Hot Code Reload for WASM Particle', async () => {
 
     const personStoreIn = await arc.createStore(new SingletonType(personType));
     const personStoreOut = await arc.createStore(new SingletonType(personType));
-    const personHandleIn = await handleForStore(personStoreIn, arc);
-    const personHandleOut = await handleForStore(personStoreOut, arc);
+    const personHandleIn = await handleForStoreInfo(personStoreIn, arc);
+    const personHandleOut = await handleForStoreInfo(personStoreOut, arc);
     await personHandleIn.setFromData({name: 'Jack', age: 15});
 
     const recipe = context.recipes.filter(r => r.name === 'ReloadHandleRecipe')[0];

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -22,14 +22,16 @@ import {DriverFactory} from '../runtime/storage/drivers/driver-factory.js';
 import {handleForStoreInfo, CollectionEntityType} from '../runtime/storage/storage.js';
 import {isCollectionEntityStore} from '../runtime/storage/store.js';
 import {StoreInfo} from '../runtime/storage/store-info.js';
+import {StorageServiceImpl} from '../runtime/storage/storage-service.js';
 
 describe('Multiplexer', () => {
   it('renders polymorphic multiplexed slots', async () => {
     const memoryProvider = new TestVolatileMemoryProvider();
+    const storageService = new StorageServiceImpl();
     RamDiskStorageDriverProvider.register(memoryProvider);
     const loader = new Loader();
     const manifest = './src/tests/particles/artifacts/polymorphic-muxing.recipes';
-    const context = await Manifest.load(manifest, loader, {memoryProvider});
+    const context = await Manifest.load(manifest, loader, {memoryProvider, storageService});
 
     const showOneParticle = context.particles.find(p => p.name === 'ShowOne');
     const showOneSpec = JSON.stringify(showOneParticle.toLiteral());

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -31,7 +31,7 @@ describe('Multiplexer', () => {
     RamDiskStorageDriverProvider.register(memoryProvider);
     const loader = new Loader();
     const manifest = './src/tests/particles/artifacts/polymorphic-muxing.recipes';
-    const context = await Manifest.load(manifest, loader, {memoryProvider, storageService});
+    const context = await Manifest.load(manifest, loader, {memoryProvider});
 
     const showOneParticle = context.particles.find(p => p.name === 'ShowOne');
     const showOneSpec = JSON.stringify(showOneParticle.toLiteral());
@@ -55,8 +55,9 @@ describe('Multiplexer', () => {
       post: reads v1
       item: consumes s1`;
 
+    const runtime = new Runtime({loader, context, memoryProvider});
     const thePostsStore = context.stores.find(isCollectionEntityStore);
-    const postsHandle = await handleForStoreInfo(thePostsStore, context);
+    const postsHandle = await handleForStoreInfo(thePostsStore, {...context, storageService: runtime.storageService});
     await postsHandle.add(Entity.identify(
         new postsHandle.entityClass({
           message: 'x',
@@ -79,7 +80,6 @@ describe('Multiplexer', () => {
         }),
         '3', null));
     // version could be set here, but doesn't matter for tests.
-    const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
 
     const observer = new SlotTestObserver();

--- a/src/tests/multiplexer-integration-test.ts
+++ b/src/tests/multiplexer-integration-test.ts
@@ -19,8 +19,9 @@ import {storageKeyPrefixForTest} from '../runtime/testing/handle-for-test.js';
 import {StrategyTestHelper} from '../planning/testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../runtime/storage/drivers/ramdisk.js';
 import {DriverFactory} from '../runtime/storage/drivers/driver-factory.js';
-import {CollectionEntityStore, handleForStore} from '../runtime/storage/storage.js';
+import {handleForStoreInfo, CollectionEntityType} from '../runtime/storage/storage.js';
 import {isCollectionEntityStore} from '../runtime/storage/store.js';
+import {StoreInfo} from '../runtime/storage/store-info.js';
 
 describe('Multiplexer', () => {
   it('renders polymorphic multiplexed slots', async () => {
@@ -53,7 +54,7 @@ describe('Multiplexer', () => {
       item: consumes s1`;
 
     const thePostsStore = context.stores.find(isCollectionEntityStore);
-    const postsHandle = await handleForStore(thePostsStore, context);
+    const postsHandle = await handleForStoreInfo(thePostsStore, context);
     await postsHandle.add(Entity.identify(
         new postsHandle.entityClass({
           message: 'x',
@@ -108,8 +109,8 @@ describe('Multiplexer', () => {
       .expectRenderSlot('ShowTwo', 'item')
       ;
 
-    const postsStore = arc.findStoreById(arc.activeRecipe.handles[0].id) as CollectionEntityStore;
-    const postsHandle2 = await handleForStore(postsStore, arc);
+    const postsStore = arc.findStoreById(arc.activeRecipe.handles[0].id) as StoreInfo<CollectionEntityType>;
+    const postsHandle2 = await handleForStoreInfo(postsStore, arc);
     const entityClass = new postsHandle.entityClass({
       message: 'w',
       renderRecipe: recipeOne,

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -89,7 +89,7 @@ describe('common particles test', () => {
     await suggestion.instantiate(arc);
     await arc.idle;
 
-    const endpointProvider = await arc.stores[2].activate() as ActiveCollectionEntityStore;
+    const endpointProvider = await arc.findActiveStoreById(arc.stores[2].id).activate() as ActiveCollectionEntityStore;
     const handle = handleForActiveStore(endpointProvider, arc);
     assert.strictEqual((await handle.toList()).length, 5);
   });

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -20,7 +20,8 @@ import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {storageKeyForTest, storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
-import {CollectionEntityStore, CollectionEntityHandle, handleForStore} from '../../runtime/storage/storage.js';
+import {CollectionEntityHandle, CollectionEntityType, handleForStoreInfo} from '../../runtime/storage/storage.js';
+import {StoreInfo} from '../../runtime/storage/store-info.js';
 
 describe('products test', () => {
 
@@ -32,8 +33,8 @@ describe('products test', () => {
 
   const verifyFilteredBook = async (arc: Arc) => {
     const booksHandle = arc.activeRecipe.handleConnections.find(hc => hc.isOutput).handle;
-    const store = arc.findStoreById(booksHandle.id) as CollectionEntityStore;
-    const handle: CollectionEntityHandle = await handleForStore(store, arc);
+    const store = arc.findStoreById(booksHandle.id) as StoreInfo<CollectionEntityType>;
+    const handle: CollectionEntityHandle = await handleForStoreInfo(store, arc);
     const list = await handle.toList();
     assert.lengthOf(list, 1);
     assert.strictEqual('Harry Potter', list[0].name);

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -20,8 +20,8 @@ import {DatabaseStorageKey} from '../runtime/storage/database-storage-key.js';
 import {Handle} from '../runtime/recipe/lib-recipe.js';
 import {digest} from '../platform/digest-web.js';
 import {VolatileStorageKey} from '../runtime/storage/drivers/volatile.js';
-import {Store} from '../runtime/storage/store.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
+import {StoreInfo} from '../runtime/storage/store-info.js';
 
 export class AllocatorRecipeResolverError extends Error {
   constructor(message: string) {
@@ -75,7 +75,7 @@ export class AllocatorRecipeResolver {
     }
 
     // Map from a handle id to its `create` handle, all handles mapping it.
-    const handleById: {[index: string]: ({handles: Handle[], store?: Store<CRDTTypeRecord>})} = {};
+    const handleById: {[index: string]: ({handles: Handle[], store?: StoreInfo<Type>})} = {};
     // Find all `create` handles of long running recipes.
     for (const recipe of recipes.filter(r => isLongRunning(r))) {
       const resolver = new CapabilitiesResolver({arcId: Id.fromString(findLongRunningArcId(recipe))});

--- a/src/types/tests/type-test.ts
+++ b/src/types/tests/type-test.ts
@@ -14,9 +14,9 @@ import {assert} from '../../platform/chai-web.js';
 import {Manifest} from '../../runtime/manifest.js';
 import {Entity} from '../../runtime/entity.js';
 import {UnaryExpressionNode, FieldNode, Op} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
-import {Store} from '../../runtime/storage/store.js';
 import {Schema} from '../lib-types.js';
 import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
+import {StoreInfo} from '../../runtime/storage/store-info.js';
 
 // For reference, this is a list of all the types and their contained data:
 //   EntityType        : Schema
@@ -572,10 +572,10 @@ describe('types', () => {
     it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
       const manifest = await Manifest.parse(manifestText);
       const recipe = manifest.recipes[1];
-      recipe.handles[0].mapToStorage({
+      recipe.handles[0].mapToStorage(new StoreInfo({
         id: 'test1',
         type: Entity.createEntityClass(manifest.findSchemaByName('Product'), null).type.collectionOf()
-      } as unknown as Store<CRDTTypeRecord>);
+      }));
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);
@@ -585,10 +585,10 @@ describe('types', () => {
     it('a subtype matches to a supertype that wants to be read when a handle exists', async () => {
       const manifest = await Manifest.parse(manifestText);
       const recipe = manifest.recipes[1];
-      recipe.handles[0].mapToStorage({
+      recipe.handles[0].mapToStorage(new StoreInfo({
         id: 'test1',
         type: Entity.createEntityClass(manifest.findSchemaByName('Lego'), null).type.collectionOf()
-      } as unknown as Store<CRDTTypeRecord>);
+      }));
       assert(recipe.normalize());
       assert(recipe.isResolved());
       assert.lengthOf(recipe.handles, 1);

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -20,7 +20,7 @@ import {VolatileStorageKey} from '../../runtime/storage/drivers/volatile.js';
 import {Exists} from '../../runtime/storage/drivers/driver.js';
 import {Reference} from '../../runtime/reference.js';
 import {Arc} from '../../runtime/arc.js';
-import {SingletonEntityStore, CollectionEntityStore, SingletonReferenceStore, CollectionReferenceStore, newStore, handleForStore} from '../../runtime/storage/storage.js';
+import {SingletonEntityStore, CollectionEntityStore, SingletonReferenceStore, CollectionReferenceStore, newStore, handleForStore, handleForStoreInfo} from '../../runtime/storage/storage.js';
 import {isSingletonEntityStore} from '../../runtime/storage/store.js';
 import {ReferenceModeStorageKey} from '../../runtime/storage/reference-mode-storage-key.js';
 import {StorageServiceImpl} from '../../runtime/storage/storage-service.js';
@@ -508,10 +508,10 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       const resType = manifest.findParticleByName('EntitySlicingTest').getConnectionByName('res').type as CollectionType<EntityType>;
       const resStore = await arc.createStore(resType, undefined, 'test:2');
 
-      const sng = await handleForStore(sngStore, arc);
+      const sng = await handleForStoreInfo(sngStore, arc);
       await sng.set(new sng.entityClass({num: 159, txt: 'Charlie', flg: true}));
 
-      const col = await handleForStore(colStore, arc);
+      const col = await handleForStoreInfo(colStore, arc);
       await col.add(new col.entityClass({num: 30, txt: 'Moe', flg: false}));
       await col.add(new col.entityClass({num: 60, txt: 'Larry', flg: false}));
       await col.add(new col.entityClass({num: 90, txt: 'Curly', flg: true}));
@@ -524,7 +524,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       await arc.instantiate(recipe);
       await arc.idle;
 
-      const res = await handleForStore(resStore, arc);
+      const res = await handleForStoreInfo(resStore, arc);
       assert.sameMembers((await res.toList()).map(e => e.val), [
         's1:159',
         's2:159,Charlie',
@@ -561,7 +561,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       await arc2.idle;
 
       const fooClass = Entity.createEntityClass(manifest.findSchemaByName('FooHandle'), null);
-      const fooHandle2 = await handleForStore(arc2.stores.find(isSingletonEntityStore), arc);
+      const fooHandle2 = await handleForStore(arc2.getActiveStore(arc2.stores.find(isSingletonEntityStore)), arc);
       assert.deepStrictEqual(await fooHandle2.fetch(), new fooClass({txt: 'Not created!'}));
 
     });


### PR DESCRIPTION
- Factor out the call to activate().
- get rid of NG suffix remainders
- Active store uses StoreInfo instead of Store in ctor
- getActiveStore implementation moved to storage service

Next steps:
- use StoreInfo in api-channel
- get rid of Store class