### PR TITLE
change paxel parser to grammar

### DIFF
--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -17,7 +17,6 @@ import arcs.core.data.expression.Expression.Scope
 import arcs.core.util.AnyOfParser
 import arcs.core.util.BigInt
 import arcs.core.util.Grammar
-import arcs.core.util.IgnoringParser
 import arcs.core.util.ParseResult
 import arcs.core.util.Parser
 import arcs.core.util.ParserException
@@ -37,7 +36,7 @@ import arcs.core.util.unaryMinus
  * A parser combinator implementation of the Paxel expression parser.
  */
 object PaxelParser : Grammar<Expression<Any>>() {
-  private val WS = "[\\s\\n]"
+  private const val WS = "[\\s\\n]"
 
   sealed class DiscreteType<T : Number> {
     object PaxelBigInt : DiscreteType<BigInt>() {
@@ -141,7 +140,7 @@ object PaxelParser : Grammar<Expression<Any>>() {
     parser(::nestedExpression)
 
   @Suppress("UNCHECKED_CAST")
-  @OptIn(kotlin.ExperimentalStdlibApi::class)
+  @OptIn(ExperimentalStdlibApi::class)
   private val scopeLookup by
   (scopeQualifier + many((token("?.") / token(".")) + ident)).map { (initial, rest) ->
     rest.fold(initial) { qualifier, (operator, id) ->
@@ -282,12 +281,10 @@ object PaxelParser : Grammar<Expression<Any>>() {
   private val paxelExpression by
   (newExpression / expressionWithQualifier / refinementExpression) as Parser<Expression<Any>>
 
-  private val topLevelExpression = (newExpression / expressionWithQualifier) as Parser<Expression<Any>>
-
-  override val topLevel by topLevelExpression + eof
+  override val topLevel by paxelExpression + ows + eof
 
   @Suppress("UNCHECKED_CAST")
-  private fun binaryOp(vararg tokens: String) = ows + AnyOfParser<String>(
+  private fun binaryOp(vararg tokens: String) = ows + AnyOfParser(
     tokens.map { token(it) }.toList()
   ).map { token ->
     Expression.BinaryOp.fromToken(token.trim()) as Expression.BinaryOp<Any?, Any?, Any?>

--- a/java/arcs/core/data/expression/PaxelParser.kt
+++ b/java/arcs/core/data/expression/PaxelParser.kt
@@ -76,16 +76,16 @@ object PaxelParser : Grammar<Expression<Any>>() {
   private val colon by -regex("($WS*:$WS*)")
 
   private val units by
-  optional(whitespace +
-             (regex("(millisecond)s?").map { Unit.Millisecond } /
-               regex("(second)s?").map { Unit.Second } /
-               regex("(minute)s?").map { Unit.Minute } /
-               regex("(hour)s?").map { Unit.Hour } /
-               regex("(day)s?").map { Unit.Day }
-               )
-  ).map {
-    it ?: Unit.Millisecond
-  }
+    optional(whitespace +
+      (regex("(millisecond)s?").map { Unit.Millisecond } /
+        regex("(second)s?").map { Unit.Second } /
+        regex("(minute)s?").map { Unit.Minute } /
+        regex("(hour)s?").map { Unit.Hour } /
+        regex("(day)s?").map { Unit.Day }
+        )
+    ).map {
+      it ?: Unit.Millisecond
+    }
 
   private val typeIdentifier by
   token("n").map { DiscreteType.PaxelBigInt } /
@@ -267,15 +267,14 @@ object PaxelParser : Grammar<Expression<Any>>() {
   (fromExpression / whereExpression / letExpression / orderByExpression)
 
   private val expressionWithQualifier by
-  (fromExpression + many(ows + qualifiedExpression) + selectExpression).map { (first, rest, select) ->
-    val all: List<QualifiedExpression> = listOf(first) + rest + listOf(select)
-    val nullQualifier: QualifiedExpression? = null
-    all.fold(
-      nullQualifier
-    ) { qualifier: QualifiedExpression?, qualified: QualifiedExpression ->
-      qualified.withQualifier(qualifier)
-    }
-  }
+    (fromExpression + many(ows + qualifiedExpression) + selectExpression)
+      .map { (first, rest, select) ->
+        val all: List<QualifiedExpression> = listOf(first) + rest + listOf(select)
+        val nullQualifier: QualifiedExpression? = null
+        all.fold(nullQualifier) { qualifier: QualifiedExpression?, qualified: QualifiedExpression ->
+          qualified.withQualifier(qualifier)
+        }
+      }
 
   @Suppress("UNCHECKED_CAST")
   private val paxelExpression by
@@ -332,7 +331,7 @@ object PaxelParser : Grammar<Expression<Any>>() {
     when (val result = this(paxelInput)) {
       is ParseResult.Success<*> -> result.value as Expression<*>
       is ParseResult.Failure -> throw IllegalArgumentException(
-        "Parse Failed reading ${paxelInput.substring(result.start.offset)}\n${result}"
+        "Parse Failed reading ${paxelInput.substring(result.start.offset)}\n$result"
       )
     }
 }

--- a/java/arcs/core/util/Parser.kt
+++ b/java/arcs/core/util/Parser.kt
@@ -245,7 +245,7 @@ private fun Failure.consumed(consumed: Int, parser: String, cause: Failure) = th
 /** Chop off the consumed part of the string. */
 fun String.advance(str: String) = this.substring(str.length)
 
-private const val TRACEBACK_AMOUNT = 10
+private const val TRACEBACK_AMOUNT = 4
 
 private fun String.traceBack(at: Int) = this.substring(
   max(0, at - TRACEBACK_AMOUNT),

--- a/java/arcs/core/util/Parser.kt
+++ b/java/arcs/core/util/Parser.kt
@@ -245,7 +245,7 @@ private fun Failure.consumed(consumed: Int, parser: String, cause: Failure) = th
 /** Chop off the consumed part of the string. */
 fun String.advance(str: String) = this.substring(str.length)
 
-private const val TRACEBACK_AMOUNT = 4
+private const val TRACEBACK_AMOUNT = 10
 
 private fun String.traceBack(at: Int) = this.substring(
   max(0, at - TRACEBACK_AMOUNT),
@@ -475,11 +475,59 @@ abstract class Grammar<T> : Parser<T>() {
     property: KProperty<*>
   ): Parser<T> = also { it.name = property.name }
 
+  /** Delegate provider that assigns names to parsers. */
+  protected operator fun <T> IgnoringParser<T>.provideDelegate(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): IgnoringParser<T> = also { it.name = property.name }
+
+  /** Delegate provider that assigns names to parsers. */
+  protected operator fun <T, R> TransformParser<T, R>.provideDelegate(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): TransformParser<T, R> = also { it.name = property.name }
+
+  /** Delegate provider that assigns names to parsers. */
+  protected operator fun <T, R> PairOfParser<T, R>.provideDelegate(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): PairOfParser<T, R> = also { it.name = property.name }
+
+  /** Delegate provider that assigns names to parsers. */
+  protected operator fun <T, S, R> TripleOfParser<T, S, R>.provideDelegate(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): TripleOfParser<T, S, R> = also { it.name = property.name }
+
   /** Allow parser fields to be delegated. */
   protected operator fun <T> Parser<T>.getValue(
     thisRef: Grammar<*>,
     property: KProperty<*>
   ): Parser<T> = this
+
+  /** Allow parser fields to be delegated. */
+  protected operator fun <T> IgnoringParser<T>.getValue(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): IgnoringParser<T> = this
+
+  /** Allow parser fields to be delegated. */
+  protected operator fun <T, R> TransformParser<T, R>.getValue(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): TransformParser<T, R> = this
+
+  /** Allow parser fields to be delegated. */
+  protected operator fun <T, R> PairOfParser<T, R>.getValue(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): PairOfParser<T, R> = this
+
+  /** Allow parser fields to be delegated. */
+  protected operator fun <T, S, R> TripleOfParser<T, S, R>.getValue(
+    thisRef: Grammar<*>,
+    property: KProperty<*>
+  ): TripleOfParser<T, S, R> = this
 
   override fun leftTokens() = topLevel.leftTokens()
 


### PR DESCRIPTION
Mostly changes '=' into 'by' and reformat using IDE to 2 spaces.

This will produce error messages like (i removed the 'e' from 'let x = ')

```
Parse Failed reading lt x = (p + 1) select x - 1
ere p < 1 lt x 
          ^
Expecting select at line 0, column 24
[Traceback]
  at topLevel
  at expressionWithQualifier
  at selectExpression
```