### PR TITLE
Using Github Actions to deploy to arcs-live.

### DIFF
--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -1,0 +1,25 @@
+# An Action to build Web Arcs and deploy to https://live.arcs.dev
+name: live-deploy
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run deployment script
+        run: tools/deploy
+
+      - name: GitHub Pages action
+        uses: peaceiris/actions-gh-pages@v3.6.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          external_repository: PolymerLabs/arcs-live
+          publish_dir: ./
+          cname: live.arcs.dev
+

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -12,10 +12,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Run Typescript Tests
+        run: |
+          tools/sigh webpack
+          tools/sigh test --all
+
       - name: Run deployment script
         run: tools/deploy
 
-      - name: GitHub Pages action
+      - name: Deploy to Github Pages
         uses: peaceiris/actions-gh-pages@v3.6.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@ _Our mission is to create an open platform for smart and ubiquitous computing, w
 
 A hosted version of Arcs is available at https://live.arcs.dev.
 
-> Note: Arcs is transitioning to Cloud Build and the live.arcs.dev hosted pages
-referenced above may not be operational currently.
->
-> TODO(bgogul): Edit above when we've restored/reconfirmed live.arcs.dev publishing and operation.
-
-
 [TypeDoc](https://live.arcs.dev/dist/apidocs/) generated documentation is available for Arcs Runtime.
 
 To develop with Arcs, please follow  our [Contributing Guide](CONTRIBUTING.md).


### PR DESCRIPTION
- Added a quick Github Action to fix the arcs-live page.
  - Re-uses the deploy script from the Travis CI days.
- Removed the TODO at the top of the README.

CC: @shaper and @Cypher1 (I believe you were looking into GH Actions recently)