### PR TITLE
Fixing arcs-live deploy

### DIFF
--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -1,4 +1,4 @@
-# An Action to build Web Arcs and deploy to https://live.arcs.dev
+# An Action to build and deploy Web Arcs to https://live.arcs.dev
 name: arcs-live
 
 on:
@@ -27,7 +27,7 @@ jobs:
       - name: Run Typescript Tests
         run: tools/sigh test --all
 
-      - name: Run deployment script
+      - name: Run deployment preparation script
         run: tools/deploy
 
       - name: Deploy to Github Pages

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -12,10 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run Typescript Tests
+      - name: Setup Node
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: '10.15.3'
+
+      - name: Build Web Runtime
         run: |
+          npm install
           tools/sigh webpack
-          tools/sigh test --all
+
+      - name: Run Typescript Tests
+        run: tools/sigh test --all
 
       - name: Run deployment script
         run: tools/deploy

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -36,5 +36,6 @@ jobs:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: PolymerLabs/arcs-live
           publish_dir: ./
+          publish_branch: master
           cname: live.arcs.dev
 

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -4,6 +4,8 @@ name: live-deploy
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -19,10 +19,8 @@ jobs:
         with:
           node-version: 10.x
 
-      - name: Build Web Runtime
-        run: |
-          npm install
-          tools/sigh webpack
+      - name: Install dependencies
+        run: npm install
 
       - name: Run Typescript Tests
         run: tools/sigh test --all

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.0
         with:
-          node-version: '10.15.3'
+          node-version: 10.x
 
       - name: Build Web Runtime
         run: |

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -1,5 +1,5 @@
 # An Action to build Web Arcs and deploy to https://live.arcs.dev
-name: live-deploy
+name: arcs-live
 
 on:
   push:

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -4,8 +4,6 @@ name: arcs-live
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/live-deploy.yml
+++ b/.github/workflows/live-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Deploy to Github Pages
         uses: peaceiris/actions-gh-pages@v3.6.4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: PolymerLabs/arcs-live
           publish_dir: ./
           cname: live.arcs.dev

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Cloud Build Status](https://storage.googleapis.com/arcs-github-gcb-badges/builds/arcs/branches/master.svg)](https://console.cloud.google.com/cloud-build/builds?query=trigger_id%3D%22bdf768b5-8901-43e5-814c-f3adffff2eab%22&project=arcs-265404)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/rswlpkq2vtp9cns0/branch/master?svg=true)](https://ci.appveyor.com/project/arcs/arcs-3i77k/branch/master)
+[![arcs-live](https://github.com/PolymerLabs/arcs/workflows/arcs-live/badge.svg)](https://github.com/PolymerLabs/arcs/actions?query=workflow%3Aarcs-live)
 
 _Our mission is to create an open platform for smart and ubiquitous computing, where users have sovereignty over their data and its use._
 

--- a/tools/deploy
+++ b/tools/deploy
@@ -2,10 +2,6 @@
 
 # Track Version
 git log -n 1 > VERSION
-# Ensure we have the correct node & npm versions
-nvm install
-nvm use
-npm install -g "npm@$(jq -r '.engines.npm' package.json)"
 # Produce build artifacts
 npm install
 tools/sigh webpackStorage

--- a/tools/deploy
+++ b/tools/deploy
@@ -3,7 +3,6 @@
 # Track Version
 git log -n 1 > VERSION
 # Produce build artifacts
-npm install
 tools/sigh webpackStorage
 tools/sigh webpack
 npm run build:typedoc


### PR DESCRIPTION
While the `tools/deploy` script installs dependencies needed for deployment, the test step of the Action does not prepare CI for `tools/sigh test`. 

This change adds Node and `npm install` before we hit the step to run tests in the Action. 

TESTED=Temporarily deployed action on PRs to master. 