### PR TITLE
Fix for case where refiner test runs in under 1 millisecond

### DIFF
--- a/src/types/tests/refiner-test.ts
+++ b/src/types/tests/refiner-test.ts
@@ -863,8 +863,8 @@ describe('refiner', () => {
         await evaluatesToTrue('not (now() < 1587539956 milliseconds)');
       });
       it('creationTime() is before now', async () => {
-        await evaluatesToTrue('creationTime() < now()');
-        await evaluatesToTrue('not (creationTime() > now())');
+        await evaluatesToTrue('creationTime() <= now()'); // TODO: Inject 'fake' for date.
+        await evaluatesToTrue('not (creationTime() >= now())');
         // Checks that 'creationTime' is before 2020-07-31 12:40:41 AM (GMT)
         // Note: Update this when this test starts failing :P
         await evaluatesToTrue('creationTime() < 33153064841000 milliseconds');


### PR DESCRIPTION
Fix for case mentioned in chat where refiner test relies on 'now()' being after entity creation time.

@cromwellian is this the only test failure that you observed?