### PR TITLE
new callbackId parameter in DSM.getLocalData

### DIFF
--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -87,7 +87,8 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
   /**
    * Gets data from the store corresponding to the given [referenceId].
    */
-  suspend fun getLocalData(referenceId: String) = store(referenceId).store.getLocalData()
+  suspend fun getLocalData(referenceId: String, callbackId: Int) =
+    store(referenceId).store.getLocalData()
 
   /** Removes [DirectStore] caches and closes those that can be closed safely. */
   suspend fun clearStoresCache() = storeMutex.withLock {

--- a/java/arcs/core/storage/DirectStoreMuxer.kt
+++ b/java/arcs/core/storage/DirectStoreMuxer.kt
@@ -86,6 +86,9 @@ class DirectStoreMuxer<Data : CrdtData, Op : CrdtOperationAtTime, T>(
 
   /**
    * Gets data from the store corresponding to the given [referenceId].
+   *
+   * [callbackId] does not serve a purpose yet, however it will be used to ensure a callback is
+   * registered to the [DirectStore] for the corresponding [callbackId]
    */
   suspend fun getLocalData(referenceId: String, callbackId: Int) =
     store(referenceId).store.getLocalData()

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -451,7 +451,11 @@ class ReferenceModeStore private constructor(
   private fun newBackingInstance(): CrdtModel<CrdtData, CrdtOperationAtTime, Referencable> =
     crdtType.createCrdtModel()
 
-  /** Gets data from the Backing Store with the corresponding [referenceId] */
+  /**
+   * Gets data from the Backing Store with the corresponding [referenceId]
+   *
+   * This is visible for tests. Do not otherwise use outside of [ReferenceModeStore]
+   */
   suspend fun getLocalData(referenceId: String) =
     backingStore.getLocalData(referenceId, backingStoreId)
 

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -267,7 +267,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
           VersionMap("me" to 1)
         )
       )
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     // Check that the stored bob's singleton data is equal to the expected bob's singleton data
     assertThat(storedBob.singletons).isEqualTo(bobEntity.data.singletons)
     // Check that the stored bob's collection data is equal to the expected bob's collection
@@ -285,7 +285,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
     val addOp = RefModeStoreOp.SetAdd(actor, VersionMap(actor to 1), bob)
     activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
     // Bob was added to the backing store.
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     assertThat(storedBob.toRawEntity("an-id")).isEqualTo(bob)
 
     // Remove Bob from the collection.
@@ -293,7 +293,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
     activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
 
     // Check the backing store Bob has been cleared.
-    val storedBob2 = activeStore.backingStore.getLocalData("an-id")
+    val storedBob2 = activeStore.getLocalData("an-id")
     assertThat(storedBob2.toRawEntity("an-id")).isEqualTo(createEmptyPersonEntity("an-id"))
 
     // Check the DB.
@@ -387,7 +387,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
     activeStore.idle()
 
     // Check Bob from backing store.
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     assertThat(storedBob.toRawEntity()).isEqualTo(bob)
     assertThat(storedBob.toRawEntity().creationTimestamp).isEqualTo(10)
     assertThat(storedBob.toRawEntity().expirationTimestamp).isEqualTo(20)

--- a/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
+++ b/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
@@ -47,7 +47,7 @@ class DirectStoreMuxerTest {
       devToolsProxy = null
     )
 
-    directStoreMuxer.on {
+    val callbackId = directStoreMuxer.on {
       callbacks++
     }
 
@@ -65,19 +65,19 @@ class DirectStoreMuxerTest {
 
     // Attempt to trigger a child store setup race
     coroutineScope {
-      launch { directStoreMuxer.getLocalData("a") }
+      launch { directStoreMuxer.getLocalData("a", callbackId) }
       launch {
         directStoreMuxer.onProxyMessage(
           MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
         )
       }
-      launch { directStoreMuxer.getLocalData("a") }
+      launch { directStoreMuxer.getLocalData("a", callbackId) }
       launch {
         directStoreMuxer.onProxyMessage(
           MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
         )
       }
-      launch { directStoreMuxer.getLocalData("a") }
+      launch { directStoreMuxer.getLocalData("a", callbackId) }
       launch {
         directStoreMuxer.onProxyMessage(
           MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))

--- a/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreDatabaseIntegrationTest.kt
@@ -170,10 +170,12 @@ class ReferenceModeStoreDatabaseIntegrationTest {
         )
       )
     )
-    assertThat(activeStore2.backingStore.getLocalData("e1").toRawEntity())
-      .isEqualTo(e1)
-    assertThat(activeStore2.backingStore.getLocalData("e2").toRawEntity())
-      .isEqualTo(e2)
+    assertThat(
+      activeStore2.getLocalData("e1").toRawEntity()
+    ).isEqualTo(e1)
+    assertThat(
+      activeStore2.getLocalData("e2").toRawEntity()
+    ).isEqualTo(e2)
   }
 
   @Test
@@ -247,7 +249,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
           VersionMap("me" to 1)
         )
       )
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     // Check that the stored bob's singleton data is equal to the expected bob's singleton data
     assertThat(storedBob.singletons).isEqualTo(bobEntity.data.singletons)
     // Check that the stored bob's collection data is equal to the expected bob's collection
@@ -266,7 +268,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
     activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
 
     // Bob was added to the backing store.
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     assertThat(storedBob.toRawEntity("an-id")).isEqualTo(bob)
 
     // Remove Bob from the collection.
@@ -274,7 +276,7 @@ class ReferenceModeStoreDatabaseIntegrationTest {
     activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
 
     // Check the backing store Bob has been cleared.
-    val storedBob2 = activeStore.backingStore.getLocalData("an-id")
+    val storedBob2 = activeStore.getLocalData("an-id")
     assertThat(storedBob2.toRawEntity("an-id")).isEqualTo(createEmptyPersonEntity("an-id"))
 
     // Check the DB.

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -218,7 +218,7 @@ class ReferenceModeStoreTest {
 
     val capturedPeople = containerDriver.sentData.first()
     assertThat(capturedPeople).isEqualTo(referenceCollection.data)
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     // Check that the stored bob's singleton data is equal to the expected bob's singleton data
     assertThat(storedBob.singletons.mapValues { it.value.data })
       .isEqualTo(bobEntity.data.singletons.mapValues { it.value.data })
@@ -241,7 +241,7 @@ class ReferenceModeStoreTest {
     activeStore.onProxyMessage(ProxyMessage.Operations(listOf(addOp), id = 1))
 
     // Bob was added to the backing store.
-    val storedBob = activeStore.backingStore.getLocalData("an-id")
+    val storedBob = activeStore.getLocalData("an-id")
     assertThat(storedBob.toRawEntity("an-id")).isEqualTo(bob)
 
     // Remove Bob from the collection.
@@ -249,7 +249,7 @@ class ReferenceModeStoreTest {
     activeStore.onProxyMessage(ProxyMessage.Operations(listOf(deleteOp), id = 1))
 
     // Check the backing store Bob has been cleared.
-    val storedBob2 = activeStore.backingStore.getLocalData("an-id")
+    val storedBob2 = activeStore.getLocalData("an-id")
     assertThat(storedBob2.toRawEntity("an-id")).isEqualTo(createEmptyPersonEntity("an-id"))
   }
 
@@ -273,10 +273,10 @@ class ReferenceModeStoreTest {
     val storedRefs = activeStore.containerStore.getLocalData() as CrdtSet.Data<Reference>
     assertThat(storedRefs.values.keys).containsExactly("id1", "id2")
 
-    val storedAlice = activeStore.backingStore.getLocalData("id1")
+    val storedAlice = activeStore.getLocalData("id1")
     assertThat(storedAlice.toRawEntity("id1")).isEqualTo(alice)
 
-    val storedBob = activeStore.backingStore.getLocalData("id2")
+    val storedBob = activeStore.getLocalData("id2")
     assertThat(storedBob.toRawEntity("id2")).isEqualTo(bob)
 
     // Clear!
@@ -286,10 +286,10 @@ class ReferenceModeStoreTest {
     val clearedRefs = activeStore.containerStore.getLocalData() as CrdtSet.Data<Reference>
     assertThat(clearedRefs.values.keys).isEmpty()
 
-    val clearedAlice = activeStore.backingStore.getLocalData("id1")
+    val clearedAlice = activeStore.getLocalData("id1")
     assertThat(clearedAlice.toRawEntity("id1")).isEqualTo(createEmptyPersonEntity("id1"))
 
-    val clearedBob = activeStore.backingStore.getLocalData("id2")
+    val clearedBob = activeStore.getLocalData("id2")
     assertThat(clearedBob.toRawEntity("id2")).isEqualTo(createEmptyPersonEntity("id2"))
   }
 


### PR DESCRIPTION
At the moment, the callbackId argument is not used in DSM.getLocalData. In a follow up PR, DSM.getLocalData will require a callbackID in order to register a new callback to the corresponding direct store if necessary. 