### PR TITLE
add storageService to shell's spawn arc method.

### DIFF
--- a/shells/lib/components/arc-component.js
+++ b/shells/lib/components/arc-component.js
@@ -12,6 +12,7 @@ import {Xen} from './xen.js';
 import {ArcHost} from './arc-host.js';
 import {SlotComposer} from '../../../build/runtime/slot-composer.js';
 import {logsFactory} from '../../../build/platform/logs-factory.js';
+import {StorageServiceImpl} from '../../../build/runtime/storage/storage-service.js';
 
 const {log, warn} = logsFactory('ArcComponent', '#cb23a6');
 
@@ -22,7 +23,7 @@ export const ArcComponentMixin = Base => class extends Base {
   // implement observable properties. I could call it observedProperties and delegate
   // observedAttributes to it, but I haven't bothered.
   static get observedAttributes() {
-    return ['context', 'storage', 'composer', 'config', 'manifest', 'plan'];
+    return ['context', 'storage', 'composer', 'config', 'manifest', 'plan', 'storageservice'];
   }
   propChanged(name) {
     return (this.props[name] !== this._lastProps[name]);
@@ -49,7 +50,7 @@ export const ArcComponentMixin = Base => class extends Base {
       state.host.plan = props.plan;
     }
   }
-  createHost({context, storage, composer, config}) {
+  createHost({context, storage, composer, storageservice, config}) {
     log('creating host');
     const containers = this.containers || {};
     if (!composer) {
@@ -59,7 +60,10 @@ export const ArcComponentMixin = Base => class extends Base {
       composer = new SlotComposer(/*{containers}*/);
       composer.observeSlots(config.broker || this.createBroker());
     }
-    return new ArcHost(context, storage, composer);
+    if (!storageservice) {
+      storageservice = new StorageServiceImpl();
+    }
+    return new ArcHost(context, storage, composer, storageservice);
   }
   createBroker() {
     return null;

--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -15,11 +15,12 @@ import {devtoolsArcInspectorFactory} from '../../../build/devtools-connector/dev
 const {log, warn, error} = logsFactory('ArcHost', '#cade57');
 
 export class ArcHost {
-  constructor(context, storage, composer, portFactories) {
+  constructor(context, storage, composer, storageservice, portFactories) {
     this.context = context;
     this.storage = storage;
     this.composer = composer;
     this.portFactories = portFactories;
+    this.storageservice = storageservice;
   }
   disposeArc() {
     if (this.arc) {
@@ -36,7 +37,7 @@ export class ArcHost {
     this.serialization = await this.computeSerialization(config, storage);
     // TODO(sjmiles): weird consequence of re-using composer, which we probably should not do anymore
     this.composer.arc = null;
-    this.arc = await this._spawn(context, this.composer, storage, config.id, this.serialization, this.portFactories);
+    this.arc = await this._spawn(context, this.composer, storage, config.id, this.serialization, this.portFactories, this.storageservice);
     if (config.manifest && !this.serialization) {
       await this.instantiateDefaultRecipe(this.arc, config.manifest);
     }
@@ -71,7 +72,7 @@ export class ArcHost {
     }
     return serialization;
   }
-  async _spawn(context, composer, storage, id, serialization, portFactories) {
+  async _spawn(context, composer, storage, id, serialization, portFactories, storageservice) {
     return Runtime.spawnArc({
       id,
       context,
@@ -80,6 +81,7 @@ export class ArcHost {
       storage: `${storage}/${id}`,
       portFactories,
       inspectorFactory: devtoolsArcInspectorFactory,
+      storageService: storageservice,
     });
   }
   async instantiateDefaultRecipe(arc, manifest) {


### PR DESCRIPTION
as part of the storage refactoring Arc's ctor expects a storage-service parameter, which wasn't previously passed from the shell. 