### PR TITLE
Improve JSON encoding of proxy messages

### DIFF
--- a/java/arcs/android/devtools/ModelUpdateMessage.kt
+++ b/java/arcs/android/devtools/ModelUpdateMessage.kt
@@ -32,13 +32,11 @@ class ModelUpdateMessage(
    * Transform the [CrdtData] into JSON.
    */
   private fun getModel(model: CrdtData) = when (model) {
-    is CrdtEntity.Data -> {
-      JsonValue.JsonObject(
-        VERSIONMAP to model.versionMap.toJson(),
-        "singletons" to singletonsJson(model.singletons),
-        "collections" to collectionsJson(model.collections)
-      )
-    }
+    is CrdtEntity.Data -> JsonValue.JsonObject(
+      VERSIONMAP to model.versionMap.toJson(),
+      "singletons" to singletonsJson(model.singletons),
+      "collections" to collectionsJson(model.collections)
+    )
     // TODO(b/162955831): other types
     else -> JsonValue.JsonNull
   }
@@ -48,44 +46,33 @@ class ModelUpdateMessage(
    */
   private fun collectionsJson(
     collections: Map<FieldName, CrdtSet<CrdtEntity.Reference>>
-  ): JsonValue<*> {
-    val myList = collections.map { (name, collection) ->
-      JsonValue.JsonObject(
-        name to JsonValue.JsonObject(
-          VERSIONMAP to collection.data.versionMap.toJson(),
-          "values" to getValues(collection.data.values)
-        )
+  ) = JsonValue.JsonObject(
+    collections.map {
+      (name, collection) -> name to JsonValue.JsonObject(
+        VERSIONMAP to collection.data.versionMap.toJson(),
+        "values" to getValues(collection.data.values)
       )
-    }
-    return JsonValue.JsonArray(myList)
-  }
+    }.toMap()
+  )
 
   /**
    * Transform the map of names to singletons into JSON.
    */
   private fun singletonsJson(
     singletons: Map<FieldName, CrdtSingleton<CrdtEntity.Reference>>
-  ): JsonValue<*> {
-    val myList = singletons.map { (name, singleton) ->
-      JsonValue.JsonObject(
-        name to JsonValue.JsonObject(
-          VERSIONMAP to singleton.data.versionMap.toJson(),
-          "values" to getValues(singleton.data.values)
-        )
+  ) = JsonValue.JsonObject(
+    singletons.map {
+      (name, singleton) -> name to JsonValue.JsonObject(
+        VERSIONMAP to singleton.data.versionMap.toJson(),
+        "values" to getValues(singleton.data.values)
       )
-    }
-    return JsonValue.JsonArray(myList)
-  }
+    }.toMap()
+  )
 
   /**
    * Transform the values of fields into JSON.
    */
   private fun getValues(
     values: MutableMap<ReferenceId, CrdtSet.DataValue<CrdtEntity.Reference>>
-  ): JsonValue<*> {
-    val myMap = values.mapValues { (ref, value) ->
-      value.value.toJson()
-    }
-    return JsonValue.JsonObject(myMap)
-  }
+  ) = JsonValue.JsonObject(values.mapValues { (ref, value) -> value.value.toJson() })
 }

--- a/javatests/arcs/android/devtools/DevToolsMessageTests.kt
+++ b/javatests/arcs/android/devtools/DevToolsMessageTests.kt
@@ -18,6 +18,7 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.crdt.CrdtSingleton
 import arcs.core.crdt.VersionMap
 import arcs.core.data.util.ReferencablePrimitive
+import arcs.core.data.util.toReferencable
 import arcs.core.storage.ProxyMessage
 import arcs.core.util.JsonValue
 import com.google.common.truth.Truth.assertThat
@@ -66,8 +67,6 @@ class DevToolsMessageTests {
 
   @Test
   fun ModelUpdateMessageTest() = runBlockingTest {
-    val referenceA: CrdtEntity.Reference = CrdtEntity.ReferenceImpl("AAA")
-    val referenceB: CrdtEntity.Reference = CrdtEntity.ReferenceImpl("BBB")
     val expected = JsonValue.JsonObject(
       KIND to JsonValue.JsonString(MODEL_UPDATE_MESSAGE),
       MESSAGE to JsonValue.JsonObject(
@@ -75,31 +74,25 @@ class DevToolsMessageTests {
           DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
             "Bar" to JsonValue.JsonNumber(2.toDouble())
           ),
-          "singletons" to JsonValue.JsonArray(
-            listOf(
-              JsonValue.JsonObject(
-                "a" to JsonValue.JsonObject(
-                  DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
-                    "alice" to JsonValue.JsonNumber(1.toDouble())
-                  ),
-                  "values" to JsonValue.JsonObject(
-                    "AAA" to JsonValue.JsonString("Reference(AAA)")
-                  )
-                )
+          "singletons" to JsonValue.JsonObject(
+            "a" to JsonValue.JsonObject(
+              DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
+                "alice" to JsonValue.JsonNumber(1.toDouble())
               ),
-              JsonValue.JsonObject(
-                "b" to JsonValue.JsonObject(
-                  DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
-                    "bob" to JsonValue.JsonNumber(1.toDouble())
-                  ),
-                  "values" to JsonValue.JsonObject(
-                    "BBB" to JsonValue.JsonString("Reference(BBB)")
-                  )
-                )
+              "values" to JsonValue.JsonObject(
+                "AAA".toReferencable().id to JsonValue.JsonString("AAA")
+              )
+            ),
+            "b" to JsonValue.JsonObject(
+              DevToolsMessage.VERSIONMAP to JsonValue.JsonObject(
+                "bob" to JsonValue.JsonNumber(1.toDouble())
+              ),
+              "values" to JsonValue.JsonObject(
+                "BBB".toReferencable().id to JsonValue.JsonString("BBB")
               )
             )
           ),
-          "collections" to JsonValue.JsonArray()
+          "collections" to JsonValue.JsonObject()
         ),
         STORE_TYPE to JsonValue.JsonString("Direct")
       )
@@ -108,10 +101,16 @@ class DevToolsMessageTests {
     val proxyMessage = ProxyMessage.ModelUpdate<CrdtData, CrdtOperation, Any?>(
       model = CrdtEntity.Data(
         singletons = mapOf(
-          "a" to CrdtSingleton(VersionMap("alice" to 1), referenceA),
-          "b" to CrdtSingleton(VersionMap("bob" to 1), referenceB)
+          "a" to CrdtSingleton<CrdtEntity.Reference>(
+            VersionMap("alice" to 1),
+            CrdtEntity.ReferenceImpl("AAA".toReferencable().id)
+          ),
+          "b" to CrdtSingleton<CrdtEntity.Reference>(
+            VersionMap("bob" to 1),
+            CrdtEntity.ReferenceImpl("BBB".toReferencable().id)
+          )
         ),
-        collections = mutableMapOf(),
+        collections = mapOf(),
         versionMap = VersionMap("Bar" to 2),
         creationTimestamp = 971,
         expirationTimestamp = -1


### PR DESCRIPTION
* Handle `CrdtEntity.ReferenceImpl` case of Reference.toJson() which improves the jsonification of primitive fields.
* Json encode more fields of the RawEntity: timestamps and collection fields.
* Kotlinification of existing jsonifying code.

Next steps for this area:
* All the non-android dependent pieces should move from `arcs/android/devtools` to `arcs/core/devtools`.