### PR TITLE
fix an exception in store-explorer

### DIFF
--- a/modalities/dom/components/arc-tools/store-explorer.js
+++ b/modalities/dom/components/arc-tools/store-explorer.js
@@ -137,7 +137,7 @@ class StoreExplorer extends Xen.Base {
         if (hideNamed && store.name && tags.length === 0) {
           continue;
         }
-        if (store.type.tag === 'Interface') {
+        if (!store.type.getEntitySchema()) {
           continue;
         }
         let malformed = false;

--- a/particles/Demo/wishlist.json
+++ b/particles/Demo/wishlist.json
@@ -5,13 +5,13 @@
     "seller": "gutenburger.com",
     "price": "$14.50",
     "shipDays": 5,
-    "image": "https://$particles/Demo/products/products/draw-book.png"
+    "image": "https://$particles/Demo/products/draw-book.png"
   },
   {
     "name": "Arduino Starter Pack",
     "price": "$49.99",
     "seller": "arduino.cc",
-    "image": "https://$particles/Demo/products/products/arduino.png"
+    "image": "https://$particles/Demo/products/arduino.png"
   },
   {
     "name": "Field Hockey Stick",
@@ -19,6 +19,6 @@
     "seller": "denile.com",
     "price": "$29.00",
     "shipDays": 3,
-    "image": "https://$particles/Demo/products/products/hockeystick.png"
+    "image": "https://$particles/Demo/products/hockeystick.png"
   }
 ]

--- a/particles/Experimental/Person_Msg_Demo/FilterMessages.js
+++ b/particles/Experimental/Person_Msg_Demo/FilterMessages.js
@@ -21,7 +21,7 @@
       for (const messageData of allMessages) {
         if (messageData.sentTime < 24) {
           delete messageData['content'];
-          messagesHandle.store(new messagesHandle.entityClass(messageData));
+          messagesHandle.add(new messagesHandle.entityClass(messageData));
         }
       }
     }

--- a/particles/Experimental/Person_Msg_Demo/GetMessages.js
+++ b/particles/Experimental/Person_Msg_Demo/GetMessages.js
@@ -57,7 +57,7 @@
       this.clear('messages');
       const messagesHandle = this.handles.get('messages');
       for (const messageData of messagesData) {
-        messagesHandle.store(new messagesHandle.entityClass(messageData));
+        messagesHandle.add(new messagesHandle.entityClass(messageData));
       }
     }
 
@@ -66,7 +66,7 @@
       this.clear('messages');
       const messagesHandle = this.handles.get('messages');
       for (const messageData of messagesData) {
-        messagesHandle.store(new messagesHandle.entityClass(messageData));
+        messagesHandle.add(new messagesHandle.entityClass(messageData));
       }
     }
 
@@ -74,7 +74,7 @@
       this.clear('messages');
       const messagesHandle = this.handles.get('messages');
       for (const messageData of messagesData) {
-        messagesHandle.store(new messagesHandle.entityClass(messageData));
+        messagesHandle.add(new messagesHandle.entityClass(messageData));
       }
     }
   };

--- a/particles/Experimental/Person_Msg_Demo/GetPeople.js
+++ b/particles/Experimental/Person_Msg_Demo/GetPeople.js
@@ -35,7 +35,7 @@ let peopleData = [
       this.clear('people');
       const peopleHandle = this.handles.get('people');
       for (const personData of peopleData) {
-        peopleHandle.store(new peopleHandle.entityClass(personData));
+        peopleHandle.add(new peopleHandle.entityClass(personData));
       }
     }
 
@@ -44,7 +44,7 @@ let peopleData = [
       this.clear('people');
       const peopleHandle = this.handles.get('people');
       for (const personData of peopleData) {
-        peopleHandle.store(new peopleHandle.entityClass(personData));
+        peopleHandle.add(new peopleHandle.entityClass(personData));
       }
     }
   };

--- a/particles/Experimental/Person_Msg_Demo/OrderPeople.js
+++ b/particles/Experimental/Person_Msg_Demo/OrderPeople.js
@@ -46,7 +46,7 @@ let to = '1';
       const peopleHandle = this.handles.get('orderedPeople');
       let index = 0;
       for (const personData of res) {
-        peopleHandle.store(new peopleHandle.entityClass({name: personData.name, id: personData.id, index}));
+        peopleHandle.add(new peopleHandle.entityClass({name: personData.name, id: personData.id, index}));
         index += 1;
       }
     }

--- a/particles/Products/source/Recommend.js
+++ b/particles/Products/source/Recommend.js
@@ -19,7 +19,7 @@ defineParticle(({Particle}) => {
       if (handle.name === 'population') {
         const output = this.handles.get('recommendations');
         for (let i = 0; i < 3 && i < model.length; i++) {
-          output.store(model[i]);
+          output.add(model[i]);
         }
         this.relevance = 9;
       }

--- a/particles/Profile/FavoriteFood.arcs
+++ b/particles/Profile/FavoriteFood.arcs
@@ -1,5 +1,5 @@
 schema FavoriteFood
-  foo: Text
+  food: Text
 
 import 'schemas/Share.arcs'
 

--- a/particles/Profile/source/FavoriteFoodPicker.js
+++ b/particles/Profile/source/FavoriteFoodPicker.js
@@ -10,7 +10,7 @@
 
 defineParticle(({SimpleParticle, html, resolver}) => {
 
-  const notoPath = `/../assets/noto-emoji-128/emoji_u`;
+  const notoPath = `/../../../particles/Profile/assets/noto-emoji-128/emoji_u`;
   const allFoods = {
     Hotdogs: '1f32d',
     Tacos: '1f32e',
@@ -113,7 +113,7 @@ defineParticle(({SimpleParticle, html, resolver}) => {
       if (food) {
         foodsHandle.remove(food);
       } else {
-        foodsHandle.store(new foodsHandle.entityClass({food: name}));
+        foodsHandle.add(new foodsHandle.entityClass({food: name}));
       }
     }
     likesFood(foods, name) {

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -19,12 +19,16 @@ import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile
 import {storageKeyPrefixForTest} from '../../../runtime/testing/handle-for-test.js';
 import {Loader} from '../../../platform/loader.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
+import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
 
 describe('planning result', () => {
   let memoryProvider;
   beforeEach(() => {
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
+  });
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
   });
 
   async function testResultSerialization(manifestFilename) {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1450,15 +1450,15 @@ ${e.message}
       }
       item.source = loader.join(manifest.fileName, item.source);
       json = await loader.loadResource(item.source);
-      entities = this.parseJson(json, item);
+      entities = this.parseJson(json, item, manifest);
     } else if (item.origin === 'resource') {
       json = manifest.resources[item.source];
       if (json == undefined) {
         throw new ManifestError(item.location, `Resource '${item.source}' referenced by store '${id}' is not defined in this manifest`);
       }
-      entities = this.parseJson(json, item);
+      entities = this.parseJson(json, item, manifest);
     } else if (item.origin === 'inline') {
-      entities = this.inlineEntitiesToSerialisedFormat(manifest, item);
+      entities = this.inlineEntitiesToSerialisedFormat(manifest, item.entities);
     }
 
     const storageKey = item['storageKey'] || manifest.createLocalDataStorageKey();
@@ -1484,21 +1484,30 @@ ${e.message}
     });
   }
 
-  private static parseJson(json, item) {
+  private static parseJson(json, item, manifest) {
     try {
-      return JSON.parse(json);
+      const parsed = JSON.parse(json);
+      if (!Array.isArray(parsed)) {
+        return parsed;
+      }
+
+      const entities: AstNode.ManifestStorageInlineEntity[] = [];
+      for (const item of parsed) {
+        entities.push({fields: item} as AstNode.ManifestStorageInlineEntity);
+      }
+      return this.inlineEntitiesToSerialisedFormat(manifest, entities);
     } catch (e) {
       throw new ManifestError(item.location, `Error parsing JSON from '${item.source}' (${e.message})'`);
     }
   }
 
-  private static inlineEntitiesToSerialisedFormat(manifest: Manifest, item: AstNode.ManifestStorage) {
+  private static inlineEntitiesToSerialisedFormat(manifest: Manifest, entities: AstNode.ManifestStorageInlineEntity[]) {
     const values = {};
     const version = {inline: 1};
-    for (const entityAst of item.entities) {
+    for (const entityAst of entities) {
       const rawData = {};
       for (const [name, descriptor] of Object.entries(entityAst.fields)) {
-        rawData[name] = descriptor.value;
+        rawData[name] = descriptor.value || descriptor;
       }
       const id = manifest.generateID('inline').toString();
       values[id] = {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1490,7 +1490,6 @@ ${e.message}
       if (!Array.isArray(parsed)) {
         return parsed;
       }
-
       const entities: AstNode.ManifestStorageInlineEntity[] = [];
       for (const item of parsed) {
         entities.push({fields: item} as AstNode.ManifestStorageInlineEntity);
@@ -1507,7 +1506,7 @@ ${e.message}
     for (const entityAst of entities) {
       const rawData = {};
       for (const [name, descriptor] of Object.entries(entityAst.fields)) {
-        rawData[name] = descriptor.value || descriptor;
+        rawData[name] = descriptor.value === undefined ? descriptor : descriptor.value;
       }
       const id = manifest.generateID('inline').toString();
       values[id] = {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -1492,7 +1492,12 @@ ${e.message}
       }
       const entities: AstNode.ManifestStorageInlineEntity[] = [];
       for (const item of parsed) {
-        entities.push({fields: item} as AstNode.ManifestStorageInlineEntity);
+        assert(typeof item === 'object');
+        const fields = {};
+        for (const key of Object.keys(item)) {
+          fields[key] = {value: item[key]};
+        }
+        entities.push({fields} as AstNode.ManifestStorageInlineEntity);
       }
       return this.inlineEntitiesToSerialisedFormat(manifest, entities);
     } catch (e) {
@@ -1506,7 +1511,7 @@ ${e.message}
     for (const entityAst of entities) {
       const rawData = {};
       for (const [name, descriptor] of Object.entries(entityAst.fields)) {
-        rawData[name] = descriptor.value === undefined ? descriptor : descriptor.value;
+        rawData[name] = descriptor.value;
       }
       const id = manifest.generateID('inline').toString();
       values[id] = {

--- a/src/runtime/storage/storage-service.ts
+++ b/src/runtime/storage/storage-service.ts
@@ -64,7 +64,8 @@ export class StorageServiceImpl implements StorageService {
     return store.onProxyMessage(message);
   }
 
-  async getActiveStore<T extends Type>(storeInfo: StoreInfo<T>): Promise<ActiveStore<TypeToCRDTTypeRecord<T>>> {    if (this.activeStoresByKey.has(storeInfo.storageKey)) {
+  async getActiveStore<T extends Type>(storeInfo: StoreInfo<T>): Promise<ActiveStore<TypeToCRDTTypeRecord<T>>> {
+    if (this.activeStoresByKey.has(storeInfo.storageKey)) {
       return this.activeStoresByKey.get(storeInfo.storageKey) as ActiveStore<TypeToCRDTTypeRecord<T>>;
     }
     if (ActiveStore.constructors.get(storeInfo.mode) == null) {

--- a/src/runtime/tests/artifacts/Products/source/Recommend.js
+++ b/src/runtime/tests/artifacts/Products/source/Recommend.js
@@ -19,7 +19,7 @@ defineParticle(({Particle}) => {
       if (handle.name === 'population') {
         const output = this.handles.get('recommendations');
         for (let i = 0; i < 3 && i < model.length; i++) {
-          output.store(model[i]);
+          output.add(model[i]);
         }
         this.relevance = 9;
       }


### PR DESCRIPTION
1) fixes exception in demos:
```
Uncaught (in promise) TypeError: Cannot read property 'names' of null
    at nameOfType (store-explorer.js:61)
    at HTMLElement._digestStores (store-explorer.js:165)
    at HTMLElement._queryArcStores (store-explorer.js:129)
```
2) fix favorite food demo
3) fix products demo and a few more

In general, update manifest parsing to support loading old format JSON files.