### PR TITLE
Reuse bits of old DevTools for NG

### DIFF
--- a/devtools/ng.html
+++ b/devtools/ng.html
@@ -2,28 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Arcs Explorer</title>
+    <title>Arcs DevTools</title>
     <link rel="shortcut icon" href="img/favicon.png">
-    <!-- External dependencies are disallowed by CSP when running as an extension,
-         but will load when running standalone. -->
-    <script src="https://www.gstatic.com/firebasejs/5.8.2/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/5.8.2/firebase-database.js"></script>
-
-    <script src="deps/vis/dist/vis.min.js"></script>
-    <script src="deps/diff/dist/diff.min.js"></script>
     <script src="deps/web-animations-js/web-animations-next-lite.min.js"></script>
     <script src="deps/jquery/dist/jquery.min.js"></script>
     <script src="deps/golden-layout/dist/goldenlayout.min.js"></script>
+    <script>window.webSocketPort = 12345;</script>
+    <script src="src/devtools.js" type="module"></script>
+    <script src='src/ng/main.js' type='module'></script>
 
-    <script>window.webSocketPort = 8787;</script>
-    <script src="src/standalone-message-passing.js"></script>
-    <script src='src/arcs-devtools-app.js' type='module'></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="deps/golden-layout/src/css/goldenlayout-base.css" />
     <link rel="stylesheet" href="deps/golden-layout/src/css/goldenlayout-light-theme.css" />
     <link rel="stylesheet" href="src/index.css" />
   </head>
   <body>
-    <arcs-devtools-app></arcs-devtools-app>
+    <devtools-main></devtools-main>
   </body>
 </html>

--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -11,7 +11,7 @@
 // This file initializes debug mode on the arc and contains message receiving
 // and queing, so that opening DevTools without showing the Arcs panel is
 // sufficient to start gathering information.
- import {listenForWebRtcSignal} from '../shared/web-rtc-signalling.js';
+import {listenForWebRtcSignal} from '../shared/web-rtc-signalling.js';
 
 (() => {
   const msgQueue = [];
@@ -27,7 +27,7 @@
     } else {
       // Otherwise use WebSocket. We may still be in devtools, but inspecting Node.js.
       // In such case, there's no window to inspect.
-      return connectViaWebSocket(params.get('explore-proxy') || 8787);
+      return connectViaWebSocket(params.get('explore-proxy') || window.webSocketPort);
     }
   })();
 

--- a/devtools/src/index.css
+++ b/devtools/src/index.css
@@ -1,0 +1,7 @@
+body {
+  margin: 0;
+  font-family: Helvetica, Verdana, Arial, sans-serif;
+  /* Mimicks DevTools styling when running standalone */
+  font-size: 75%;
+  height: -webkit-fill-available;
+}

--- a/devtools/src/ng/main.js
+++ b/devtools/src/ng/main.js
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
+import {html} from '../../deps/@polymer/polymer/lib/utils/html-tag.js';
+import '../../deps/golden-layout/src/css/goldenlayout-base.css.js';
+import '../../deps/golden-layout/src/css/goldenlayout-light-theme.css.js';
+import '../arcs-shared.js';
+import './overview.js';
+import './raw-log.js';
+import '../../deps/@polymer/iron-icons/iron-icons.js';
+import '../../deps/@polymer/iron-icons/editor-icons.js';
+import '../../deps/@polymer/iron-icons/maps-icons.js';
+import '../../deps/@polymer/iron-icons/image-icons.js';
+import '../../deps/@polymer/iron-icons/av-icons.js';
+
+class Main extends PolymerElement {
+  static get template() {
+    return html`
+    <style include="shared-styles goldenlayout-base.css goldenlayout-light-theme.css">
+      #main {
+        position: relative;
+        height: 100vh;
+      }
+      /* TODO: Create our own golden-layout theme instead of overriding. */
+      .lm_content {
+        background: white;
+        position: relative;
+        overflow: auto;
+      }
+      .lm_header .lm_tab {
+        /* Fixing uneven padding caused by missing close button.
+           This can be reverted once we allow closing and re-opening tools. */
+        padding: 0 10px 4px;
+      }
+    </style>
+    <div id="main"></div>
+`;
+  }
+
+  static get is() { return 'devtools-main'; }
+
+  ready() {
+    super.ready();
+
+    const tools = {
+      'Raw Log': 'devtools-raw-log',
+      'Overview': 'devtools-overview',
+    };
+
+    // TODO: Save user's layout to local storage and restore from it.
+    const layout = new GoldenLayout({
+      content: [{
+        type: 'stack',
+        content: Object.entries(tools).map(([name]) => ({
+          type: 'component',
+          componentName: name,
+          // TODO: Allow closing and then re-opening tools.
+          isClosable: false
+        }))
+      }],
+      settings: {
+        // Pulling a tool into a popup resets its state,
+        // which we cannot recover.
+        showPopoutIcon: false,
+      },
+    }, this.$.main);
+
+    for (const [name, elementName] of Object.entries(tools)) {
+      layout.registerComponent(name, function(container) {
+        const element = document.createElement(elementName);
+        container.getElement().append(element);
+        container.on('show', () => element.setAttribute('active', ''));
+        container.on('hide', () => element.removeAttribute('active'));
+      });
+    }
+
+    layout.init();
+
+    // We need to observe the body for changes as opposed to #main, because when the viewport
+    // shrinks #main will not shrink if it is filled with content, body however will.
+    new ResizeObserver(rects => {
+      const {width, height} = rects[0].contentRect;
+      layout.updateSize(width, height);
+    }).observe(document.body);
+
+    // We perform below after the event loop tick to let other polymer elements
+    // to go through ready() handlers before we let the events in.
+    setTimeout(() => {
+      document.dispatchEvent(new Event('arcs-communication-channel-ready'));
+    }, 0);
+  }
+}
+
+window.customElements.define(Main.is, Main);

--- a/devtools/src/ng/overview.js
+++ b/devtools/src/ng/overview.js
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
+import {html} from '../../deps/@polymer/polymer/lib/utils/html-tag.js';
+
+class Overview extends PolymerElement {
+  static get template() {
+    return html`
+      <div>Coming Soon :)</div>
+    `;
+  }
+
+  static get is() { return 'devtools-overview'; }
+}
+
+window.customElements.define(Overview.is, Overview);

--- a/devtools/src/ng/raw-log.js
+++ b/devtools/src/ng/raw-log.js
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {PolymerElement} from '../../deps/@polymer/polymer/polymer-element.js';
+import {html} from '../../deps/@polymer/polymer/lib/utils/html-tag.js';
+import {formatTime, MessengerMixin} from '../arcs-shared.js';
+import '../../deps/@polymer/iron-list/iron-list.js';
+import {ObjectExplorer} from '../common/object-explorer.js';
+import '../common/filter-input.js';
+
+class RawLog extends MessengerMixin(PolymerElement) {
+  static get template() {
+    return html`
+    <style include="shared-styles">
+      :host {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        flex-grow: 0;
+      }
+      iron-list {
+        flex-grow: 1;
+        overflow-y: auto;
+      }
+      #download {
+        height: 20px;
+      }
+      [kind] {
+        margin: 0 4px;
+        color: var(--dark-red);
+      }
+    </style>
+    <header class="header">
+      <div section>
+        <iron-icon id="download" disabled$="{{!downloadEnabled}}" icon="file-download" title="Download log" on-click="downloadLog"></iron-icon>
+        <div divider></div>
+        <filter-input filter="{{searchParams}}"></filter-input>
+      </div>
+    </header>
+    <iron-list id="list" items="{{filteredEntries}}">
+      <template>
+        <div entry>
+          <object-explorer data="[[item.explorerData]]" on-expand="_handleExpand">
+            <span kind>[[item.kind]]</span>
+          </object-explorer>
+        </div>
+      </template>
+    </iron-list>`;
+  }
+
+  constructor() {
+    super();
+    this.reset();
+  }
+
+  static get properties() {
+    return {
+      active: {
+        type: Boolean,
+        observer: '_onActiveChanged',
+        reflectToAttribute: true
+      },
+      searchParams: {
+        type: Object,
+        observer: '_onSearchChanged'
+      },
+      entries: Array,
+      filteredEntries: Array,
+    };
+  }
+
+  _onSearchChanged(params) {
+    // Go through filtered and non-filtered entries at the same time and
+    // check which messages should be removed/added/kept to the filtered entries.
+    let fi = 0; // Filtered index.
+    for (const entry of this.entries) {
+      const found = ObjectExplorer.find(entry.explorerData, params);
+      const filter = !params || found;
+      if (entry === this.filteredEntries[fi]) {
+        if (filter) {
+          fi++;
+        } else {
+          this.splice('filteredEntries', fi, 1);
+        }
+      } else {
+        if (filter) {
+          this.splice('filteredEntries', fi, 0, entry);
+          this.notifyPath(`filteredEntries.${fi}.highlight`);
+          fi++;
+        }
+      }
+    }
+    for (const explorer of this.shadowRoot.querySelectorAll('[entry] > object-explorer')) {
+      explorer.find = params;
+    }
+    this.downloadEnabled = !!this.filteredEntries.length;
+  }
+
+  reset() {
+    this.entries = [];
+    this.filteredEntries = [];
+    this.downloadEnabled = false;
+  }
+
+  // We don't bundle messages in DevToolsNg yet, so there will be just one.
+  onRawMessageBundle(msg) {
+    if (msg.kind === 'RawStoreMessage') return;
+    const entry = this.newEntry(msg);
+    this.entries.push(entry);
+    if (!this.searchParams || entry.explorerData.found) {
+      this.push('filteredEntries', entry);
+    }
+    this.downloadEnabled = !!this.filteredEntries.length;
+  }
+
+  newEntry(msg) {
+    const explorerData = ObjectExplorer.prepareData(msg.message);
+    ObjectExplorer.find(explorerData, this.searchParams);
+
+    return {
+      kind: msg.kind,
+      msg,
+      explorerData,
+    };
+  }
+
+  downloadLog() {
+    if (!this.downloadEnabled) return;
+
+    const lines = this.filteredEntries.map(e => {
+      return `${JSON.stringify(e.msg)}\n`;
+    });
+    const a = document.createElement('a');
+    a.download = `arcs-log.log`;
+    a.href = window.URL.createObjectURL(new Blob(lines, {type: 'text/plain'}));
+    a.dataset.downloadurl = ['text/plain', a.download, a.href].join(':');
+    a.click();
+  }
+
+  _handleExpand(e) {
+    const ix = this.filteredEntries.findIndex(item => item.explorerData === e.detail);
+    this.$.list.updateSizeForIndex(ix);
+  }
+
+  _onActiveChanged(active) {
+    if (active) {
+      // Iron-list needs to be notified that the panel got shown, so that it draws itself.
+      this.$.list.fire('iron-resize');
+    }
+  }
+
+
+  static get is() { return 'devtools-raw-log'; }
+}
+
+window.customElements.define(RawLog.is, RawLog);

--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -51,7 +51,7 @@ interface DevToolsMessage {
     const val REMOVE_TYPE = "remove"
 
     /** A [REMOVE_TYPE] should be used when a [CrdtSet.Operation.Fastforward] is received. */
-    const val FAST_FORWARD_TYPE = "fastforward"
+    const val FAST_FORWARD_TYPE = "fastForward"
 
     // String constants to be used in JSON messages.
     /** JSON key for [kind]. */
@@ -88,13 +88,13 @@ interface DevToolsMessage {
     const val CLOCK = "clock"
 
     /** Json key for the versionmap. */
-    const val VERSIONMAP = "versionmap"
+    const val VERSIONMAP = "versionMap"
 
     /** Json key for the type of [Store] the message comes from. */
-    const val STORE_TYPE = "storetype"
+    const val STORE_TYPE = "storeType"
 
     /** To be used as the [STORE_TYPE] for a [ReferenceModeStore]. */
-    const val REFERENCEMODE = "referncemode"
+    const val REFERENCEMODE = "referenceMode"
 
     /** To be used as the [STORE_TYPE] for a [DirectStore]. */
     const val DIRECT = "direct"


### PR DESCRIPTION
Creating a parallel webapp for DevTools NG reusing pieces of the original DevTool webapp (http://localhost:8786/devtools/ng.html):

* Message pass-through allowing webSocket, webRTC and Chrome Extension message passing.
* Modular UI with GoldenLayout based panels (for viewing multiple tools at once and customizing the layout).
* Borrowed code from PEC Log to create DevTools NG Raw Log. Now it only renders what can be seen on the screen, which will give better performance longer term. Also reusing some other goodies: search and Download of the log into a file.

Also fixed some constants to follow camelCase.