### PR TITLE
Don't deal with devtools/ with npm install in top level

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -13,7 +13,7 @@ It can connect to Arcs Runtime using one of 3 transport channels:
 
 Ensure you have all the node packages installed:
 ```
-npm install
+cd devtools; npm install
 ```
 
 ## Using with local WebShell as a Chrome Extension

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "module": "dist/webmain.js",
   "main": "dist/index.es.js",
   "scripts": {
-    "prepare": "cross-env tools/sigh check && cd devtools && npm i && cd ../concrete-storage && npm i",
+    "prepare": "cross-env tools/sigh check && cd concrete-storage && npm i",
     "test-extension": "mocha-chrome extension/tests/index.test.html",
     "test:licenses": "jsgl --local . && npm --prefix devtools run test:licenses && npm --prefix cloud run test:licenses",
     "build:rollup": "rollup -c --sourcemap",


### PR DESCRIPTION
Some folks may `npm install` often and this is unnecessarily slowing them down.