### PR TITLE
Prevent DB creation race by always running e2e test StorageService in main process

### DIFF
--- a/javatests/arcs/android/e2e/testapp/AndroidManifest.xml
+++ b/javatests/arcs/android/e2e/testapp/AndroidManifest.xml
@@ -68,6 +68,15 @@
       android:exported="false"
       android:process=":test"/>
 
+    <!-- Note: We currently enforce running the StorageService on the default process to
+         prevent a potential race in DB creation. The WorkManager tasks will always run in the
+         main process, and they manipulate the DB directly. -->
+    <service
+      android:name="arcs.sdk.android.storage.service.StorageService"
+      android:exported="false"
+      android:process=""
+      tools:replace="android:process"/>
+
     <service
       android:name="arcs.android.devtools.DevToolsService"
       android:exported="false"/>

--- a/javatests/arcs/android/e2e/testapp/TestApplication.kt
+++ b/javatests/arcs/android/e2e/testapp/TestApplication.kt
@@ -18,10 +18,12 @@ import arcs.android.util.initLogForAndroid
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.util.Log
+import arcs.core.util.TaggedLog
 import kotlinx.coroutines.runBlocking
 
 /** Application class for Arcs Test. */
 class TestApplication : Application(), Configuration.Provider {
+  private val log = TaggedLog { "TestApplication" }
 
   override fun getWorkManagerConfiguration() =
     Configuration.Builder()
@@ -29,9 +31,10 @@ class TestApplication : Application(), Configuration.Provider {
       .build()
 
   override fun onCreate() {
+    initLogForAndroid(Log.Level.Debug)
+    log.info { "onCreate ${getProcessName()}" }
     super.onCreate()
     runBlocking { RamDisk.clear() }
     DriverAndKeyConfigurator.configure(AndroidSqliteDatabaseManager(this))
-    initLogForAndroid(Log.Level.Debug)
   }
 }


### PR DESCRIPTION
Our DatabaseImpl is not robust to multiple processes racing to run
`onCreate`, which leads to the e2e test occassionally failing with an
error about duplicate table creation.

Our current workmanager task implementations work directly with the
database. Workmanager tasks always run in the main process. This means
that, for the time being, in order to avoid this race, we need to make
the StorageService run in the main process, as well.

This test will still be exercising the cross-process AIDL binding
because it creates *another* service in a different process that binds
to the storage service.

b/170119674