### PR TITLE
[DO NOT SUBMIT] Repro for reading empty list causing a crash

### DIFF
--- a/javatests/arcs/showcase/inline/BUILD
+++ b/javatests/arcs/showcase/inline/BUILD
@@ -57,6 +57,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/api",
         "//java/arcs/core/storage/database",
         "//java/arcs/core/testutil",
+        "//java/arcs/core/testutil/handles",
         "//java/arcs/core/util/testutil",
         "//javatests/arcs/showcase",
         "//third_party/android/androidx_test/ext/junit",

--- a/javatests/arcs/showcase/inline/Items.kt
+++ b/javatests/arcs/showcase/inline/Items.kt
@@ -6,10 +6,10 @@ data class MyLevel0(
 
 data class MyLevel1(
   val name: String,
-  val children: Set<MyLevel0>
+  val children: List<MyLevel0>
 )
 
 data class MyLevel2(
   val name: String,
-  val children: Set<MyLevel1>
+  val children: List<MyLevel1>
 )

--- a/javatests/arcs/showcase/inline/ReadWriteTest.kt
+++ b/javatests/arcs/showcase/inline/ReadWriteTest.kt
@@ -2,6 +2,8 @@ package arcs.showcase.inline
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.core.host.toRegistration
+import arcs.core.testutil.handles.dispatchFetchAll
+import arcs.core.testutil.runTest
 import arcs.core.util.testutil.LogRule
 import arcs.showcase.ShowcaseEnvironment
 import com.google.common.truth.Truth.assertThat
@@ -9,6 +11,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import arcs.core.testutil.handles.dispatchStore
+import kotlinx.coroutines.delay
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
@@ -30,8 +34,8 @@ class ReadWriteTest {
   private val storage = ArcsStorage(env)
 
   private val l0 = MyLevel0("l0-1")
-  private val l1 = MyLevel1("l1-1", setOf(l0))
-  private val l2 = MyLevel2("l2-1", setOf(l1))
+  private val l1 = MyLevel1("l1-1", listOf())
+  private val l2 = MyLevel2("l2-1", listOf())
 
   @Test
   fun writeAndReadBack0() {
@@ -49,5 +53,19 @@ class ReadWriteTest {
   fun writeAndReadBack2() {
     storage.put2(l2)
     assertThat(storage.all2()).containsExactly(l2)
+  }
+
+  @Test
+  fun crashingRepro() = runTest{
+    val arc = env.startArc(WriteRecipePlan)
+    env.getParticle<Writer2>(arc).handles.level2.dispatchStore(AbstractWriter2.Level2("hello"))
+    env.stopArc(arc)
+
+    delay(2000)
+
+    val arc2 = env.startArc(WriteRecipePlan)
+    val read = env.getParticle<Reader2>(arc2).handles.level2.dispatchFetchAll()
+    assertThat(read).containsExactly(AbstractReader2.Level2("hello"))
+    env.stopArc(arc2)
   }
 }

--- a/javatests/arcs/showcase/inline/Reader.kt
+++ b/javatests/arcs/showcase/inline/Reader.kt
@@ -24,7 +24,7 @@ class Reader1 : AbstractReader1() {
 
   private suspend fun Level1.fromArcs() = MyLevel1(
     name = name,
-    children = children.map { it.fromArcs() }.toSet()
+    children = children.map { it.fromArcs() }
   )
 
   suspend fun read(): List<MyLevel1> = withContext(handles.level1.dispatcher) {
@@ -39,12 +39,12 @@ class Reader2 : AbstractReader2() {
 
   private fun Level1.fromArcs() = MyLevel1(
     name = name,
-    children = children.map { it.fromArcs() }.toSet()
+    children = children.map { it.fromArcs() }
   )
 
   private fun Level2.fromArcs() = MyLevel2(
     name = name,
-    children = children.map { it.fromArcs() }.toSet()
+    children = children.map { it.fromArcs() }
   )
 
   suspend fun read(): List<MyLevel2> = withContext(handles.level2.dispatcher) {

--- a/javatests/arcs/showcase/inline/Writer.kt
+++ b/javatests/arcs/showcase/inline/Writer.kt
@@ -24,7 +24,7 @@ class Writer1 : AbstractWriter1() {
 
   private suspend fun MyLevel1.toArcs() = Level1(
     name = name,
-    children = children.map { it.toArcs() }.toSet()
+    children = children.map { it.toArcs() }
   )
 
   suspend fun write(item: MyLevel1) = withContext(handles.level1.dispatcher) {
@@ -39,12 +39,12 @@ class Writer2 : AbstractWriter2() {
 
   private suspend fun MyLevel1.toArcs() = Level1(
     name = name,
-    children = children.map { it.toArcs() }.toSet()
+    children = children.map { it.toArcs() }
   )
 
   private suspend fun MyLevel2.toArcs() = Level2(
     name = name,
-    children = children.map { it.toArcs() }.toSet()
+    children = children.map { it.toArcs() }
   )
 
   suspend fun write(item: MyLevel2) = withContext(handles.level2.dispatcher) {

--- a/javatests/arcs/showcase/inline/schema.arcs
+++ b/javatests/arcs/showcase/inline/schema.arcs
@@ -6,15 +6,15 @@ schema Level0
 
 schema Level1
   name: Text
-  children: [inline Level0]
+  children: List<inline Level0>
 
 schema Level2
   name: Text
-  children: [inline Level1]
+  children: List<inline Level1>
 
 schema Level3
   name: Text
-  children: [inline Level2]
+  children: List<inline Level2>
 
 particle Writer0 in 'arcs.showcase.inline.Writer0'
   level0: writes [Level0 {name}]


### PR DESCRIPTION
````
java.lang.IllegalArgumentException: DB in an inconsistent state: entity data exists against storage_key_id 0 without matching ID from entities table
	at arcs.android.storage.database.DatabaseImpl.getEntityFields(DatabaseImpl.kt:422)
	at arcs.android.storage.database.DatabaseImpl.getEntity(DatabaseImpl.kt:309)
	at arcs.android.storage.database.DatabaseImpl$get$2.invokeSuspend(DatabaseImpl.kt:251)
	at arcs.android.storage.database.DatabaseImpl$get$2.invoke(DatabaseImpl.kt)
```