### PR TITLE
DirectStoreMuxer callback refactor

### DIFF
--- a/java/arcs/android/storage/service/IMuxedStorageService.aidl
+++ b/java/arcs/android/storage/service/IMuxedStorageService.aidl
@@ -30,6 +30,6 @@ interface IMuxedStorageService {
      * @param callback invoked whenever the storage channel responds with a
      *     message
      */
-    void openMuxedStorageChannel(
+    oneway void openMuxedStorageChannel(
         in byte[] encodedStoreOptions, IStorageChannelCallback callback);
 }

--- a/java/arcs/android/storage/service/IMuxedStorageService.aidl
+++ b/java/arcs/android/storage/service/IMuxedStorageService.aidl
@@ -30,6 +30,6 @@ interface IMuxedStorageService {
      * @param callback invoked whenever the storage channel responds with a
      *     message
      */
-    IStorageChannel openMuxedStorageChannel(
+    void openMuxedStorageChannel(
         in byte[] encodedStoreOptions, IStorageChannelCallback callback);
 }

--- a/java/arcs/android/storage/service/IStorageChannelCallback.aidl
+++ b/java/arcs/android/storage/service/IStorageChannelCallback.aidl
@@ -11,6 +11,8 @@
 
 package arcs.android.storage.service;
 
+import arcs.android.storage.service.IStorageChannel;
+
 /** Callback for asynchronously receiving messages from a storage channel. */
 interface IStorageChannelCallback {
     /**
@@ -20,4 +22,11 @@ interface IStorageChannelCallback {
      *     arcs.android.storage.StorageServiceMessageProto}
      */
     oneway void onMessage(in byte[] encodedMessage);
+
+    /**
+     * Invoked when the storage channel has been created.
+     *
+     * @param channel the created storage channel
+     */
+    oneway void onCreate(IStorageChannel channel);
 }

--- a/java/arcs/core/storage/DirectStoreMuxerImpl.kt
+++ b/java/arcs/core/storage/DirectStoreMuxerImpl.kt
@@ -5,6 +5,7 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.util.randomCallbackManager
 import arcs.core.type.Type
 import arcs.core.util.LruCacheMap
+import arcs.core.util.MutableBiMap
 import arcs.core.util.Random
 import arcs.core.util.TaggedLog
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +21,11 @@ class DirectStoreMuxerImpl<Data : CrdtData, Op : CrdtOperation, T>(
   private val writeBackProvider: WriteBackProvider,
   private val devTools: DevToolsForStorage?
 ) : DirectStoreMuxer<Data, Op, T> {
-  private val storeMutex = Mutex()
+  /**
+   * [stateMutex] guards all accesses to the [DirectStoreMuxer]'s [callbackManager], [stores], and
+   * [callbackIdToMuxIdMap].
+   */
+  private val stateMutex = Mutex()
   private val log = TaggedLog { "DirectStoreMuxer" }
 
   /**
@@ -36,43 +41,68 @@ class DirectStoreMuxerImpl<Data : CrdtData, Op : CrdtOperation, T>(
   override val stores = LruCacheMap<String, DirectStoreMuxer.StoreRecord<Data, Op, T>>(
     50,
     livenessPredicate = { _, sr -> !sr.store.closed }
-  ) { _, sr -> closeStore(sr) }
+  ) { muxId, sr -> closeStore(muxId, sr) }
 
-  /** Safely closes a [DirectStore] and cleans up its resources. */
-  private fun closeStore(storeRecord: DirectStoreMuxer.StoreRecord<*, *, *>) {
+  /**
+   * Maps each [callbackId] managed by the [callbackManager] to a set of muxId's. The set of muxId's
+   * represent the set of [DirectStore] instances with a callback associated to the [callbackId].
+   *
+   * The [callbackId] belongs to a listener that registered a callback to the [DirectStoreMuxer],
+   * and the muxId's represent the set of stores that the listener has access to.
+   */
+  private val callbackIdToMuxIdMap = mutableMapOf<Int, MutableSet<String>>()
+
+  /**
+   * Safely closes a [DirectStore] and cleans up its resources.
+   *
+   * closeStore mutates state and therefore must only be callbed by a function that holds the
+   * stateMutex.
+   */
+  private fun closeStore(muxId: String, storeRecord: DirectStoreMuxer.StoreRecord<*, *, *>) {
     if (!storeRecord.store.closed) {
-      log.debug { "close the store(${storeRecord.id})" }
+      log.debug { "close the store($muxId)" }
 
       try {
+        storeRecord.idMap.lefts
+          .asSequence()
+          .mapNotNull { callbackId -> callbackIdToMuxIdMap[callbackId] }
+          .forEach { muxIdSet -> muxIdSet.remove(muxId) }
+        storeRecord.idMap.clear()
         storeRecord.store.close()
       } catch (e: Exception) {
         // TODO(b/160251910): Make logging detail more cleanly conditional.
-        log.debug(e) { "failed to close the store(${storeRecord.id})" }
+        log.debug(e) { "failed to close the store($muxId)" }
         log.info { "failed to close the store" }
       }
     }
   }
 
-  override fun on(callback: MuxedProxyCallback<Data, Op, T>): Int {
-    return callbackManager.register(callback::invoke)
+  override suspend fun on(callback: MuxedProxyCallback<Data, Op, T>): Int = stateMutex.withLock {
+    val callbackId = callbackManager.register(callback::invoke)
+    callbackIdToMuxIdMap[callbackId] = mutableSetOf()
+    callbackId
   }
 
-  override fun off(token: Int) {
-    callbackManager.unregister(token)
+  override suspend fun off(callbackId: Int): Unit = stateMutex.withLock {
+    callbackIdToMuxIdMap[callbackId]?.forEach { muxId ->
+      val (idMap, store) = checkNotNull(stores[muxId]) { "store not found" }
+      idMap.removeL(callbackId)?.let { callbackIdForStore -> store.off(callbackIdForStore) }
+    }
+    callbackIdToMuxIdMap.remove(callbackId)
+    callbackManager.unregister(callbackId)
   }
 
   @Suppress("UNUSED_PARAMETER")
-  override suspend fun getLocalData(referenceId: String, callbackId: Int): Data {
-    return store(referenceId).store.getLocalData()
-  }
+  override suspend fun getLocalData(referenceId: String, callbackId: Int): Data =
+    getStore(referenceId, callbackId).store.getLocalData()
 
-  override suspend fun clearStoresCache() = storeMutex.withLock {
-    for ((_, sr) in stores) closeStore(sr)
+  override suspend fun clearStoresCache(): Unit = stateMutex.withLock {
+    stores.forEach { (muxId, sr) -> closeStore(muxId, sr) }
     stores.clear()
   }
 
   override suspend fun idle() {
-    storeMutex.withLock {
+    stateMutex.withLock {
       stores.values.toList()
     }.forEach {
       /**
@@ -84,9 +114,15 @@ class DirectStoreMuxerImpl<Data : CrdtData, Op : CrdtOperation, T>(
     }
   }
 
-  override suspend fun onProxyMessage(muxedMessage: MuxedProxyMessage<Data, Op, T>) {
-    val (id, store) = store(muxedMessage.muxId)
-    val deMuxedMessage: ProxyMessage<Data, Op, T> = muxedMessage.message.withId(id)
+  override suspend fun onProxyMessage(
+    muxedMessage: MuxedProxyMessage<Data, Op, T>
+  ) {
+    val messageId = requireNotNull(muxedMessage.message.id) { "messages must have an ID" }
+    val (idMap, store) = getStore(muxedMessage.muxId, messageId)
+    val messageIdForStore = requireNotNull(idMap.getR(messageId)) {
+      "callback was not successfully registered to store."
+    }
+    val deMuxedMessage: ProxyMessage<Data, Op, T> = muxedMessage.message.withId(messageIdForStore)
     store.onProxyMessage(deMuxedMessage)
   }
 
@@ -102,19 +138,53 @@ class DirectStoreMuxerImpl<Data : CrdtData, Op : CrdtOperation, T>(
       devTools = devTools
     )
 
-    val id = store.on {
-      callbackManager.send(MuxedProxyMessage(referenceId, it))
-    }
-
     // Return a new Record and add it to our local stores, keyed by muxId.
-    return DirectStoreMuxer.StoreRecord(id, store)
+    return DirectStoreMuxer.StoreRecord(MutableBiMap(), store)
   }
 
-  private suspend fun store(id: String): DirectStoreMuxer.StoreRecord<Data, Op, T> {
-    return storeMutex.withLock {
-      stores.getOrPut(id) {
-        setupStore(id)
+  override suspend fun getStore(
+    muxId: String,
+    callbackId: Int
+  ): DirectStoreMuxer.StoreRecord<Data, Op, T> = stateMutex.withLock {
+    val storeRecord = stores.getOrPut(muxId) { this.setupStore(muxId) }
+
+    // Register `callbackId` with store if it is not already registered. It is necessary to register
+    // a callback per id because when the DirectStoreMuxer receives a message from the DirectStore,
+    // it utilizes the message id to determine which observer to redirect the message to.
+    if (callbackId != null) {
+      check(callbackManager.callbacks.containsKey(callbackId)) {
+        "Callback id is not registered to the Direct Store Muxer."
+      }
+
+      if (!storeRecord.idMap.containsL(callbackId)) {
+        val callbackIdForStore = storeRecord.store.on {
+          callbackManager.getCallback(callbackId)?.invoke(
+            MuxedProxyMessage(muxId, it.withId(callbackId))
+          )
+        }
+        storeRecord.idMap.put(callbackId, callbackIdForStore)
+        callbackIdToMuxIdMap.getOrPut(callbackId) { mutableSetOf() }.add(muxId)
       }
     }
+    storeRecord
+  }
+
+  /**
+   * Ensures the [callbackManager], [callbackIdToMuxIdMap] and [stores] maintain consistent state.
+   */
+  suspend fun consistentState(): Boolean = stateMutex.withLock {
+    // check stores are consistent with callbackManager and callbackIdToMuxIdMap
+    for ((muxId, sr) in stores) {
+      if (!callbackManager.callbacks.keys.containsAll(sr.idMap.lefts)) return false
+      if (!sr.idMap.lefts.all { callbackIdToMuxIdMap[it]?.contains(muxId) == true }) return false
+    }
+
+    // check callbackIdToMuxIdMap is consistent with callbackManager and stores
+    if (!callbackManager.callbacks.keys.containsAll(callbackIdToMuxIdMap.keys)) return false
+    for ((id, muxIdSet) in callbackIdToMuxIdMap) {
+      if (!muxIdSet.all { muxId -> stores[muxId]?.idMap?.containsL(id) == true }) return false
+    }
+
+    return true
   }
 }

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -49,6 +49,7 @@ import arcs.core.util.Result
 import arcs.core.util.TaggedLog
 import arcs.core.util.computeNotNull
 import arcs.core.util.nextSafeRandomLong
+import kotlin.properties.Delegates
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -157,15 +158,9 @@ class ReferenceModeStore private constructor(
    * This is visible only for tests. Do not use outside of [ReferenceModeStore] other than for
    * tests.
    */
-  val backingStoreId: Int
+  var backingStoreId by Delegates.notNull<Int>()
 
   init {
-    backingStoreId = backingStore.on { muxedMessage ->
-      receiveQueue.enqueue {
-        handleBackingStoreMessage(muxedMessage.message, muxedMessage.muxId)
-      }
-    }
-
     @Suppress("UNCHECKED_CAST")
     crdtType = requireNotNull(
       type as? Type.TypeContainer<CrdtModelType<CrdtData, CrdtOperationAtTime, Referencable>>
@@ -764,11 +759,16 @@ class ReferenceModeStore private constructor(
         backingStore,
         devTools?.forRefModeStore(options)
       ).also { refModeStore ->
-        // Since `on` is a suspending method, we need to setup the container store callback
-        // here in this create method, which is inside of a coroutine.
+        // Since `on` is a suspending method, we need to setup both the container store callback and
+        // the backing store callback here in this create method, which is inside of a coroutine.
         containerStore.on {
           refModeStore.receiveQueue.enqueue {
             refModeStore.handleContainerMessage(it.toReferenceModeMessage())
+          }
+        }
+        refModeStore.backingStoreId = refModeStore.backingStore.on {
+          refModeStore.receiveQueue.enqueue {
+            refModeStore.handleBackingStoreMessage(it.message, it.muxId)
           }
         }
       }

--- a/java/arcs/core/storage/testutil/DriverMocks.kt
+++ b/java/arcs/core/storage/testutil/DriverMocks.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.testutil
+
+import arcs.core.storage.Driver
+import arcs.core.storage.DriverProvider
+import arcs.core.storage.StorageKey
+import arcs.core.type.Type
+import kotlin.reflect.KClass
+
+class MockDriverProvider : DriverProvider {
+  override fun willSupport(storageKey: StorageKey): Boolean = true
+
+  override suspend fun <Data : Any> getDriver(
+    storageKey: StorageKey,
+    dataClass: KClass<Data>,
+    type: Type
+  ): Driver<Data> = MockDriver(storageKey)
+
+  override suspend fun removeAllEntities() = Unit
+
+  override suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long) =
+    Unit
+}
+
+class MockDriver<T : Any>(
+  override val storageKey: StorageKey
+) : Driver<T> {
+  override var token: String? = null
+  var receiver: (suspend (data: T, version: Int) -> Unit)? = null
+  var sentData = mutableListOf<T>()
+  var fail = false
+
+  override suspend fun registerReceiver(
+    token: String?,
+    receiver: suspend (data: T, version: Int) -> Unit
+  ) {
+    this.token = token
+    this.receiver = receiver
+  }
+
+  override suspend fun send(data: T, version: Int): Boolean {
+    sentData.add(data)
+    return !fail
+  }
+}

--- a/java/arcs/core/storage/testutil/NoopDirectStoreMuxer.kt
+++ b/java/arcs/core/storage/testutil/NoopDirectStoreMuxer.kt
@@ -15,9 +15,9 @@ open class NoopDirectStoreMuxer : UntypedDirectStoreMuxer {
   override val storageKey: StorageKey = DummyStorageKey("dummy")
   override val backingType: Type = TypeVariable("dummy")
 
-  override fun on(callback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>): Int = 0
+  override suspend fun on(callback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>): Int = 0
 
-  override fun off(token: Int) {}
+  override suspend fun off(token: Int) {}
 
   override suspend fun getLocalData(referenceId: String, callbackId: Int): CrdtData {
     throw NotImplementedError()
@@ -30,6 +30,13 @@ open class NoopDirectStoreMuxer : UntypedDirectStoreMuxer {
   override suspend fun onProxyMessage(
     muxedMessage: MuxedProxyMessage<CrdtData, CrdtOperation, Any?>
   ) {}
+
+  override suspend fun getStore(
+    muxId: String,
+    callbackId: Int
+  ): DirectStoreMuxer.StoreRecord<CrdtData, CrdtOperation, Any?> {
+    throw NotImplementedError()
+  }
 
   override val stores =
     emptyMap<String, DirectStoreMuxer.StoreRecord<CrdtData, CrdtOperation, Any?>>()

--- a/javatests/arcs/android/storage/service/MuxedStorageChannelImplTest.kt
+++ b/javatests/arcs/android/storage/service/MuxedStorageChannelImplTest.kt
@@ -44,7 +44,7 @@ class MuxedStorageChannelImplTest {
   fun proxiesMessagesFromDirectStoreMuxer() = runBlockingTest {
     var muxedProxyCallback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>? = null
     val directStoreMuxer = object : NoopDirectStoreMuxer() {
-      override fun on(callback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>): Int {
+      override suspend fun on(callback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>): Int {
         muxedProxyCallback = callback
         return 123
       }
@@ -141,9 +141,9 @@ class MuxedStorageChannelImplTest {
   fun close_unregistersListener() = runBlockingTest {
     val job = Job()
     val directStoreMuxer = object : NoopDirectStoreMuxer() {
-      override fun on(callback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>) = 1234
+      override suspend fun on(callback: MuxedProxyCallback<CrdtData, CrdtOperation, Any?>) = 1234
 
-      override fun off(token: Int) {
+      override suspend fun off(token: Int) {
         assertThat(resultCallback.hasBeenCalled).isFalse()
         assertThat(token).isEqualTo(1234)
         job.complete()
@@ -168,11 +168,11 @@ class MuxedStorageChannelImplTest {
     assertThat(result).contains("close failed")
   }
 
-  private fun createChannel(
+  private suspend fun createChannel(
     scope: CoroutineScope,
     directStoreMuxer: UntypedDirectStoreMuxer = NoopDirectStoreMuxer()
   ): MuxedStorageChannelImpl {
-    return MuxedStorageChannelImpl(
+    return MuxedStorageChannelImpl.create(
       directStoreMuxer,
       scope,
       BindingContextStatsImpl(),

--- a/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
+++ b/javatests/arcs/core/storage/DirectStoreMuxerTest.kt
@@ -1,5 +1,17 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
 package arcs.core.storage
 
+import arcs.core.common.ReferenceId
 import arcs.core.crdt.CrdtEntity
 import arcs.core.crdt.CrdtSingleton
 import arcs.core.crdt.VersionMap
@@ -10,19 +22,47 @@ import arcs.core.data.SchemaFields
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.testutil.MockDriver
+import arcs.core.storage.testutil.MockDriverProvider
 import arcs.core.storage.testutil.testDriverFactory
 import arcs.core.storage.testutil.testWriteBackProvider
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class DirectStoreMuxerTest {
+
+  private lateinit var storageKey: RamDiskStorageKey
+  private lateinit var schema: Schema
+  private val driverFactory = FixedDriverFactory(MockDriverProvider())
+
+  @Before
+  fun setup() = runBlockingTest {
+    storageKey = RamDiskStorageKey("test")
+    schema = Schema(
+      emptySet(),
+      SchemaFields(
+        singletons = mapOf(
+          "name" to FieldType.Text,
+          "age" to FieldType.Int
+        ),
+        collections = emptyMap()
+      ),
+      "abc"
+    )
+    DefaultDriverFactory.update(MockDriverProvider())
+  }
 
   @Test
   fun directStoreMuxerNoRace() = runBlocking<Unit>(Dispatchers.IO) {
@@ -73,19 +113,19 @@ class DirectStoreMuxerTest {
       launch { directStoreMuxer.getLocalData("a", callbackId) }
       launch {
         directStoreMuxer.onProxyMessage(
-          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
+          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, callbackId))
         )
       }
       launch { directStoreMuxer.getLocalData("a", callbackId) }
       launch {
         directStoreMuxer.onProxyMessage(
-          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
+          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, callbackId))
         )
       }
       launch { directStoreMuxer.getLocalData("a", callbackId) }
       launch {
         directStoreMuxer.onProxyMessage(
-          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, 1))
+          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(data, callbackId))
         )
       }
     }
@@ -121,4 +161,271 @@ class DirectStoreMuxerTest {
     }
     assertThat(callbacks).isEqualTo(1)
   }
+
+  @Test
+  fun directStoreMuxer_maintains_consistentState() = runBlockingTest {
+    val directStoreMuxer = createDirectStoreMuxer(this)
+
+    val entityCrdtA = createPersonEntityCrdt("bob", 42)
+    val entityCrdtB = createPersonEntityCrdt("alice", 10)
+
+    // Initially set up two clients that are registered to the DirectStoreMuxer. These clients are
+    // established outside of the coroutine scope because a reference to them is needed to confirm
+    // later that they have successfully deregistered from the DirectStoreMuxer.
+    val callbackId1 = directStoreMuxer.on {}
+    val callbackId2 = directStoreMuxer.on {}
+
+    // Two stores are established outside the coroutine scope because a reference to them is needed
+    // to confirm later that they have successfully closed.
+    val storeA = directStoreMuxer.getStore("a", callbackId1).store
+    val storeB = directStoreMuxer.getStore("b", callbackId1).store
+
+    // Simulate several clients registering to and sending/receiving messages to/from the
+    // DirectStoreMuxer.
+    coroutineScope {
+      launch {
+        directStoreMuxer.getLocalData("a", callbackId1)
+        directStoreMuxer.off(callbackId1)
+      }
+      launch {
+        directStoreMuxer.getLocalData("a", callbackId2)
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(entityCrdtA.data, callbackId2))
+        )
+        directStoreMuxer.off(callbackId2)
+      }
+      launch {
+        val callbackId3 = directStoreMuxer.on {}
+        directStoreMuxer.getLocalData("a", callbackId3)
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("a", ProxyMessage.SyncRequest(callbackId3))
+        )
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("b", ProxyMessage.SyncRequest(callbackId3))
+        )
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("a", ProxyMessage.SyncRequest(callbackId3))
+        )
+      }
+      launch {
+        val callbackId4 = directStoreMuxer.on {}
+        directStoreMuxer.getLocalData("b", callbackId4)
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("a", ProxyMessage.SyncRequest(callbackId4))
+        )
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("b", ProxyMessage.ModelUpdate(entityCrdtB.data, callbackId4))
+        )
+      }
+      launch {
+        val callbackId5 = directStoreMuxer.on {}
+        directStoreMuxer.getLocalData("a", callbackId5)
+        directStoreMuxer.getLocalData("b", callbackId5)
+
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("b", ProxyMessage.SyncRequest(callbackId5))
+        )
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(entityCrdtA.data, callbackId5))
+        )
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("b", ProxyMessage.ModelUpdate(entityCrdtA.data, callbackId5))
+        )
+      }
+      launch {
+        val callbackId6 = directStoreMuxer.on {}
+        directStoreMuxer.onProxyMessage(
+          MuxedProxyMessage("a", ProxyMessage.ModelUpdate(entityCrdtA.data, callbackId6))
+        )
+        directStoreMuxer.clearStoresCache()
+      }
+    }
+
+    // Check that the stores have successfully closed.
+    assertThat(storeA.closed).isTrue()
+    assertThat(storeB.closed).isTrue()
+
+    // Check that the shared mutable state in the directStoreMuxer has maintained consistent.
+    assertThat(directStoreMuxer.consistentState()).isTrue()
+
+    // Check that deregistered callbacks are no longer registered with the DirectStoreMuxer
+    assertFailsWith<IllegalStateException>(
+      "Callback id is not registered to the Direct Store Muxer."
+    ) { directStoreMuxer.getLocalData("a", callbackId1) }
+
+    assertFailsWith<IllegalStateException>(
+      "Callback id is not registered to the Direct Store Muxer."
+    ) { directStoreMuxer.getLocalData("a", callbackId2) }
+  }
+
+  @Test
+  fun propagateModelUpdates_fromProxyMuxer_toDrivers() = runBlockingTest {
+    val directStoreMuxer = createDirectStoreMuxer(this)
+
+    val callbackId = directStoreMuxer.on {}
+
+    val entityCrdtA = createPersonEntityCrdt("bob", 42)
+
+    directStoreMuxer.onProxyMessage(
+      MuxedProxyMessage("a", ProxyMessage.ModelUpdate(entityCrdtA.data, callbackId))
+    )
+
+    val driverA = directStoreMuxer.getEntityDriver("a")
+    val capturedA = driverA.sentData.first()
+    assertThat(capturedA.toRawEntity().singletons).containsExactly(
+      "name", "bob".toReferencable(),
+      "age", 42.toReferencable()
+    )
+    assertThat(directStoreMuxer.stores.size).isEqualTo(1)
+
+    val entityCrdtB = createPersonEntityCrdt("alice", 10)
+
+    directStoreMuxer.onProxyMessage(
+      MuxedProxyMessage("b", ProxyMessage.ModelUpdate(entityCrdtB.data, callbackId))
+    )
+
+    val driverB = directStoreMuxer.getEntityDriver("b")
+    val capturedB = driverB.sentData.first()
+    assertThat(capturedB.toRawEntity().singletons).containsExactly(
+      "name", "alice".toReferencable(),
+      "age", 10.toReferencable()
+    )
+    assertThat(directStoreMuxer.stores.size).isEqualTo(2)
+  }
+
+  @Test
+  fun propagatesModelUpdate_fromProxyMuxer_toDriver_toOtherProxyMuxers() = runBlockingTest {
+    val directStoreMuxer = createDirectStoreMuxer(this)
+
+    val job = Job(coroutineContext[Job])
+
+    // Client that sends a model update to direct store muxer
+    var callbackInvoked = false
+    var callbackId1 = directStoreMuxer.on {
+      callbackInvoked = true
+    }
+
+    // Client that receives a model update from direct store muxer
+    val callbackId2 = directStoreMuxer.on { muxedMessage ->
+      assertThat(muxedMessage.message is ProxyMessage.ModelUpdate).isTrue()
+      job.complete()
+    }
+
+    // Set up store for muxId "a" and register for each client.
+    val muxIdA = "a"
+    directStoreMuxer.getLocalData(muxIdA, callbackId1)
+    directStoreMuxer.getLocalData(muxIdA, callbackId2)
+
+    val entityCrdtA = createPersonEntityCrdt("bob", 42)
+
+    directStoreMuxer.onProxyMessage(
+      MuxedProxyMessage(muxIdA, ProxyMessage.ModelUpdate(entityCrdtA.data, callbackId1))
+    )
+
+    val driverA = directStoreMuxer.getEntityDriver(muxIdA)
+    val capturedA = driverA.sentData.first()
+    assertThat(capturedA.toRawEntity().singletons).containsExactly(
+      "name", "bob".toReferencable(),
+      "age", 42.toReferencable()
+    )
+    job.join()
+    assertThat(callbackInvoked).isFalse()
+  }
+
+  @Test
+  fun onlySendsModelResponse_toRequestingProxy() = runBlockingTest {
+    val directStoreMuxer = createDirectStoreMuxer(this)
+
+    val job = Job(coroutineContext[Job])
+
+    // Client that sends a sync request.
+    val callbackId1 = directStoreMuxer.on { muxedMessage ->
+      assertThat(muxedMessage.message is ProxyMessage.ModelUpdate).isTrue()
+      job.complete()
+    }
+
+    // Other client.
+    var callback2Invoked = false
+    val callbackId2 = directStoreMuxer.on {
+      callback2Invoked = true
+    }
+
+    // Set up store for muxId "a" and register for each client.
+    val muxIdA = "a"
+    directStoreMuxer.getLocalData(muxIdA, callbackId1)
+    directStoreMuxer.getLocalData(muxIdA, callbackId2)
+
+    directStoreMuxer.onProxyMessage(
+      MuxedProxyMessage(muxIdA, ProxyMessage.SyncRequest(callbackId1))
+    )
+    job.join()
+    assertThat(callback2Invoked).isFalse()
+  }
+
+  @Test
+  fun unregisterSucessfully() = runBlockingTest {
+    val directStoreMuxer = createDirectStoreMuxer(this)
+
+    val callbackId1 = directStoreMuxer.on {}
+
+    val muxIdA = "a"
+    val (idMapA, _) = directStoreMuxer.getStore(muxIdA, callbackId1)
+
+    val muxIdB = "b"
+    val (idMapB, _) = directStoreMuxer.getStore(muxIdB, callbackId1)
+
+    assertThat(idMapA.size).isEqualTo(1)
+    assertThat(idMapB.size).isEqualTo(1)
+
+    directStoreMuxer.off(callbackId1)
+
+    assertThat(idMapA.size).isEqualTo(0)
+    assertThat(idMapB.size).isEqualTo(0)
+
+    assertFailsWith<IllegalStateException>(
+      "Callback id is not registered to the Direct Store Muxer."
+    ) { directStoreMuxer.getLocalData("a", callbackId1) }
+
+    assertFailsWith<IllegalStateException>(
+      "Callback id is not registered to the Direct Store Muxer."
+    ) { directStoreMuxer.getLocalData("b", callbackId1) }
+  }
+
+  // region Helpers
+
+  private fun createDirectStoreMuxer(
+    scope: CoroutineScope
+  ): DirectStoreMuxerImpl<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity> {
+    return DirectStoreMuxerImpl(
+      storageKey,
+      backingType = EntityType(schema),
+      scope = scope,
+      driverFactory = driverFactory,
+      writeBackProvider = ::testWriteBackProvider,
+      devTools = null
+    )
+  }
+
+  private fun DirectStoreMuxer<CrdtEntity.Data, CrdtEntity.Operation, CrdtEntity>.getEntityDriver(
+    id: ReferenceId
+  ): MockDriver<CrdtEntity.Data> =
+    requireNotNull(stores[id]).store.driver as MockDriver<CrdtEntity.Data>
+
+  private fun createPersonEntityCrdt(name: String, age: Int): CrdtEntity = CrdtEntity(
+    CrdtEntity.Data(
+      versionMap = VersionMap("me" to 1),
+      singletons = mapOf(
+        "name" to CrdtSingleton(
+          initialVersion = VersionMap("me" to 1),
+          initialData = CrdtEntity.Reference.buildReference(name.toReferencable())
+        ),
+        "age" to CrdtSingleton(
+          initialVersion = VersionMap("me" to 1),
+          initialData = CrdtEntity.Reference.buildReference(age.toReferencable())
+        )
+      )
+    )
+  )
+
+  // endregion
 }

--- a/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
+++ b/javatests/arcs/core/storage/RamDiskDirectStoreMuxerIntegrationTest.kt
@@ -61,6 +61,7 @@ class RamDiskDirectStoreMuxerIntegrationTest {
     var job = Job()
 
     val storageKey = RamDiskStorageKey("unique")
+    var callbackId = 0
     val store = DirectStoreMuxerImpl<CrdtData, CrdtOperationAtTime, Any?>(
       storageKey = storageKey,
       backingType = CountType(),
@@ -69,7 +70,7 @@ class RamDiskDirectStoreMuxerIntegrationTest {
       writeBackProvider = ::testWriteBackProvider,
       devTools = null
     ).also {
-      it.on { muxedProxyMessage ->
+      callbackId = it.on { muxedProxyMessage ->
         message.value = muxedProxyMessage.message
           as ProxyMessage<CrdtCount.Data, CrdtCount.Operation, Int>
         muxId.value = muxedProxyMessage.muxId
@@ -86,13 +87,13 @@ class RamDiskDirectStoreMuxerIntegrationTest {
     store.onProxyMessage(
       MuxedProxyMessage<CrdtData, CrdtOperationAtTime, Any?>(
         "thing0",
-        ProxyMessage.ModelUpdate(count1.data, null)
+        ProxyMessage.ModelUpdate(count1.data, callbackId)
       )
     )
     store.onProxyMessage(
       MuxedProxyMessage<CrdtData, CrdtOperationAtTime, Any?>(
         "thing1",
-        ProxyMessage.ModelUpdate(count2.data, null)
+        ProxyMessage.ModelUpdate(count2.data, callbackId)
       )
     )
 
@@ -101,7 +102,7 @@ class RamDiskDirectStoreMuxerIntegrationTest {
     store.onProxyMessage(
       MuxedProxyMessage(
         "thing0",
-        ProxyMessage.SyncRequest(null)
+        ProxyMessage.SyncRequest(callbackId)
       )
     )
     job.join()
@@ -114,7 +115,7 @@ class RamDiskDirectStoreMuxerIntegrationTest {
     store.onProxyMessage(
       MuxedProxyMessage(
         "thing1",
-        ProxyMessage.SyncRequest(null)
+        ProxyMessage.SyncRequest(callbackId)
       )
     )
     job.join()
@@ -127,7 +128,7 @@ class RamDiskDirectStoreMuxerIntegrationTest {
     store.onProxyMessage(
       MuxedProxyMessage(
         "not-a-thing",
-        ProxyMessage.SyncRequest(null)
+        ProxyMessage.SyncRequest(callbackId)
       )
     )
     job.join()

--- a/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
+++ b/javatests/arcs/core/storage/ReferenceModeStoreTest.kt
@@ -29,12 +29,12 @@ import arcs.core.storage.referencemode.RefModeStoreData
 import arcs.core.storage.referencemode.RefModeStoreOp
 import arcs.core.storage.referencemode.RefModeStoreOutput
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
+import arcs.core.storage.testutil.MockDriver
+import arcs.core.storage.testutil.MockDriverProvider
 import arcs.core.storage.testutil.testWriteBackProvider
 import arcs.core.testutil.assertSuspendingThrows
-import arcs.core.type.Type
 import arcs.core.util.testutil.LogRule
 import com.google.common.truth.Truth.assertThat
-import kotlin.reflect.KClass
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -424,7 +424,7 @@ class ReferenceModeStoreTest {
       .onProxyMessage(
         MuxedProxyMessage(
           "an-id",
-          ProxyMessage.ModelUpdate(bobCrdt.data, id = 1)
+          ProxyMessage.ModelUpdate(bobCrdt.data, id = activeStore.backingStoreId)
         )
       )
 
@@ -632,7 +632,7 @@ class ReferenceModeStoreTest {
       )
     )
 
-    val backingStore = activeStore.backingStore.stores.getValue("an-id")
+    val backingStore = activeStore.backingStore.getStore("an-id", activeStore.backingStoreId)
     backingStore.store.onReceive(entityCrdt.data, id + 2)
 
     activeStore.idle()
@@ -828,43 +828,6 @@ class ReferenceModeStoreTest {
 
     override fun childKeyWithComponent(component: String): StorageKey =
       MockHierarchicalStorageKey("$segment$component")
-  }
-
-  private class MockDriverProvider : DriverProvider {
-    override fun willSupport(storageKey: StorageKey): Boolean = true
-
-    override suspend fun <Data : Any> getDriver(
-      storageKey: StorageKey,
-      dataClass: KClass<Data>,
-      type: Type
-    ): Driver<Data> = MockDriver(storageKey)
-
-    override suspend fun removeAllEntities() = Unit
-
-    override suspend fun removeEntitiesCreatedBetween(startTimeMillis: Long, endTimeMillis: Long) =
-      Unit
-  }
-
-  private class MockDriver<T : Any>(
-    override val storageKey: StorageKey
-  ) : Driver<T> {
-    override var token: String? = null
-    var receiver: (suspend (data: T, version: Int) -> Unit)? = null
-    var sentData = mutableListOf<T>()
-    var fail = false
-
-    override suspend fun registerReceiver(
-      token: String?,
-      receiver: suspend (data: T, version: Int) -> Unit
-    ) {
-      this.token = token
-      this.receiver = receiver
-    }
-
-    override suspend fun send(data: T, version: Int): Boolean {
-      sentData.add(data)
-      return !fail
-    }
   }
 
   // endregion


### PR DESCRIPTION
Accomodate for several observers listening to a Direct Store Muxer. This is in preparation for the introduction of Storage Proxy Muxers. The Direct Store Muxer must be able to facilitate message passing between several Storage Proxy Muxers and Direct Stores. The message passing modifications must maintain compatibility with the existing usage of the DSM in the Reference Mode Store.

- StoreRecord maintains a bidirectional map of callbackIds (observer-to-DSM-callbackIds : DSM-to-directStore-callbackIds)

- `callbackIdToMuxIdMap` in the DirectStoreMuxer keeps track of all the muxId's a particular "observer-to-DSM" callbackId has a connection with. This is used when deregistering a callback.

- `stateMutex` in the DirectStoreMuxer is used whenever the DirectStoreMuxers mutable state is accessed/modified.

- In the DirectStoreMuxer, separate setUpStore and registerToStore, allowing multiple callbacks to be registered to the same store.