### PR TITLE
Add test for DevToolsService.onMessageCallback()

### DIFF
--- a/java/arcs/android/devtools/AndroidManifest.xml
+++ b/java/arcs/android/devtools/AndroidManifest.xml
@@ -12,5 +12,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="arcs.android">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="28" android:targetSdkVersion="29"/>
 </manifest>

--- a/java/arcs/android/devtools/BUILD
+++ b/java/arcs/android/devtools/BUILD
@@ -33,6 +33,7 @@ arcs_kt_android_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/util",
         "//java/arcs/sdk/android/storage/service",
+        "//third_party/java/androidx/annotation",
         "//third_party/java/nanohttpd",
         "//third_party/java/nanohttpd:nanohttpd_websocket",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/android/devtools/DevWebServer.kt
+++ b/java/arcs/android/devtools/DevWebServer.kt
@@ -17,9 +17,12 @@ package arcs.android.devtools
 interface DevWebServer {
 
   /**
-   * Send a string to the client.
+   * Send a string to all the clients.
    */
   fun send(msg: String)
 
+  /**
+   * Send a string to a single client/websocket.
+   */
   fun send(msg: String, socket: DevWebServerImpl.WsdSocket)
 }

--- a/java/arcs/android/devtools/DevWebServerImpl.kt
+++ b/java/arcs/android/devtools/DevWebServerImpl.kt
@@ -29,7 +29,7 @@ object DevWebServerImpl : DevWebServer, NanoWSD("localhost", 33317) {
   private val onMessageCallbacks = mutableSetOf<(String, WsdSocket) -> Unit>()
 
   /**
-   * Send a string to the client.
+   * Send a string to all the clients.
    */
   override fun send(msg: String) {
     wsdSockets.forEach { socket ->
@@ -38,7 +38,7 @@ object DevWebServerImpl : DevWebServer, NanoWSD("localhost", 33317) {
   }
 
   /**
-   * Send a string to the client.
+   * Send a string to a single client/websocket.
    */
   override fun send(msg: String, socket: WsdSocket) {
     socket.send(msg)
@@ -78,7 +78,7 @@ object DevWebServerImpl : DevWebServer, NanoWSD("localhost", 33317) {
   }
 
   // TODO: This is a WIP for DevTools, still in flux.
-  class WsdSocket(
+  open class WsdSocket(
     handshakeRequest: NanoHTTPD.IHTTPSession?,
     val log: TaggedLog,
     val removeCallback: (WsdSocket) -> Unit

--- a/javatests/arcs/android/devtools/AndroidManifest.xml
+++ b/javatests/arcs/android/devtools/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2020 Google LLC.
+  ~
+  ~ This code may only be used under the BSD style license found at
+  ~ http://polymer.github.io/LICENSE.txt
+  ~
+  ~ Code distributed by Google as part of this project is also subject to an additional IP rights
+  ~ grant found at
+  ~ http://polymer.github.io/PATENTS.txt
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="arcs.android">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-sdk android:minSdkVersion="28" android:targetSdkVersion="28"/>
+</manifest>

--- a/javatests/arcs/android/devtools/BUILD
+++ b/javatests/arcs/android/devtools/BUILD
@@ -10,7 +10,11 @@ package(default_visibility = ["//java/arcs:allowed-packages"])
 
 arcs_kt_jvm_test_suite(
     name = "devtools",
-    srcs = ["DevToolsMessageTests.kt"],
+    srcs = [
+        "JsonEncodingsTest.kt",
+        "ModelUpdateMessageTest.kt",
+        "StoreOperationMessageTest.kt",
+    ],
     package = "arcs.android.devtools",
     deps = [
         "//java/arcs/android/devtools",
@@ -22,8 +26,6 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/storage:reference",
         "//java/arcs/core/storage/testutil",
         "//java/arcs/core/util",
-        "//third_party/java/junit:junit-android",
-        "//third_party/java/truth:truth-android",
         "//java/arcs/sdk/android/storage/service",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",
@@ -49,7 +51,6 @@ arcs_kt_android_test_suite(
         "//java/arcs/android/common/resurrection",
         "//java/arcs/android/devtools",
         "//java/arcs/android/devtools:aidl",
-        "//java/arcs/android/devtools/storage:devtools",
         "//java/arcs/android/storage",
         "//java/arcs/android/storage/service",
         "//java/arcs/android/storage/service:aidl",
@@ -59,6 +60,7 @@ arcs_kt_android_test_suite(
         "//java/arcs/core/storage/keys",
         "//java/arcs/core/testutil",
         "//java/arcs/sdk/android/storage",
+        "//java/arcs/sdk/android/storage/service",
         "//third_party/android/androidx_test/core",
         "//third_party/android/androidx_test/ext/junit",
         "//third_party/android/androidx_test/runner/rules",

--- a/javatests/arcs/android/devtools/BUILD
+++ b/javatests/arcs/android/devtools/BUILD
@@ -1,5 +1,6 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
+    "arcs_kt_android_test_suite",
     "arcs_kt_jvm_test_suite",
 )
 
@@ -8,8 +9,8 @@ licenses(["notice"])
 package(default_visibility = ["//java/arcs:allowed-packages"])
 
 arcs_kt_jvm_test_suite(
-    name = "store-message",
-    srcs = glob(["*Test.kt"]),
+    name = "devtools",
+    srcs = ["DevToolsMessageTests.kt"],
     package = "arcs.android.devtools",
     deps = [
         "//java/arcs/android/devtools",
@@ -23,5 +24,48 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/core/util",
         "//third_party/java/junit:junit-android",
         "//third_party/java/truth:truth-android",
+        "//java/arcs/sdk/android/storage/service",
+        "//third_party/android/androidx_test/core",
+        "//third_party/android/androidx_test/ext/junit",
+        "//third_party/android/androidx_test/runner/rules",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/mockito:mockito-android",
+        "//third_party/java/nanohttpd",
+        "//third_party/java/nanohttpd:nanohttpd_websocket",
+        "//third_party/java/robolectric",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
+        "//third_party/kotlin/mockito_kotlin:mockito_kotlin-android",
+    ],
+)
+
+arcs_kt_android_test_suite(
+    name = "devtoolsservice",
+    srcs = ["DevToolsTests.kt"],
+    manifest = "AndroidManifest.xml",
+    package = "arcs.android.devtools",
+    deps = [
+        "//java/arcs/android/common/resurrection",
+        "//java/arcs/android/devtools",
+        "//java/arcs/android/devtools:aidl",
+        "//java/arcs/android/devtools/storage:devtools",
+        "//java/arcs/android/storage",
+        "//java/arcs/android/storage/service",
+        "//java/arcs/android/storage/service:aidl",
+        "//java/arcs/core/storage:storage_key",
+        "//java/arcs/core/storage/driver:driver_providers",
+        "//java/arcs/core/storage/driver:ramdisk",
+        "//java/arcs/core/storage/keys",
+        "//java/arcs/core/testutil",
+        "//java/arcs/sdk/android/storage",
+        "//third_party/android/androidx_test/core",
+        "//third_party/android/androidx_test/ext/junit",
+        "//third_party/android/androidx_test/runner/rules",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/mockito:mockito-android",
+        "//third_party/java/robolectric",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/javatests/arcs/android/devtools/DevToolsTests.kt
+++ b/javatests/arcs/android/devtools/DevToolsTests.kt
@@ -17,10 +17,10 @@ import android.os.Bundle
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.sdk.android.storage.service.StorageService
-import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
@@ -32,8 +32,6 @@ class DevToolsTests {
 
   @Test
   fun testDevToolsServiceOnMessageCallback() {
-    assertThat(true)
-
     val devToolsIntent = Intent(
       ApplicationProvider.getApplicationContext<Context>(),
       DevToolsService::class.java
@@ -48,7 +46,7 @@ class DevToolsTests {
     session2.open
     val message = "{\"type\":\"request\", \"message\":\"storageKeys\"}"
     devTools.onMessageCallback(message, session1)
-    verify(session1, times(1)).send("")
-    verify(session2, times(0)).send("")
+    verify(session1).send("")
+    verify(session2, never()).send("")
   }
 }

--- a/javatests/arcs/android/devtools/DevToolsTests.kt
+++ b/javatests/arcs/android/devtools/DevToolsTests.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.devtools
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.sdk.android.storage.service.StorageService
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class DevToolsTests {
+
+  val session1 = mock(DevWebServerImpl.WsdSocket::class.java)
+  val session2 = mock(DevWebServerImpl.WsdSocket::class.java)
+
+  @Test
+  fun testDevToolsServiceOnMessageCallback() {
+    assertThat(true)
+
+    val devToolsIntent = Intent(
+      ApplicationProvider.getApplicationContext<Context>(),
+      DevToolsService::class.java
+    )
+    val bundle = Bundle()
+    bundle.putSerializable(DevToolsService.STORAGE_CLASS, StorageService::class.java)
+
+    devToolsIntent.putExtras(bundle)
+
+    val devTools = DevToolsService()
+    session1.open
+    session2.open
+    val message = "{\"type\":\"request\", \"message\":\"storageKeys\"}"
+    devTools.onMessageCallback(message, session1)
+    verify(session1, times(1)).send("")
+    verify(session2, times(0)).send("")
+  }
+}


### PR DESCRIPTION
Add a test for DevToolsService.onMessageCallback(). Slight refactor included to make the test easier.

Also note the update to DevTools only requiring Android Version 28 to allow tests to pass.

cc: @piotrswigon 