### PR TITLE
Rename 'clock' to 'versionMap' in Kotlin.

### DIFF
--- a/java/arcs/android/crdt/CrdtEntityProto.kt
+++ b/java/arcs/android/crdt/CrdtEntityProto.kt
@@ -27,7 +27,7 @@ fun CrdtEntityProto.Operation.toOperation(): CrdtEntity.Operation =
     CrdtEntityProto.Operation.OperationCase.SET_SINGLETON -> with(setSingleton) {
       CrdtEntity.Operation.SetSingleton(
         actor = actor,
-        clock = fromProto(versionMap),
+        versionMap = fromProto(versionMap),
         field = field,
         value = value.toCrdtEntityReference()
       )
@@ -35,14 +35,14 @@ fun CrdtEntityProto.Operation.toOperation(): CrdtEntity.Operation =
     CrdtEntityProto.Operation.OperationCase.CLEAR_SINGLETON -> with(clearSingleton) {
       CrdtEntity.Operation.ClearSingleton(
         actor = actor,
-        clock = fromProto(versionMap),
+        versionMap = fromProto(versionMap),
         field = field
       )
     }
     CrdtEntityProto.Operation.OperationCase.ADD_TO_SET -> with(addToSet) {
       CrdtEntity.Operation.AddToSet(
         actor = actor,
-        clock = fromProto(versionMap),
+        versionMap = fromProto(versionMap),
         field = field,
         added = added.toCrdtEntityReference()
       )
@@ -50,7 +50,7 @@ fun CrdtEntityProto.Operation.toOperation(): CrdtEntity.Operation =
     CrdtEntityProto.Operation.OperationCase.REMOVE_FROM_SET -> with(removeFromSet) {
       CrdtEntity.Operation.RemoveFromSet(
         actor = actor,
-        clock = fromProto(versionMap),
+        versionMap = fromProto(versionMap),
         field = field,
         removed = removed
       )
@@ -58,7 +58,7 @@ fun CrdtEntityProto.Operation.toOperation(): CrdtEntity.Operation =
     CrdtEntityProto.Operation.OperationCase.CLEAR_ALL -> with(clearAll) {
       CrdtEntity.Operation.ClearAll(
         actor = actor,
-        clock = fromProto(versionMap)
+        versionMap = fromProto(versionMap)
       )
     }
     CrdtEntityProto.Operation.OperationCase.OPERATION_NOT_SET, null ->
@@ -83,7 +83,7 @@ fun CrdtEntity.Operation.toProto(): CrdtEntityProto.Operation {
   when (this) {
     is CrdtEntity.Operation.SetSingleton -> {
       proto.setSingleton = CrdtEntityProto.Operation.SetSingleton.newBuilder()
-        .setVersionMap(clock.toProto())
+        .setVersionMap(versionMap.toProto())
         .setActor(actor)
         .setField(field)
         .setValue(value.toProto())
@@ -91,14 +91,14 @@ fun CrdtEntity.Operation.toProto(): CrdtEntityProto.Operation {
     }
     is CrdtEntity.Operation.ClearSingleton -> {
       proto.clearSingleton = CrdtEntityProto.Operation.ClearSingleton.newBuilder()
-        .setVersionMap(clock.toProto())
+        .setVersionMap(versionMap.toProto())
         .setActor(actor)
         .setField(field)
         .build()
     }
     is CrdtEntity.Operation.AddToSet -> {
       proto.addToSet = CrdtEntityProto.Operation.AddToSet.newBuilder()
-        .setVersionMap(clock.toProto())
+        .setVersionMap(versionMap.toProto())
         .setActor(actor)
         .setField(field)
         .setAdded(added.toProto())
@@ -106,7 +106,7 @@ fun CrdtEntity.Operation.toProto(): CrdtEntityProto.Operation {
     }
     is CrdtEntity.Operation.RemoveFromSet -> {
       proto.removeFromSet = CrdtEntityProto.Operation.RemoveFromSet.newBuilder()
-        .setVersionMap(clock.toProto())
+        .setVersionMap(versionMap.toProto())
         .setActor(actor)
         .setField(field)
         .setRemoved(removed)
@@ -114,7 +114,7 @@ fun CrdtEntity.Operation.toProto(): CrdtEntityProto.Operation {
     }
     is CrdtEntity.Operation.ClearAll -> {
       proto.clearAll = CrdtEntityProto.Operation.ClearAll.newBuilder()
-        .setVersionMap(clock.toProto())
+        .setVersionMap(versionMap.toProto())
         .setActor(actor)
         .build()
     }

--- a/java/arcs/android/crdt/CrdtSetProto.kt
+++ b/java/arcs/android/crdt/CrdtSetProto.kt
@@ -22,27 +22,27 @@ fun CrdtSetProto.Operation.toOperation(): CrdtSet.Operation<Referencable> = when
   CrdtSetProto.Operation.OperationCase.ADD -> with(add) {
     CrdtSet.Operation.Add(
       actor = actor,
-      clock = fromProto(versionMap),
+      versionMap = fromProto(versionMap),
       added = added.toReferencable()!!
     )
   }
   CrdtSetProto.Operation.OperationCase.REMOVE -> with(remove) {
     CrdtSet.Operation.Remove<Referencable>(
       actor = actor,
-      clock = fromProto(versionMap),
+      versionMap = fromProto(versionMap),
       removed = removed
     )
   }
   CrdtSetProto.Operation.OperationCase.CLEAR -> with(clear) {
     CrdtSet.Operation.Clear<Referencable>(
       actor = actor,
-      clock = fromProto(versionMap)
+      versionMap = fromProto(versionMap)
     )
   }
   CrdtSetProto.Operation.OperationCase.FAST_FORWARD -> with(fastForward) {
     CrdtSet.Operation.FastForward<Referencable>(
-      oldClock = fromProto(oldVersionMap),
-      newClock = fromProto(newVersionMap),
+      oldVersionMap = fromProto(oldVersionMap),
+      newVersionMap = fromProto(newVersionMap),
       added = addedList.mapTo(mutableListOf()) { it.toDataValue() },
       removed = removedList.mapTo(mutableListOf()) { it.toReferencable()!! }
     )
@@ -77,29 +77,29 @@ fun CrdtSet.Operation<*>.toProto(): CrdtSetProto.Operation {
 
 /** Serializes a [CrdtSet.Operation.Add] to its proto form. */
 private fun CrdtSet.Operation.Add<*>.toProto() = CrdtSetProto.Operation.Add.newBuilder()
-  .setVersionMap(clock.toProto())
+  .setVersionMap(versionMap.toProto())
   .setActor(actor)
   .setAdded(added.toProto())
   .build()
 
 /** Serializes a [CrdtSet.Operation.Remove] to its proto form. */
 private fun CrdtSet.Operation.Remove<*>.toProto() = CrdtSetProto.Operation.Remove.newBuilder()
-  .setVersionMap(clock.toProto())
+  .setVersionMap(versionMap.toProto())
   .setActor(actor)
   .setRemoved(removed)
   .build()
 
 /** Serializes a [CrdtSet.Operation.Clear] to its proto form. */
 private fun CrdtSet.Operation.Clear<*>.toProto() = CrdtSetProto.Operation.Clear.newBuilder()
-  .setVersionMap(clock.toProto())
+  .setVersionMap(versionMap.toProto())
   .setActor(actor)
   .build()
 
 /** Serializes a [CrdtSet.Operation.FastForward] to its proto form. */
 private fun CrdtSet.Operation.FastForward<*>.toProto() =
   CrdtSetProto.Operation.FastForward.newBuilder()
-    .setOldVersionMap(oldClock.toProto())
-    .setNewVersionMap(newClock.toProto())
+    .setOldVersionMap(oldVersionMap.toProto())
+    .setNewVersionMap(newVersionMap.toProto())
     .addAllAdded(added.map { it.toProto() })
     .addAllRemoved(removed.map { it.toProto() })
     .build()

--- a/java/arcs/android/crdt/CrdtSingletonProto.kt
+++ b/java/arcs/android/crdt/CrdtSingletonProto.kt
@@ -17,14 +17,14 @@ fun CrdtSingletonProto.Operation.toOperation(): CrdtSingleton.Operation<Referenc
     CrdtSingletonProto.Operation.OperationCase.UPDATE -> with(update) {
       CrdtSingleton.Operation.Update<Referencable>(
         actor = actor,
-        clock = fromProto(versionMap),
+        versionMap = fromProto(versionMap),
         value = value.toReferencable()!!
       )
     }
     CrdtSingletonProto.Operation.OperationCase.CLEAR -> with(clear) {
       CrdtSingleton.Operation.Clear<Referencable>(
         actor = actor,
-        clock = fromProto(versionMap)
+        versionMap = fromProto(versionMap)
       )
     }
     CrdtSingletonProto.Operation.OperationCase.OPERATION_NOT_SET, null ->
@@ -52,7 +52,7 @@ fun CrdtSingleton.Operation<*>.toProto(): CrdtSingletonProto.Operation {
 /** Serializes a [CrdtSingleton.Operation.Update] to its proto form. */
 private fun CrdtSingleton.Operation.Update<*>.toProto() =
   CrdtSingletonProto.Operation.Update.newBuilder()
-    .setVersionMap(clock.toProto())
+    .setVersionMap(versionMap.toProto())
     .setActor(actor)
     .setValue(value.toProto())
     .build()
@@ -60,7 +60,7 @@ private fun CrdtSingleton.Operation.Update<*>.toProto() =
 /** Serializes a [CrdtSingleton.Operation.Clear] to its proto form. */
 private fun CrdtSingleton.Operation.Clear<*>.toProto() =
   CrdtSingletonProto.Operation.Clear.newBuilder()
-    .setVersionMap(clock.toProto())
+    .setVersionMap(versionMap.toProto())
     .setActor(actor)
     .build()
 

--- a/java/arcs/android/devtools/DevToolsMessage.kt
+++ b/java/arcs/android/devtools/DevToolsMessage.kt
@@ -81,11 +81,8 @@ interface DevToolsMessage {
     /** Json Key for the values removed in a [CrdtOperation]. */
     const val REMOVED = "removed"
 
-    /** Json Key for the old clock in a [FastForward] operation. */
-    const val OLD_CLOCK = "oldClock"
-
-    /** Json Key for the clock in a [CrdtOperation]. */
-    const val CLOCK = "clock"
+    /** Json Key for the old versionMap in a [FastForward] operation. */
+    const val OLD_VERSIONMAP = "oldVersionMap"
 
     /** Json key for the versionmap. */
     const val VERSIONMAP = "versionMap"

--- a/java/arcs/android/devtools/StoreMessage.kt
+++ b/java/arcs/android/devtools/StoreMessage.kt
@@ -14,7 +14,7 @@ import arcs.core.util.JsonValue
 interface StoreMessage : DevToolsMessage {
 
   /**
-   * Turn the clock [VersionMap] into a [JsonValue.JsonObject].
+   * Turn the [VersionMap] into a [JsonValue.JsonObject].
    */
   fun VersionMap.toJson() = JsonValue.JsonObject(
     actors.map { it to JsonValue.JsonNumber(this[it].toDouble()) }.toMap()

--- a/java/arcs/android/devtools/StoreOperationMessage.kt
+++ b/java/arcs/android/devtools/StoreOperationMessage.kt
@@ -5,9 +5,8 @@ import arcs.android.devtools.DevToolsMessage.Companion.ADDED
 import arcs.android.devtools.DevToolsMessage.Companion.ADD_TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.CLEAR_ALL_TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.CLEAR_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.CLOCK
 import arcs.android.devtools.DevToolsMessage.Companion.FAST_FORWARD_TYPE
-import arcs.android.devtools.DevToolsMessage.Companion.OLD_CLOCK
+import arcs.android.devtools.DevToolsMessage.Companion.OLD_VERSIONMAP
 import arcs.android.devtools.DevToolsMessage.Companion.OPERATIONS
 import arcs.android.devtools.DevToolsMessage.Companion.REMOVED
 import arcs.android.devtools.DevToolsMessage.Companion.REMOVE_TYPE
@@ -18,6 +17,7 @@ import arcs.android.devtools.DevToolsMessage.Companion.STORE_TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.UPDATE_TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.VALUE
+import arcs.android.devtools.DevToolsMessage.Companion.VERSIONMAP
 import arcs.core.common.Referencable
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtEntity
@@ -57,14 +57,14 @@ class StoreOperationMessage(
               TYPE to JsonValue.JsonString(UPDATE_TYPE),
               VALUE to op.value.toJson(),
               ACTOR to JsonValue.JsonString(op.actor),
-              CLOCK to op.clock.toJson()
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           is CrdtSingleton.Operation.Clear<*> -> {
             JsonValue.JsonObject(
               TYPE to JsonValue.JsonString(CLEAR_TYPE),
               ACTOR to JsonValue.JsonString(op.actor),
-              CLOCK to op.clock.toJson()
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           is CrdtSet.Operation.Add<*> -> {
@@ -72,14 +72,14 @@ class StoreOperationMessage(
               TYPE to JsonValue.JsonString(ADD_TYPE),
               ADDED to op.added.toJson(),
               ACTOR to JsonValue.JsonString(op.actor),
-              CLOCK to op.clock.toJson()
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           is CrdtSet.Operation.Clear<*> -> {
             JsonValue.JsonObject(
               TYPE to JsonValue.JsonString(CLEAR_TYPE),
               ACTOR to JsonValue.JsonString(op.actor),
-              CLOCK to op.clock.toJson()
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           is CrdtSet.Operation.Remove<*> -> {
@@ -87,7 +87,7 @@ class StoreOperationMessage(
               TYPE to JsonValue.JsonString(REMOVE_TYPE),
               REMOVED to JsonValue.JsonString(op.removed),
               ACTOR to JsonValue.JsonString(op.actor),
-              CLOCK to op.clock.toJson()
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           is CrdtSet.Operation.FastForward<*> -> {
@@ -95,15 +95,15 @@ class StoreOperationMessage(
               TYPE to JsonValue.JsonString(FAST_FORWARD_TYPE),
               ADDED to getAddedListValue(op.added),
               REMOVED to getRemovedListValue(op.removed),
-              OLD_CLOCK to JsonValue.JsonString(op.oldClock.toString()),
-              CLOCK to op.clock.toJson()
+              OLD_VERSIONMAP to JsonValue.JsonString(op.oldVersionMap.toString()),
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           is CrdtEntity.Operation.ClearAll -> {
             JsonValue.JsonObject(
               TYPE to JsonValue.JsonString(CLEAR_ALL_TYPE),
               ACTOR to JsonValue.JsonString(op.actor),
-              CLOCK to op.clock.toJson()
+              VERSIONMAP to op.versionMap.toJson()
             )
           }
           else -> JsonValue.JsonString(op.toString())

--- a/java/arcs/core/crdt/CrdtModel.kt
+++ b/java/arcs/core/crdt/CrdtModel.kt
@@ -95,7 +95,7 @@ interface CrdtOperationAtTime : CrdtOperation {
    * **Note:** Be sure this is a *copy* of the owning [CrdtData]'s [VersionMap] so it doesn't
    * change out from under the operation when the model changes.
    */
-  val clock: VersionMap
+  val versionMap: VersionMap
 }
 
 /** Changes applied to both sides of a call to [CrdtModel.merge]. */

--- a/java/arcs/core/crdt/CrdtSingleton.kt
+++ b/java/arcs/core/crdt/CrdtSingleton.kt
@@ -147,48 +147,48 @@ class CrdtSingleton<T : Referencable>(
 
   sealed class Operation<T : Referencable>(
     override val actor: Actor,
-    override val clock: VersionMap
+    override val versionMap: VersionMap
   ) : IOperation<T> {
     /** An [Operation] to update the value stored by the [CrdtSingleton]. */
     open class Update<T : Referencable>(
       override val actor: Actor,
-      override val clock: VersionMap,
+      override val versionMap: VersionMap,
       val value: T
-    ) : Operation<T>(actor, clock) {
+    ) : Operation<T>(actor, versionMap) {
       override fun applyTo(set: CrdtSet<T>): Boolean {
         // Remove does not require an increment, but the caller of this method will have
         // incremented its version, so we hack a version with t-1 for this actor.
-        val removeClock = VersionMap(clock)
-        removeClock[actor]--
+        val removeVersionMap = VersionMap(versionMap)
+        removeVersionMap[actor]--
 
         // If we can't remove all existing values, we can't update the value.
-        if (!Clear<T>(actor, removeClock).applyTo(set)) return false
+        if (!Clear<T>(actor, removeVersionMap).applyTo(set)) return false
 
         // After removal of all existing values, we simply need to add the new value.
-        return set.applyOperation(Add(actor, clock, value))
+        return set.applyOperation(Add(actor, versionMap, value))
       }
 
       override fun equals(other: Any?): Boolean =
         other is Update<*> &&
-          other.clock == clock &&
+          other.versionMap == versionMap &&
           other.actor == actor &&
           other.value == value
 
       override fun hashCode(): Int = toString().hashCode()
 
       override fun toString(): String =
-        "CrdtSingleton.Operation.Update($clock, $actor, $value)"
+        "CrdtSingleton.Operation.Update($versionMap, $actor, $value)"
     }
 
     /** An [Operation] to clear the value stored by the [CrdtSingleton]. */
     open class Clear<T : Referencable>(
       override val actor: Actor,
-      override val clock: VersionMap
-    ) : Operation<T>(actor, clock) {
+      override val versionMap: VersionMap
+    ) : Operation<T>(actor, versionMap) {
       override fun applyTo(set: CrdtSet<T>): Boolean {
-        // Clear all existing values if our clock allows it.
+        // Clear all existing values if our versionMap allows it.
 
-        val removeOps = set.data.values.map { (id, _) -> Remove<T>(actor, clock, id) }
+        val removeOps = set.data.values.map { (id, _) -> Remove<T>(actor, versionMap, id) }
 
         removeOps.forEach { set.applyOperation(it) }
         return true
@@ -196,12 +196,12 @@ class CrdtSingleton<T : Referencable>(
 
       override fun equals(other: Any?): Boolean =
         other is Clear<*> &&
-          other.clock == clock &&
+          other.versionMap == versionMap &&
           other.actor == actor
 
       override fun hashCode(): Int = toString().hashCode()
 
-      override fun toString(): String = "CrdtSingleton.Operation.Clear($clock, $actor)"
+      override fun toString(): String = "CrdtSingleton.Operation.Clear($versionMap, $actor)"
     }
   }
 

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -345,9 +345,9 @@ class ReferenceModeStore private constructor(
     when (proxyMessage) {
       is ProxyMessage.ModelUpdate ->
         holdQueue.processReferenceId(muxId, proxyMessage.model.versionMap)
-      // TODO(b/161912425) Verify the clock checking logic here.
+      // TODO(b/161912425) Verify the versionMap checking logic here.
       is ProxyMessage.Operations -> if (proxyMessage.operations.isNotEmpty()) {
-        holdQueue.processReferenceId(muxId, proxyMessage.operations.last().clock)
+        holdQueue.processReferenceId(muxId, proxyMessage.operations.last().versionMap)
       }
       is ProxyMessage.SyncRequest ->
         throw IllegalArgumentException("Unexpected SyncRequest from the backing store")

--- a/java/arcs/core/storage/StorageProxy.kt
+++ b/java/arcs/core/storage/StorageProxy.kt
@@ -484,7 +484,7 @@ open class StorageProxy<Data : CrdtData, Op : CrdtOperationAtTime, T> private co
   private fun applyPostSyncModelOps() {
     if (modelOpsToApplyAfterSyncing.isEmpty()) return
 
-    val ops = modelOpsToApplyAfterSyncing.filter { it.clock.dominates(crdt.versionMap) }
+    val ops = modelOpsToApplyAfterSyncing.filter { it.versionMap.dominates(crdt.versionMap) }
     modelOpsToApplyAfterSyncing.clear()
     processModelOps(ops)
   }

--- a/java/arcs/core/storage/referencemode/Message.kt
+++ b/java/arcs/core/storage/referencemode/Message.kt
@@ -37,15 +37,15 @@ private fun List<CrdtOperation>.toReferenceModeMessageOps(): List<CrdtOperationA
   return this.map { op ->
     when (op) {
       is CrdtSingleton.Operation.Update<*> ->
-        CrdtSingleton.Operation.Update(op.actor, op.clock, op.value)
+        CrdtSingleton.Operation.Update(op.actor, op.versionMap, op.value)
       is CrdtSingleton.Operation.Clear<*> ->
-        CrdtSingleton.Operation.Clear<Referencable>(op.actor, op.clock)
+        CrdtSingleton.Operation.Clear<Referencable>(op.actor, op.versionMap)
       is CrdtSet.Operation.Add<*> ->
-        CrdtSet.Operation.Add(op.actor, op.clock, op.added)
+        CrdtSet.Operation.Add(op.actor, op.versionMap, op.added)
       is CrdtSet.Operation.Remove<*> ->
-        CrdtSet.Operation.Remove<Referencable>(op.actor, op.clock, op.removed)
+        CrdtSet.Operation.Remove<Referencable>(op.actor, op.versionMap, op.removed)
       is CrdtSet.Operation.Clear<*> ->
-        CrdtSet.Operation.Clear<Referencable>(op.actor, op.clock)
+        CrdtSet.Operation.Clear<Referencable>(op.actor, op.versionMap)
       else -> throw CrdtException("Unsupported operation for ReferenceModeStore: $this")
     }
   }

--- a/java/arcs/core/storage/referencemode/RefModeCrdtTypes.kt
+++ b/java/arcs/core/storage/referencemode/RefModeCrdtTypes.kt
@@ -85,43 +85,43 @@ sealed class RefModeStoreData : CrdtData {
 interface RefModeStoreOp : CrdtOperationAtTime {
   interface Singleton : RefModeStoreOp, CrdtSingleton.IOperation<RawEntity>
 
-  class SingletonUpdate(actor: Actor, clock: VersionMap, value: RawEntity) :
+  class SingletonUpdate(actor: Actor, versionMap: VersionMap, value: RawEntity) :
     Singleton,
     RefModeSingleton,
-    CrdtSingleton.Operation.Update<RawEntity>(actor, clock, value) {
+    CrdtSingleton.Operation.Update<RawEntity>(actor, versionMap, value) {
     constructor(
       singletonOp: Update<RawEntity>
-    ) : this(singletonOp.actor, singletonOp.clock, singletonOp.value)
+    ) : this(singletonOp.actor, singletonOp.versionMap, singletonOp.value)
   }
 
-  class SingletonClear(actor: Actor, clock: VersionMap) :
+  class SingletonClear(actor: Actor, versionMap: VersionMap) :
     Singleton,
     RefModeSingleton,
-    CrdtSingleton.Operation.Clear<RawEntity>(actor, clock) {
-    constructor(singletonOp: Clear<RawEntity>) : this(singletonOp.actor, singletonOp.clock)
+    CrdtSingleton.Operation.Clear<RawEntity>(actor, versionMap) {
+    constructor(singletonOp: Clear<RawEntity>) : this(singletonOp.actor, singletonOp.versionMap)
   }
 
   interface Set : RefModeStoreOp, CrdtSet.IOperation<RawEntity>
 
-  class SetAdd(actor: Actor, clock: VersionMap, added: RawEntity) :
+  class SetAdd(actor: Actor, versionMap: VersionMap, added: RawEntity) :
     Set,
     RefModeSet,
-    CrdtSet.Operation.Add<RawEntity>(actor, clock, added) {
-    constructor(setOp: Add<RawEntity>) : this(setOp.actor, setOp.clock, setOp.added)
+    CrdtSet.Operation.Add<RawEntity>(actor, versionMap, added) {
+    constructor(setOp: Add<RawEntity>) : this(setOp.actor, setOp.versionMap, setOp.added)
   }
 
-  class SetRemove(actor: Actor, clock: VersionMap, removed: ReferenceId) :
+  class SetRemove(actor: Actor, versionMap: VersionMap, removed: ReferenceId) :
     Set,
     RefModeSet,
-    CrdtSet.Operation.Remove<RawEntity>(actor, clock, removed) {
-    constructor(setOp: Remove<RawEntity>) : this(setOp.actor, setOp.clock, setOp.removed)
+    CrdtSet.Operation.Remove<RawEntity>(actor, versionMap, removed) {
+    constructor(setOp: Remove<RawEntity>) : this(setOp.actor, setOp.versionMap, setOp.removed)
   }
 
-  class SetClear(actor: Actor, clock: VersionMap) :
+  class SetClear(actor: Actor, versionMap: VersionMap) :
     Set,
     RefModeSet,
-    CrdtSet.Operation.Clear<RawEntity>(actor, clock) {
-    constructor(setOp: Clear<RawEntity>) : this(setOp.actor, setOp.clock)
+    CrdtSet.Operation.Clear<RawEntity>(actor, versionMap) {
+    constructor(setOp: Clear<RawEntity>) : this(setOp.actor, setOp.versionMap)
   }
 }
 

--- a/javatests/arcs/android/crdt/CrdtSetProtoTest.kt
+++ b/javatests/arcs/android/crdt/CrdtSetProtoTest.kt
@@ -120,12 +120,12 @@ class CrdtSetProtoTest {
 
   @Test
   fun operationFastForward_parcelableRoundTrip_works() {
-    val oldClock = VersionMap("alice" to 1)
-    val newClock = VersionMap("alice" to 1, "bob" to 1)
+    val oldVersionMap = VersionMap("alice" to 1)
+    val newVersionMap = VersionMap("alice" to 1, "bob" to 1)
     val op = CrdtSet.Operation.FastForward(
-      oldClock,
-      newClock,
-      added = mutableListOf(CrdtSet.DataValue(newClock, entity1)),
+      oldVersionMap,
+      newVersionMap,
+      added = mutableListOf(CrdtSet.DataValue(newVersionMap, entity1)),
       removed = mutableListOf(entity2)
     )
 

--- a/javatests/arcs/android/devtools/DevToolsMessageTests.kt
+++ b/javatests/arcs/android/devtools/DevToolsMessageTests.kt
@@ -1,7 +1,6 @@
 package arcs.android.devtools
 
 import arcs.android.devtools.DevToolsMessage.Companion.ACTOR
-import arcs.android.devtools.DevToolsMessage.Companion.CLOCK
 import arcs.android.devtools.DevToolsMessage.Companion.KIND
 import arcs.android.devtools.DevToolsMessage.Companion.MESSAGE
 import arcs.android.devtools.DevToolsMessage.Companion.MODEL_UPDATE_MESSAGE
@@ -13,6 +12,7 @@ import arcs.android.devtools.DevToolsMessage.Companion.STORE_TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.UPDATE_TYPE
 import arcs.android.devtools.DevToolsMessage.Companion.VALUE
+import arcs.android.devtools.DevToolsMessage.Companion.VERSIONMAP
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtEntity
 import arcs.core.crdt.CrdtOperation
@@ -45,7 +45,7 @@ class DevToolsMessageTests {
               TYPE to JsonValue.JsonString(UPDATE_TYPE),
               VALUE to JsonValue.JsonString("foo"),
               ACTOR to JsonValue.JsonString("bar"),
-              CLOCK to JsonValue.JsonObject(
+              VERSIONMAP to JsonValue.JsonObject(
                 "fooBar" to JsonValue.JsonNumber(1.toDouble())
               )
             )
@@ -58,7 +58,7 @@ class DevToolsMessageTests {
         CrdtSingleton.Operation.Update(
           value = ReferencablePrimitive(String::class, "foo"),
           actor = "bar",
-          clock = VersionMap(mapOf("fooBar" to 1))
+          versionMap = VersionMap(mapOf("fooBar" to 1))
         )
       ),
       id = 1

--- a/javatests/arcs/core/crdt/CrdtEntityTest.kt
+++ b/javatests/arcs/core/crdt/CrdtEntityTest.kt
@@ -204,7 +204,7 @@ class CrdtEntityTest {
   }
 
   @Test
-  fun keepsSeparateClocks_forSeparateFields() {
+  fun keepsSeparateVersionMaps_forSeparateFields() {
     val rawEntity = RawEntity(
       singletonFields = setOf("name", "age")
     )

--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -165,7 +165,7 @@ class CrdtSetTest {
     alice.add("bob", VersionMap("bob" to 2), "one")
     alice.add("charlie", VersionMap("charlie" to 1), "three")
 
-    // Non-actor counts can be larger the store's clock, but the actor's count must match.
+    // Non-actor counts can be larger the store's versionMap, but the actor's count must match.
     assertThat(alice.versionMap).isEqualTo(VersionMap("alice" to 1, "bob" to 2, "charlie" to 1))
     assertThat(
       alice.applyOperation(
@@ -182,7 +182,7 @@ class CrdtSetTest {
     alice.add("bob", VersionMap("bob" to 2), "three")
     alice.add("charlie", VersionMap("charlie" to 1), "four")
 
-    // Charlie's view of Bob's clock is behind Alice's, so one of Bob's entries isn't removed.
+    // Charlie's view of Bob's versionMap is behind Alice's, so one of Bob's entries isn't removed.
     assertThat(alice.versionMap).isEqualTo(VersionMap("alice" to 1, "bob" to 2, "charlie" to 1))
     assertThat(
       alice.applyOperation(
@@ -319,8 +319,8 @@ class CrdtSetTest {
       )
     assertThat(fastForward.removed)
       .containsExactly(Reference("removed by alice"))
-    assertThat(fastForward.oldClock).isEqualTo(VersionMap("bob" to 3, "charlie" to 5))
-    assertThat(fastForward.newClock).isEqualTo(expectedVersion)
+    assertThat(fastForward.oldVersionMap).isEqualTo(VersionMap("bob" to 3, "charlie" to 5))
+    assertThat(fastForward.newVersionMap).isEqualTo(expectedVersion)
 
     assertThat(bob.applyOperation(fastForward)).isTrue()
 
@@ -383,8 +383,8 @@ class CrdtSetTest {
     assertThat(
       alice.applyOperation(
         CrdtSet.Operation.FastForward(
-          oldClock = VersionMap("alice" to 5),
-          newClock = VersionMap("alice" to 10)
+          oldVersionMap = VersionMap("alice" to 5),
+          newVersionMap = VersionMap("alice" to 10)
         )
       )
     ).isFalse()
@@ -401,8 +401,8 @@ class CrdtSetTest {
     assertThat(
       alice.applyOperation(
         CrdtSet.Operation.FastForward(
-          oldClock = VersionMap("alice" to 1),
-          newClock = VersionMap("bob" to 2),
+          oldVersionMap = VersionMap("alice" to 1),
+          newVersionMap = VersionMap("bob" to 2),
           added = mutableListOf(
             CrdtSet.DataValue(VersionMap("alice" to 2), Reference("four"))
           )
@@ -413,7 +413,7 @@ class CrdtSetTest {
   }
 
   @Test
-  fun fastForward_advancesTheClock() {
+  fun fastForward_advancesTheVersionMap() {
     listOf(
       Add("alice", VersionMap("alice" to 1), "one"),
       Add("alice", VersionMap("alice" to 2), "two"),
@@ -427,8 +427,8 @@ class CrdtSetTest {
     assertThat(
       alice.applyOperation(
         CrdtSet.Operation.FastForward(
-          oldClock = VersionMap("alice" to 2, "bob" to 1),
-          newClock = VersionMap("alice" to 27, "bob" to 45)
+          oldVersionMap = VersionMap("alice" to 2, "bob" to 1),
+          newVersionMap = VersionMap("alice" to 27, "bob" to 45)
         )
       )
     ).isTrue()
@@ -448,8 +448,8 @@ class CrdtSetTest {
     assertThat(
       alice.applyOperation(
         CrdtSet.Operation.FastForward(
-          oldClock = VersionMap("alice" to 1, "bob" to 1),
-          newClock = VersionMap("alice" to 1, "bob" to 9),
+          oldVersionMap = VersionMap("alice" to 1, "bob" to 1),
+          newVersionMap = VersionMap("alice" to 1, "bob" to 9),
           added = mutableListOf(
             CrdtSet.DataValue(VersionMap("alice" to 1, "bob" to 7), Reference("one")),
             CrdtSet.DataValue(VersionMap("alice" to 1, "bob" to 9), Reference("four"))
@@ -497,8 +497,8 @@ class CrdtSetTest {
     assertThat(
       alice.applyOperation(
         CrdtSet.Operation.FastForward(
-          oldClock = VersionMap("alice" to 1, "bob" to 1),
-          newClock = VersionMap("alice" to 1, "bob" to 5),
+          oldVersionMap = VersionMap("alice" to 1, "bob" to 1),
+          newVersionMap = VersionMap("alice" to 1, "bob" to 5),
           removed = mutableListOf(
             Reference("one"),
             Reference("two")
@@ -515,8 +515,8 @@ class CrdtSetTest {
   @Test
   fun fastForward_simplifiesSingleAddOp_fromASingleActor() {
     val simplified = CrdtSet.Operation.FastForward(
-      oldClock = VersionMap("alice" to 1, "bob" to 1),
-      newClock = VersionMap("alice" to 2, "bob" to 1),
+      oldVersionMap = VersionMap("alice" to 1, "bob" to 1),
+      newVersionMap = VersionMap("alice" to 2, "bob" to 1),
       added = mutableListOf(
         CrdtSet.DataValue(VersionMap("alice" to 2, "bob" to 1), Reference("one"))
       )
@@ -529,8 +529,8 @@ class CrdtSetTest {
   @Test
   fun fastForward_simplifiesMultipleAddOps_fromASingleActor() {
     val simplified = CrdtSet.Operation.FastForward(
-      oldClock = VersionMap("alice" to 1, "bob" to 1),
-      newClock = VersionMap("alice" to 3, "bob" to 1),
+      oldVersionMap = VersionMap("alice" to 1, "bob" to 1),
+      newVersionMap = VersionMap("alice" to 3, "bob" to 1),
       added = mutableListOf(
         CrdtSet.DataValue(VersionMap("alice" to 3, "bob" to 1), Reference("two")),
         CrdtSet.DataValue(VersionMap("alice" to 2, "bob" to 1), Reference("one"))
@@ -547,8 +547,8 @@ class CrdtSetTest {
   @Test
   fun fastForward_doesntSimplify_removeOps() {
     val ff = CrdtSet.Operation.FastForward(
-      oldClock = VersionMap("alice" to 1),
-      newClock = VersionMap("alice" to 1),
+      oldVersionMap = VersionMap("alice" to 1),
+      newVersionMap = VersionMap("alice" to 1),
       removed = mutableListOf(
         Reference("one")
       )
@@ -560,8 +560,8 @@ class CrdtSetTest {
   @Test
   fun fastForward_doesntSimplify_pureVersionBumps() {
     val ff = CrdtSet.Operation.FastForward<Reference>(
-      oldClock = VersionMap("alice" to 1),
-      newClock = VersionMap("alice" to 5)
+      oldVersionMap = VersionMap("alice" to 1),
+      newVersionMap = VersionMap("alice" to 5)
     )
 
     assertThat(ff.simplify()).isEqualTo(listOf(ff))
@@ -570,8 +570,8 @@ class CrdtSetTest {
   @Test
   fun fastForward_doesntSimplify_addOpsFromSingleActor_withVersionJumps() {
     val ff = CrdtSet.Operation.FastForward(
-      oldClock = VersionMap("alice" to 0),
-      newClock = VersionMap("alice" to 4),
+      oldVersionMap = VersionMap("alice" to 0),
+      newVersionMap = VersionMap("alice" to 4),
       added = mutableListOf(
         CrdtSet.DataValue(VersionMap("alice" to 1), Reference("one")),
         CrdtSet.DataValue(VersionMap("alice" to 2), Reference("two")),
@@ -585,8 +585,8 @@ class CrdtSetTest {
   @Test
   fun fastForward_doesntSimplify_addOpsFromMultipleActors() {
     val ff = CrdtSet.Operation.FastForward(
-      oldClock = VersionMap("alice" to 1, "bob" to 1),
-      newClock = VersionMap("alice" to 2, "bob" to 2),
+      oldVersionMap = VersionMap("alice" to 1, "bob" to 1),
+      newVersionMap = VersionMap("alice" to 2, "bob" to 2),
       added = mutableListOf(
         CrdtSet.DataValue(VersionMap("alice" to 2), Reference("one")),
         CrdtSet.DataValue(VersionMap("bob" to 2), Reference("two"))
@@ -597,10 +597,10 @@ class CrdtSetTest {
   }
 
   @Test
-  fun fastForward_doesntSimplify_addOps_whenNewClockIsAJump() {
+  fun fastForward_doesntSimplify_addOps_whenNewVersionMapIsAJump() {
     val ff = CrdtSet.Operation.FastForward(
-      oldClock = VersionMap("alice" to 1),
-      newClock = VersionMap("alice" to 3),
+      oldVersionMap = VersionMap("alice" to 1),
+      newVersionMap = VersionMap("alice" to 3),
       added = mutableListOf(
         CrdtSet.DataValue(VersionMap("alice" to 2), Reference("one"))
       )

--- a/javatests/arcs/core/storage/StorageProxyTest.kt
+++ b/javatests/arcs/core/storage/StorageProxyTest.kt
@@ -95,7 +95,7 @@ class StorageProxyTest {
     scheduler = Scheduler(Executors.newSingleThreadExecutor().asCoroutineDispatcher() + Job())
     MockitoAnnotations.initMocks(this)
     setupMockModel()
-    whenever(mockCrdtOperation.clock).thenReturn(VersionMap())
+    whenever(mockCrdtOperation.versionMap).thenReturn(VersionMap())
   }
 
   @After


### PR DESCRIPTION
As discussed in tea, renaming the "clock" variables to "versionMap" for consistency across the code.

(Second PR coming to do the same in Typescript.)

cc: @shans @justinfagnani @galganif @mykmartin 