### PR TITLE
Rename 'clock' to 'versionMap' in TypeScript

### DIFF
--- a/src/crdt/tests/crdt-entity-test.ts
+++ b/src/crdt/tests/crdt-entity-test.ts
@@ -38,7 +38,7 @@ describe('CRDTEntity', () => {
     const entity = new CRDTEntity(singletons, collections);
 
     const value = {id: 'bob', value: 'bob'};
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value, actor: 'me', clock: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value, actor: 'me', versionMap: {'me': 1}}));
     assert.deepEqual(entity.getParticleView(),
       {singletons: {name: value}, collections: {tags: new Set<Referenceable>()}});
   });
@@ -53,8 +53,8 @@ describe('CRDTEntity', () => {
     const entity = new CRDTEntity(singletons, collections);
 
     const value = {id: 'bob', value: 'bob'};
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value, actor: 'me', clock: {'me': 1}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Clear, field: 'name', actor: 'me', clock: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value, actor: 'me', versionMap: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Clear, field: 'name', actor: 'me', versionMap: {'me': 1}}));
     assert.deepEqual(entity.getParticleView(), {singletons: {name: null}, collections: {tags: new Set<{id: string, value: string}>()}});
   });
 
@@ -68,7 +68,7 @@ describe('CRDTEntity', () => {
     const entity = new CRDTEntity(singletons, collections);
 
     const value = {id: 'bob', value: 'bob'};
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'tags', added: value, actor: 'me', clock: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'tags', added: value, actor: 'me', versionMap: {'me': 1}}));
     assert.deepEqual(entity.getParticleView(), {singletons: {name: null}, collections: {tags: new Set<{id: string, value: string}>([value])}});
   });
 
@@ -82,8 +82,8 @@ describe('CRDTEntity', () => {
     const entity = new CRDTEntity(singletons, collections);
 
     const value = {id: 'bob', value: 'bob'};
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'tags', added: value, actor: 'me', clock: {'me': 1}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Remove, field: 'tags', removed: value, actor: 'me', clock: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'tags', added: value, actor: 'me', versionMap: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Remove, field: 'tags', removed: value, actor: 'me', versionMap: {'me': 1}}));
     assert.deepEqual(entity.getParticleView(), {singletons: {name: null}, collections: {tags: new Set<{id: string, value: string}>()}});
   });
 
@@ -104,17 +104,17 @@ describe('CRDTEntity', () => {
     const tag = {id: '#perf', value: '#perf'};
     const favoriteNumber = {id: '4', value: 4};
 
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value: name, actor: 'me', clock: {'me': 1}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'age', value: age, actor: 'me', clock: {'me': 2}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'tags', added: tag, actor: 'me', clock: {'me': 3}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'favoriteNumbers', added: favoriteNumber, actor: 'me', clock: {'me': 4}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value: name, actor: 'me', versionMap: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'age', value: age, actor: 'me', versionMap: {'me': 2}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'tags', added: tag, actor: 'me', versionMap: {'me': 3}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Add, field: 'favoriteNumbers', added: favoriteNumber, actor: 'me', versionMap: {'me': 4}}));
     assert.deepEqual(entity.getParticleView(), {
       singletons: {name, age},
       collections: {tags: new Set([tag]), favoriteNumbers: new Set([favoriteNumber])}
     });
   });
 
-  it('clocks for separate fields are consistent with entity global clock', () => {
+  it('clocks for separate fields are consistent with entity global versionMap', () => {
     const singletons = {
       name: new CRDTSingleton<{id: string, value: string}>(),
       age: new CRDTSingleton<{id: string, value: number}>()
@@ -126,42 +126,42 @@ describe('CRDTEntity', () => {
     const age1 = {id: '42', value: 42};
     const age2 = {id: '37', value: 37};
 
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value: name1, actor: 'me', clock: {'me': 1}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'age', value: age1, actor: 'me', clock: {'me': 2}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value: name2, actor: 'me', clock: {'me': 3}}));
-    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'age', value: age2, actor: 'them', clock: {'me': 3, 'them': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value: name1, actor: 'me', versionMap: {'me': 1}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'age', value: age1, actor: 'me', versionMap: {'me': 2}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'name', value: name2, actor: 'me', versionMap: {'me': 3}}));
+    assert.isTrue(entity.applyOperation({type: EntityOpTypes.Set, field: 'age', value: age2, actor: 'them', versionMap: {'me': 3, 'them': 1}}));
 
-    const expectedClock = {'me': 3, 'them': 1};
-    assert.deepEqual(entity.model.version, expectedClock);
-    assert.deepEqual(entity.model.singletons['name'].getData().version, expectedClock);
-    assert.deepEqual(entity.model.singletons['age'].getData().version, expectedClock);
+    const expectedVersionMap = {'me': 3, 'them': 1};
+    assert.deepEqual(entity.model.version, expectedVersionMap);
+    assert.deepEqual(entity.model.singletons['name'].getData().version, expectedVersionMap);
+    assert.deepEqual(entity.model.singletons['age'].getData().version, expectedVersionMap);
 
   });
 
   it('fails when an invalid field name is provided', () => {
     const entity = new CRDTEntity({}, {});
 
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Set, field: 'invalid', value: {id: 'foo'}, actor: 'me', clock: {'me': 1}}), 'Invalid field');
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Clear, field: 'invalid', actor: 'me', clock: {'me': 1}}), 'Invalid field');
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Add, field: 'invalid', added: {id: 'foo'}, actor: 'me', clock: {'me': 1}}), 'Invalid field');
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Remove, field: 'invalid', removed: {id: 'foo'}, actor: 'me', clock: {'me': 1}}), 'Invalid field');
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Set, field: 'invalid', value: {id: 'foo'}, actor: 'me', versionMap: {'me': 1}}), 'Invalid field');
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Clear, field: 'invalid', actor: 'me', versionMap: {'me': 1}}), 'Invalid field');
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Add, field: 'invalid', added: {id: 'foo'}, actor: 'me', versionMap: {'me': 1}}), 'Invalid field');
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Remove, field: 'invalid', removed: {id: 'foo'}, actor: 'me', versionMap: {'me': 1}}), 'Invalid field');
   });
 
   it('fails when singleton operations are provided to collection fields', () => {
     const entity = new CRDTEntity({}, {things: new CRDTCollection<{id: string}>()});
 
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Set, field: 'things', value: {id: 'foo'}, actor: 'me', clock: {'me': 1}}),
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Set, field: 'things', value: {id: 'foo'}, actor: 'me', versionMap: {'me': 1}}),
       `Can't apply Set operation to collection field`);
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Clear, field: 'things', actor: 'me', clock: {'me': 1}}),
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Clear, field: 'things', actor: 'me', versionMap: {'me': 1}}),
       `Can't apply Clear operation to collection field`);
   });
 
   it('fails when collection operations are provided to singleton fields', () => {
     const entity = new CRDTEntity({thing: new CRDTSingleton<{id: string}>()}, {});
 
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Add, field: 'thing', added: {id: 'foo'}, actor: 'me', clock: {'me': 1}}),
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Add, field: 'thing', added: {id: 'foo'}, actor: 'me', versionMap: {'me': 1}}),
       `Can't apply Add operation to singleton field`);
-    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Remove, field: 'thing', removed: {id: 'foo'}, actor: 'me', clock: {'me': 1}}),
+    assert.throws(() => entity.applyOperation({type: EntityOpTypes.Remove, field: 'thing', removed: {id: 'foo'}, actor: 'me', versionMap: {'me': 1}}),
       `Can't apply Remove operation to singleton field`);
   });
 });

--- a/src/crdt/tests/crdt-singleton-test.ts
+++ b/src/crdt/tests/crdt-singleton-test.ts
@@ -20,7 +20,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '1'},
       actor: 'A',
-      clock: {A: 1},
+      versionMap: {A: 1},
     });
     assert.deepEqual(singleton.getParticleView(), {id: '1'});
 
@@ -28,7 +28,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '2'},
       actor: 'A',
-      clock: {A: 2},
+      versionMap: {A: 2},
     });
     assert.deepEqual(singleton.getParticleView(), {id: '2'});
 
@@ -37,7 +37,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '3'},
       actor: 'A',
-      clock: {A: 2},
+      versionMap: {A: 2},
     }));
     assert.deepEqual(singleton.getParticleView(), {id: '2'});
   });
@@ -50,7 +50,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '1'},
       actor: 'A',
-      clock: {A: 1},
+      versionMap: {A: 1},
     });
     assert.deepEqual(singleton.getParticleView(), {id: '1'});
 
@@ -58,19 +58,19 @@ describe('CRDTSingleton', () => {
     singleton.applyOperation({
       type: SingletonOpTypes.Clear,
       actor: 'A',
-      clock: {A: 0},
+      versionMap: {A: 0},
     });
     assert.deepEqual(singleton.getParticleView(), {id: '1'});
     singleton.applyOperation({
       type: SingletonOpTypes.Clear,
       actor: 'A',
-      clock: {A: 2},
+      versionMap: {A: 2},
     });
     assert.deepEqual(singleton.getParticleView(), {id: '1'});
 
     // Up-to-date version number, does clear it.
     singleton.applyOperation(
-      {type: SingletonOpTypes.Clear, actor: 'A', clock: {A: 1}});
+      {type: SingletonOpTypes.Clear, actor: 'A', versionMap: {A: 1}});
     assert.strictEqual(singleton.getParticleView(), null);
   });
 
@@ -82,7 +82,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '1'},
       actor: 'A',
-      clock: {A: 1},
+      versionMap: {A: 1},
     });
     assert.deepEqual(
       singleton.getData().values, {'1': {value: {id: '1'}, version: {A: 1}}});
@@ -93,7 +93,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '2'},
       actor: 'B',
-      clock: {B: 1},
+      versionMap: {B: 1},
     });
     assert.deepEqual(
       singleton.getData().values,
@@ -106,7 +106,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '2'},
       actor: 'B',
-      clock: {A: 1, B: 2},
+      versionMap: {A: 1, B: 2},
     });
     assert.deepEqual(
       singleton.getData().values,
@@ -116,7 +116,7 @@ describe('CRDTSingleton', () => {
     singleton.applyOperation({
       type: SingletonOpTypes.Clear,
       actor: 'A',
-      clock: {A: 1, B: 2}
+      versionMap: {A: 1, B: 2}
     });
     assert.deepEqual(singleton.getData().values, {});
     assert.strictEqual(singleton.getParticleView(), null);
@@ -128,7 +128,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '1'},
       actor: 'A',
-      clock: {A: 1},
+      versionMap: {A: 1},
     });
 
     const singletonB = new CRDTSingleton<{id: string}>();
@@ -136,7 +136,7 @@ describe('CRDTSingleton', () => {
       type: SingletonOpTypes.Set,
       value: {id: '2'},
       actor: 'B',
-      clock: {B: 1},
+      versionMap: {B: 1},
     });
 
     const {modelChange, otherChange} = singletonA.merge(singletonB.getData());
@@ -158,7 +158,7 @@ describe('CRDTSingleton', () => {
     assert.isTrue(singletonA.applyOperation({
       type: SingletonOpTypes.Clear,
       actor: 'A',
-      clock: newVersion,
+      versionMap: newVersion,
     }));
     assert.strictEqual(singletonA.getParticleView(), null);
   });

--- a/src/runtime/storage/reference-mode-store.ts
+++ b/src/runtime/storage/reference-mode-store.ts
@@ -334,7 +334,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity,
         this.holdQueue.processID(message.muxId, message.model.version);
         break;
       case ProxyMessageType.Operations:
-        this.holdQueue.processID(message.muxId, message.operations[message.operations.length - 1].clock);
+        this.holdQueue.processID(message.muxId, message.operations[message.operations.length - 1].versionMap);
         break;
       case ProxyMessageType.SyncRequest:
         throw new Error('Unexpected SyncRequest from backing store');
@@ -599,7 +599,7 @@ export class ReferenceModeStore<Entity extends SerializedEntity,
   /* Clear the entity in the backing store. */
   private async clearEntityInBackingStore(entity: Entity) {
     const model = this.entityToModel(entity);
-    const op: EntityOperation<S, C> = {type: EntityOpTypes.ClearAll, actor: this.crdtKey, clock: model.version};
+    const op: EntityOperation<S, C> = {type: EntityOpTypes.ClearAll, actor: this.crdtKey, versionMap: model.version};
     return this.backingStore.onProxyMessage({type: ProxyMessageType.Operations, operations: [op], id: this.backingStoreId, muxId: entity.id});
   }
 

--- a/src/runtime/storage/tests/direct-store-muxer-test.ts
+++ b/src/runtime/storage/tests/direct-store-muxer-test.ts
@@ -60,8 +60,8 @@ describe('Direct Store Muxer', async () => {
     const dsm = await storageService.getActiveStore(new StoreInfo({
         id: 'base-store-id', exists: Exists.ShouldCreate, type: muxType, storageKey: testKey})) as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>;
     const entityCRDT = new CRDTEntity<{name: {id: string}, age: {id: string, value: number}}, {}>({name: new CRDTSingleton<{id: string}>(), age: new CRDTSingleton<{id: string, value: number}>()}, {});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor: 'me', clock: {['me']: 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob'}, actor: 'me', clock: {['me']: 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor: 'me', versionMap: {['me']: 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob'}, actor: 'me', versionMap: {['me']: 1}});
 
     const spm1Listener = new Promise(async (resolve) => {
       await dsm.on(async msg => {
@@ -120,8 +120,8 @@ describe('Direct Store Muxer', async () => {
         id: 'base-store-id', exists: Exists.ShouldCreate, type: muxType, storageKey: testKey}));
 
     const entityCRDT = new CRDTEntity<{name: {id: string}, age: {id: string, value: number}}, {}>({name: new CRDTSingleton<{id: string}>(), age: new CRDTSingleton<{id: string, value: number}>()}, {});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor: 'me', clock: {['me']: 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob'}, actor: 'me', clock: {['me']: 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor: 'me', versionMap: {['me']: 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob'}, actor: 'me', versionMap: {['me']: 1}});
 
     return new Promise(async (resolve, reject) => {
       // storage proxy muxer that will receive a model update

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -43,14 +43,14 @@ describe('entity handle factory', () => {
     Entity.identify(fooEntity1, fooMuxId1, null);
 
     const fooEntity1CRDT = new CRDTEntity({value: new CRDTSingleton<{id: string, value: string}>()}, {});
-    fooEntity1CRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
+    fooEntity1CRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
 
     const fooEntity2 = new fooEntityClass({value: 'OtherText'});
     const fooMuxId2 = 'fooMuxId2';
     Entity.identify(fooEntity2, fooMuxId2, null);
 
     const fooEntity2CRDT = new CRDTEntity({value: new CRDTSingleton<{id: string, value: string}>()}, {});
-    fooEntity2CRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'OtherText'}, actor: 'me', clock: {'me': 1}});
+    fooEntity2CRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'OtherText'}, actor: 'me', versionMap: {'me': 1}});
 
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTMuxEntity>();
     const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>, new MuxType(fooEntityType), mockDirectStoreMuxer.storageKey.toString());

--- a/src/runtime/storage/tests/handle-test.ts
+++ b/src/runtime/storage/tests/handle-test.ts
@@ -217,7 +217,7 @@ describe('CollectionHandle', async () => {
       type: CollectionOpTypes.Remove,
       removed: {id: 'id', creationTimestamp, rawData: {}},
       actor: 'actor',
-      clock: {'actor': 1}
+      versionMap: {'actor': 1}
     };
     await handle.onUpdate(op);
     assert.equal(Entity.id(particle.lastUpdate.removed[0]), 'id');
@@ -231,14 +231,14 @@ describe('CollectionHandle', async () => {
       type: CollectionOpTypes.FastForward,
       added: [],
       removed: [{id: 'id', creationTimestamp, rawData: {}}],
-      oldClock: {'actor': 1},
-      newClock: {'actor': 1}
+      oldVersionMap: {'actor': 1},
+      newVersionMap: {'actor': 1}
     };
     await handle.onUpdate(op);
     assert.isTrue(particle.onSyncCalled);
   });
 
-  it('uses the storage proxy clock', async () => {
+  it('uses the storage proxy versionMap', async () => {
     const handle = await getCollectionHandle(barType);
 
     const versionMap: VersionMap = {'actor': 1, 'other': 2};
@@ -251,15 +251,15 @@ describe('CollectionHandle', async () => {
 
     // This will pull in the version map above.
     await handle.toList();
-    // Swap out storageProxy.applyOp to check the updated clock is passed in the next op.
-    let capturedClock: VersionMap;
+    // Swap out storageProxy.applyOp to check the updated versionMap is passed in the next op.
+    let capturedVersionMap: VersionMap;
     handle.storageProxy.applyOp = async (op: CollectionOperation<{id: string}>) => {
-      capturedClock = 'clock' in op ? op.clock : null;
+      capturedVersionMap = 'versionMap' in op ? op.versionMap : null;
       return true;
     };
-    // Use an op that does not increment the clock.
+    // Use an op that does not increment the versionMap.
     await handle.remove(newEntity('id'));
-    assert.deepEqual(capturedClock, versionMap);
+    assert.deepEqual(capturedVersionMap, versionMap);
   });
 
   it('can override default options', async () => {
@@ -322,7 +322,7 @@ describe('SingletonHandle', async () => {
       type: SingletonOpTypes.Set,
       value: newEntity('B')[SYMBOL_INTERNALS].serialize(),
       actor: 'other',
-      clock: {'other': 1},
+      versionMap: {'other': 1},
     });
     await handle.clear();
     assert.strictEqual(await handle.fetch(), null);
@@ -342,14 +342,14 @@ describe('SingletonHandle', async () => {
       type: SingletonOpTypes.Set,
       value: {id: 'id', creationTimestamp, rawData: {}},
       actor: 'actor',
-      clock: {'actor': 1}
+      versionMap: {'actor': 1}
     };
     await handle.onUpdate(op);
     assert.deepEqual(particle.lastUpdate, {data: {}, originator: false});
     assert.equal(Entity.id(particle.lastUpdate.data), 'id');
   });
 
-  it('uses the storage proxy clock', async () => {
+  it('uses the storage proxy versionMap', async () => {
     const handle = await getSingletonHandle(barType);
 
     const versionMap: VersionMap = {'actor': 1, 'other': 2};
@@ -362,20 +362,20 @@ describe('SingletonHandle', async () => {
 
     // This will pull in the version map above.
     await handle.fetch();
-    // Swap out storageProxy.applyOp to check the updated clock is passed in the next op.
-    let capturedClock;
+    // Swap out storageProxy.applyOp to check the updated versionMap is passed in the next op.
+    let capturedVersionMap;
     handle.storageProxy.applyOp = async (op: SingletonOperation<{id: string}>) => {
       if (op.type === SingletonOpTypes.Set || op.type === SingletonOpTypes.Clear) {
-        capturedClock = op.clock;
+        capturedVersionMap = op.versionMap;
       } else {
-        capturedClock = op.newClock;
+        capturedVersionMap = op.newVersionMap;
       }
 
       return true;
     };
-    // Use an op that does not increment the clock.
+    // Use an op that does not increment the versionMap.
     await handle.clear();
-    assert.deepEqual(capturedClock, versionMap);
+    assert.deepEqual(capturedVersionMap, versionMap);
   });
 
   it('respects canWrite', async () => {
@@ -431,10 +431,10 @@ describe('EntityHandle', async () => {
       nums: new CRDTCollection<{id: string, value: number}>()
     };
     const entityCRDT = new CRDTEntity(singletons, collections);
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', clock: {'me': 2}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', clock: {'me': 3}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', clock: {'me': 4}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', versionMap: {'me': 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', versionMap: {'me': 3}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', versionMap: {'me': 4}});
 
     await handle.onSync(entityCRDT.getParticleView());
 
@@ -473,8 +473,8 @@ describe('EntityHandle', async () => {
     };
     const collections = {};
     const entityCRDT = new CRDTEntity(singletons, collections);
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'ref', value: barReference, actor: 'me', clock: {me: 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'ref', value: barReference, actor: 'me', versionMap: {me: 2}});
 
     await handle.onSync(entityCRDT.getParticleView());
 
@@ -514,8 +514,8 @@ describe('EntityHandle', async () => {
       refs: new CRDTCollection<Reference>()
     };
     const entityCRDT = new CRDTEntity(singletons, collections);
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'refs', added: barReference, actor: 'me', clock: {me: 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'refs', added: barReference, actor: 'me', versionMap: {me: 2}});
 
     await handle.onSync(entityCRDT.getParticleView());
 
@@ -546,10 +546,10 @@ describe('EntityHandle', async () => {
     nums: new CRDTCollection<{id: string, value: number}>()
   };
   const entityCRDT = new CRDTEntity(singletons, collections);
-  entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-  entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', clock: {'me': 2}});
-  entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', clock: {'me': 3}});
-  entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', clock: {'me': 4}});
+  entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+  entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', versionMap: {'me': 2}});
+  entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', versionMap: {'me': 3}});
+  entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', versionMap: {'me': 4}});
 
   // initialize model in storageProxy
   await handle.storageProxy.onMessage({
@@ -581,8 +581,8 @@ describe('EntityHandle', async () => {
     };
     const entityCRDT = new CRDTEntity(singletons, collections);
 
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', clock: {'me': 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', versionMap: {'me': 2}});
 
     // initialize model in storageProxy
     await handle.storageProxy.onMessage({
@@ -624,8 +624,8 @@ describe('EntityHandle', async () => {
     };
     const entityCRDT = new CRDTEntity(singletons, collections);
 
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', clock: {'me': 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', versionMap: {'me': 2}});
 
     // initialize model in storageProxy
     await handle.storageProxy.onMessage({
@@ -668,8 +668,8 @@ describe('EntityHandle', async () => {
     };
     const collections = {};
     const entityCRDT = new CRDTEntity(singletons, collections);
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', clock: {'me': 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', versionMap: {'me': 2}});
 
     // initialize model in storageProxy
     await handle.storageProxy.onMessage({
@@ -711,8 +711,8 @@ describe('EntityHandle', async () => {
     };
     const collections = {};
     const entityCRDT = new CRDTEntity(singletons, collections);
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', clock: {'me': 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', versionMap: {'me': 2}});
 
     // initialize model in storageProxy
     await handle.storageProxy.onMessage({
@@ -760,10 +760,10 @@ describe('EntityHandle', async () => {
       nums: new CRDTCollection<{id: string, value: number}>()
     };
     const entityCRDT = new CRDTEntity(singletons, collections);
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', clock: {'me': 2}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', clock: {'me': 3}});
-    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', clock: {'me': 4}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'flag', value: {id: 'true', value: true}, actor: 'me', versionMap: {'me': 2}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '1', value: 1}, actor: 'me', versionMap: {'me': 3}});
+    entityCRDT.applyOperation({type: EntityOpTypes.Add, field: 'nums', added: {id: '2', value: 2}, actor: 'me', versionMap: {'me': 4}});
 
     // initialize model in storageProxy
     await handle.storageProxy.onMessage({

--- a/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
@@ -56,10 +56,10 @@ describe('RamDisk + Direct Store Muxer Integration', async () => {
 
 
     const entity1 = new CRDTEntity({txt: new CRDTSingleton<{id: string, value: string}>()}, {});
-    entity1.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'text1', value: 'text1'}, actor: 'me', clock: {'me': 1}});
+    entity1.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'text1', value: 'text1'}, actor: 'me', versionMap: {'me': 1}});
 
     const entity2 = new CRDTEntity({txt: new CRDTSingleton<{id: string, value: string}>()}, {});
-    entity2.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'text2', value: 'text2'}, actor: 'me', clock: {'me': 1}});
+    entity2.applyOperation({type: EntityOpTypes.Set, field: 'txt', value: {id: 'text2', value: 'text2'}, actor: 'me', versionMap: {'me': 1}});
 
     const id = store.on(async (message) => {return;});
     await store.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: entity1.getData(), id, muxId: 'thing0'});

--- a/src/runtime/storage/tests/reference-mode-store-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-test.ts
@@ -133,14 +133,14 @@ describe('Reference Mode Store', async () => {
     entity.id = 'an-id';
     entity.creationTimestamp = now;
     entity.rawData.name = 'bob';
-    collection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: entity});
+    collection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: entity});
 
      await activeStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: collection.getData(), id: 1});
 
     const actor = activeStore['crdtKey'];
     const referenceCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {[actor]: 1}};
-    referenceCollection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: reference});
+    referenceCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: reference});
 
     const entityCRDT = myEntityToMyEntityModel(entity, actor);
 
@@ -161,7 +161,7 @@ describe('Reference Mode Store', async () => {
     entity.id = 'an-id';
     entity.creationTimestamp = now;
     entity.rawData.name = 'bob';
-    collection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: entity});
+    collection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: entity});
     const result = await activeStore.onProxyMessage({type: ProxyMessageType.ModelUpdate, model: collection.getData(), id: 1});
 
     // Clone.
@@ -184,14 +184,14 @@ describe('Reference Mode Store', async () => {
     entity.id = 'an-id';
     entity.creationTimestamp = now;
     entity.rawData.name = 'bob';
-    const operation: CollectionOperation<MyEntity> = {type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: entity};
+    const operation: CollectionOperation<MyEntity> = {type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: entity};
 
     await activeStore.onProxyMessage({type: ProxyMessageType.Operations, operations: [operation], id: 1});
 
     const actor = activeStore['crdtKey'];
     const referenceCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {[actor]: 1}};
-    referenceCollection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: reference});
+    referenceCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: reference});
 
     const entityCRDT = myEntityToMyEntityModel(entity, actor);
 
@@ -213,7 +213,7 @@ describe('Reference Mode Store', async () => {
     // Add Bob to a collection.
     const addOperation: CollectionOperation<MyEntity> = {
       type: CollectionOpTypes.Add,
-      clock: {me: 1},
+      versionMap: {me: 1},
       actor: 'me',
       added: entity
     };
@@ -225,7 +225,7 @@ describe('Reference Mode Store', async () => {
     // Now remove it from the collection.
     const deleteOp: CollectionOperation<MyEntity> = {
       type: CollectionOpTypes.Remove,
-      clock: {me: 1},
+      versionMap: {me: 1},
       actor: 'me',
       removed: entity
     };
@@ -252,7 +252,7 @@ describe('Reference Mode Store', async () => {
     entity.rawData.age = 42;
     entity.id = 'an-id';
     entity.rawData.name = 'bob';
-    const operation: CollectionOperation<MyEntity> = {type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: entity};
+    const operation: CollectionOperation<MyEntity> = {type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: entity};
     collection.applyOperation(operation);
 
     let sentSyncRequest = false;
@@ -309,11 +309,11 @@ describe('Reference Mode Store', async () => {
     entity.rawData.age = 42;
     entity.id = 'an-id';
     entity.rawData.name = 'bob';
-    collection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: entity});
+    collection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: entity});
 
     const referenceCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {me: 1}};
-    referenceCollection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: reference});
+    referenceCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: reference});
 
     const actor = activeStore['crdtKey'];
     const entityCRDT = myEntityToMyEntityModel(entity, actor);
@@ -344,7 +344,7 @@ describe('Reference Mode Store', async () => {
 
     const referenceCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {me: 1}};
-    referenceCollection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: reference});
+    referenceCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: reference});
 
     const driver = activeStore.containerStore['driver'] as MockDriver<CollectionData<Reference>>;
     driver.send = async model => {throw new Error('Should not be invoked');};
@@ -366,12 +366,12 @@ describe('Reference Mode Store', async () => {
     entity.id = 'an-id';
     entity.creationTimestamp = now;
     entity.rawData.name = 'bob';
-    collection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: entity});
+    collection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: entity});
 
     // conflicting remote count from store
     const remoteCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'another-id', version: {them: 1}};
-    remoteCollection.applyOperation({type: CollectionOpTypes.Add, clock: {them: 1}, actor: 'them', added: reference});
+    remoteCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {them: 1}, actor: 'them', added: reference});
 
     // ensure remote entity is stored in backing store
     const id2 = activeStore.backingStore.on(msg => null);
@@ -393,7 +393,7 @@ describe('Reference Mode Store', async () => {
 
     const actor = activeStore['crdtKey'];
     const reference2: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {[actor]: 1}};
-    remoteCollection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: reference2});
+    remoteCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: reference2});
     assert.deepEqual(capturedModel, remoteCollection.getData());
   });
 
@@ -417,13 +417,13 @@ describe('Reference Mode Store', async () => {
     e3.creationTimestamp = now;
 
     await activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
-      {type: CollectionOpTypes.Add, actor: 'me', clock: {me: 1}, added: e1}
+      {type: CollectionOpTypes.Add, actor: 'me', versionMap: {me: 1}, added: e1}
     ]});
     await activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
-      {type: CollectionOpTypes.Add, actor: 'me', clock: {me: 2}, added: e2}
+      {type: CollectionOpTypes.Add, actor: 'me', versionMap: {me: 2}, added: e2}
     ]});
     await activeStore.onProxyMessage({type: ProxyMessageType.Operations, id: 1, operations: [
-      {type: CollectionOpTypes.Add, actor: 'me', clock: {me: 3}, added: e3}
+      {type: CollectionOpTypes.Add, actor: 'me', versionMap: {me: 3}, added: e3}
     ]});
 
     const e1V = {value: {id: 'e1', storageKey: new MockHierarchicalStorageKey(''), version: {}}, version: {me: 1}};
@@ -447,7 +447,7 @@ describe('Reference Mode Store', async () => {
 
     const referenceCollection = new ReferenceCollection();
     const reference: Reference = {storageKey: new MockHierarchicalStorageKey(''), id: 'an-id', version: {[actor]: 1}};
-    referenceCollection.applyOperation({type: CollectionOpTypes.Add, clock: {me: 1}, actor: 'me', added: reference});
+    referenceCollection.applyOperation({type: CollectionOpTypes.Add, versionMap: {me: 1}, actor: 'me', added: reference});
 
     return new Promise(async (resolve, reject) => {
       let backingStoreSent = false;
@@ -469,8 +469,8 @@ describe('Reference Mode Store', async () => {
       const store = activeStore.backingStore['stores']['an-id']['store'] as DirectStore<CRDTEntityTypeRecord<{name: {id: string}, age: {id: string, value: number}}, {}>>;
 
       const entityCRDT = new MyEntityModel();
-      entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor, clock: {[actor]: 1}});
-      entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob', value: 'bob'}, actor, clock: {[actor]: 2}});
+      entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'age', value: {id: '42', value: 42}, actor, versionMap: {[actor]: 1}});
+      entityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'name', value: {id: 'bob', value: 'bob'}, actor, versionMap: {[actor]: 2}});
 
       await store.onReceive(entityCRDT.getData(), 1);
     });

--- a/src/runtime/storage/tests/storage-proxy-muxer-test.ts
+++ b/src/runtime/storage/tests/storage-proxy-muxer-test.ts
@@ -26,10 +26,10 @@ describe('StorageProxyMuxer', async () => {
   const fooEntityType = EntityType.make(['Foo'], {value: 'Text'});
 
   const fooEntityCRDT = new CRDTEntity({value: new CRDTSingleton<{id: string, value: string}>()}, {});
-  fooEntityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'Text'}, actor: 'me', clock: {'me': 1}});
+  fooEntityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'Text'}, actor: 'me', versionMap: {'me': 1}});
 
   const foo2EntityCRDT = new CRDTEntity({value: new CRDTSingleton<{id: string, value: string}>()}, {});
-  foo2EntityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'AlsoText', value: 'AlsoText'}, actor: 'me', clock: {'me': 1}});
+  foo2EntityCRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'AlsoText', value: 'AlsoText'}, actor: 'me', versionMap: {'me': 1}});
 
   it('creation of storage proxies', async () => {
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>();
@@ -64,7 +64,7 @@ describe('StorageProxyMuxer', async () => {
       field: 'value',
       value: {id: 'DifferentText'},
       actor: 'me',
-      clock: {'me': 2}
+      versionMap: {'me': 2}
     };
     const result = await storageProxy.applyOp(op);
     assert.isTrue(result);
@@ -136,7 +136,7 @@ describe('StorageProxyMuxer', async () => {
       field: 'value',
       value: {id: 'DifferentText'},
       actor: 'me',
-      clock: {'me': 1}
+      versionMap: {'me': 1}
     };
 
     await storageProxyMuxer.onMessage({type: ProxyMessageType.Operations, operations: [op], id: 1, muxId: 'foo-id'});

--- a/src/runtime/storage/tests/storage-proxy-test.ts
+++ b/src/runtime/storage/tests/storage-proxy-test.ts
@@ -42,7 +42,7 @@ describe('StorageProxy', async () => {
       type: SingletonOpTypes.Set,
       value: {id: 'e2'},
       actor: 'A',
-      clock: {A: 2}
+      versionMap: {A: 2}
     };
     const result = await storageProxy.applyOp(op);
     assert.isTrue(result);
@@ -72,7 +72,7 @@ describe('StorageProxy', async () => {
       type: SingletonOpTypes.Set,
       value: {id: 'e1'},
       actor: 'A',
-      clock: {A: 2}
+      versionMap: {A: 2}
     };
     await storageProxy.onMessage({type: ProxyMessageType.Operations, operations: [op], id: 1});
     await storageProxy.idle();

--- a/src/runtime/testing/identity.ts
+++ b/src/runtime/testing/identity.ts
@@ -59,7 +59,7 @@ export function setLogFilterById(name, id: number) {
 
 export function operation<T extends CRDTTypeRecord>(op: T['operation']) {
   if (op['value'] && op['type'] === 0) {
-    return `+{id: ${op['value']['id']} ${JSON.stringify(op['value']['rawData'])}} @${JSON.stringify(op[`clock`])} by ${op[`actor`]}`;
+    return `+{id: ${op['value']['id']} ${JSON.stringify(op['value']['rawData'])}} @${JSON.stringify(op[`versionMap`])} by ${op[`actor`]}`;
   }
   return JSON.stringify(op);
 }


### PR DESCRIPTION
As discussed in tea, renaming the "clock" variables to "versionMap" for consistency across the code.

Typescript version of #6349 

cc: @shans @justinfagnani @mykmartin @AliceLetitia @galganif 