### PR TITLE
Customize the init message from DevTools UIs

### DIFF
--- a/devtools/index.html
+++ b/devtools/index.html
@@ -15,7 +15,11 @@
     <script src="deps/jquery/dist/jquery.min.js"></script>
     <script src="deps/golden-layout/dist/goldenlayout.min.js"></script>
 
-    <script>window.webSocketPort = 8787;</script>
+    <script>
+      window.webSocketPort = 8787;
+      window.sendInitOnConnection = true;
+    </script>
+
     <script src="src/standalone-message-passing.js"></script>
     <script src='src/arcs-devtools-app.js' type='module'></script>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />

--- a/devtools/src/devtools.js
+++ b/devtools/src/devtools.js
@@ -69,10 +69,12 @@ import {listenForWebRtcSignal} from '../shared/web-rtc-signalling.js';
 
   function connectViaExtensionApi() {
     const backgroundPageConnection = chrome.runtime.connect({name: 'arcs'});
-    backgroundPageConnection.postMessage({
-        name: 'init',
-        tabId: chrome.devtools.inspectedWindow.tabId
-    });
+    if (window.sendInitOnConnection) {
+      backgroundPageConnection.postMessage({
+          name: 'init',
+          tabId: chrome.devtools.inspectedWindow.tabId
+      });
+    }
     backgroundPageConnection.onMessage.addListener(
       e => queueOrFire(e));
     return msg => {
@@ -89,7 +91,9 @@ import {listenForWebRtcSignal} from '../shared/web-rtc-signalling.js';
     ws.onopen = _ => {
       console.log(`WebSocket connection established.`);
       ws.onmessage = receiveMessage;
-      ws.send('init');
+      if (window.sendInitOnConnection) {
+        ws.send('init');
+      }
     };
     ws.onerror = _ => {
       queueOrFire([{
@@ -123,7 +127,9 @@ import {listenForWebRtcSignal} from '../shared/web-rtc-signalling.js';
       channel.onmessage = receiveMessage;
       channel.onopen = _ => {
         console.log('WebRTC channel opened.');
-        channel.send('init');
+        if (window.sendInitOnConnection) {
+          channel.send('init');
+        }
         queueOrFire([{messageType: 'connection-status-connected'}]);
       };
       channel.onclose = _ => {


### PR DESCRIPTION
The original devtools infra required the UI to send "init" message once it is ready, so that the Runtime in certain contexts can decide to wait for the DevTools to appear if debugging from the initialization time was required.

The new devtools doesn't have this requirement and the "init" message is confusing the DevToolsService on Android.

This PR allows configuring the message passing infra, so that the webapp using it can decide whether to send the "init" message or not.