### PR TITLE
Bugfix: max read schema of policies must take care of nested schemas

### DIFF
--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -172,7 +172,7 @@ export class IngressValidation {
         const targetSchema = target.getMaxReadSchema();
         IngressValidation.updateMaxReadSchemas(maxReadSchemas, targetSchema);
         // Update the accessible fields for any nested references.
-        Object.values(targetSchema.fields).map(f => {
+        Object.values(targetSchema.fields).forEach(f => {
           IngressValidation.updateMaxReadSchemasForReferences(maxReadSchemas, f);
         });
 
@@ -204,7 +204,7 @@ export class IngressValidation {
     if (field.isReference) {
       IngressValidation.updateMaxReadSchemas(maxReadSchemas, targetSchema);
     } else if (field.isInline) {
-      Object.values(targetSchema.fields).map(f =>
+      Object.values(targetSchema.fields).forEach(f =>
         IngressValidation.updateMaxReadSchemasForReferences(maxReadSchemas, f));
     }
     return;

--- a/src/runtime/policy/policy.ts
+++ b/src/runtime/policy/policy.ts
@@ -340,7 +340,8 @@ export class PolicyField {
     const restrictedFields = {};
     const schema = entityType.entitySchema;
     for (const subfield of this.subfields) {
-      restrictedFields[subfield.name] = schema.fields[subfield.name];
+      restrictedFields[subfield.name] =
+        subfield.toSchemaField(schema.fields[subfield.name]);
     }
     return EntityType.make(schema.names, restrictedFields, schema);
   }

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -497,6 +497,8 @@ policy MyPolicy {
     deleteFieldRecursively(expectedSchemas['Group'], 'location', {replaceWithNulls: true});
       assert.deepEqual(maxReadSchemas['Group'], expectedSchemas['Group']);
       assert.deepEqual(maxReadSchemas['Address'], expectedSchemas['Address']);
+      // 'Person' and 'Name' are not in `maxReadSchemas` because they
+      // only appear as inline entities.
       assert.isFalse('Person' in maxReadSchemas);
       assert.isFalse('Name' in maxReadSchemas);
   });
@@ -623,6 +625,8 @@ policy MyPolicy {
     deleteFieldRecursively(expectedSchemas['Address'], 'location', {replaceWithNulls: true});
     assert.deepEqual(maxReadSchemas['Person'], expectedSchemas['Person']);
     assert.deepEqual(maxReadSchemas['Address'], expectedSchemas['Address']);
+    // 'Name' is not in `maxReadSchemas` because it only appears as
+    // an inline entity.
     assert.isFalse('Name' in maxReadSchemas);
   });
 
@@ -664,6 +668,8 @@ policy MyPolicy {
       deleteFieldRecursively(expectedSchemas['Group'], 'location', {replaceWithNulls: true});
       assert.deepEqual(maxReadSchemas['Name'], expectedSchemas['Name']);
       assert.deepEqual(maxReadSchemas['Group'], expectedSchemas['Group']);
+      // 'Person' is not in `maxReadSchemas` because it only appears as
+      // an inline entity.
       assert.isFalse('Person' in maxReadSchemas);
     });
 });

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -493,6 +493,8 @@ policy MyPolicy {
         schema Group
           persons: List<inline Person>
       `)).schemas;
+    deleteFieldRecursively(maxReadSchemas['Group'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(expectedSchemas['Group'], 'location', {replaceWithNulls: true});
       assert.deepEqual(maxReadSchemas['Group'], expectedSchemas['Group']);
       assert.deepEqual(maxReadSchemas['Address'], expectedSchemas['Address']);
       assert.isFalse('Person' in maxReadSchemas);
@@ -561,13 +563,15 @@ policy MyPolicy {
         address: &Address {number, street, city}
         otherAddresses: [&Address {city, country}]
       `)).schemas;
-    deleteFieldRecursively(maxReadSchema, 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(maxReadSchemas['Person'], 'location', {replaceWithNulls: true});
     deleteFieldRecursively(expectedSchemas['Person'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(maxReadSchemas['Address'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(expectedSchemas['Address'], 'location', {replaceWithNulls: true});
     assert.deepEqual(maxReadSchemas['Person'], expectedSchemas['Person']);
     assert.deepEqual(maxReadSchemas['Address'], expectedSchemas['Address']);
   });
 
-  it('inline fields do not affect max read schemas', async () => {
+  it('inline entities do not affect max read schemas', async () => {
     const manifest = await Manifest.parse(`
       schema Address
         number: Number
@@ -613,13 +617,17 @@ policy MyPolicy {
         name: inline Name {last: Text}
         addresses: List<inline Address {number: Number, street: Text, city: Text}>
     `)).schemas;
+    deleteFieldRecursively(maxReadSchemas['Person'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(expectedSchemas['Person'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(maxReadSchemas['Address'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(expectedSchemas['Address'], 'location', {replaceWithNulls: true});
     assert.deepEqual(maxReadSchemas['Person'], expectedSchemas['Person']);
     assert.deepEqual(maxReadSchemas['Address'], expectedSchemas['Address']);
     assert.isFalse('Name' in maxReadSchemas);
   });
 
   it(
-    'references in inline schemas affect max read schema', async () => {
+    'references in inline entities affect max read schema', async () => {
       const manifest = await Manifest.parse(`
         schema Name
           first: Text
@@ -652,6 +660,8 @@ policy MyPolicy {
         schema Group
           persons: List<inline Person>
       `)).schemas;
+      deleteFieldRecursively(maxReadSchemas['Group'], 'location', {replaceWithNulls: true});
+      deleteFieldRecursively(expectedSchemas['Group'], 'location', {replaceWithNulls: true});
       assert.deepEqual(maxReadSchemas['Name'], expectedSchemas['Name']);
       assert.deepEqual(maxReadSchemas['Group'], expectedSchemas['Group']);
       assert.isFalse('Person' in maxReadSchemas);

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -447,8 +447,7 @@ policy MyPolicy {
     assert.deepEqual(schema, expectedSchemas['Person']);
   });
 
-  it(
-    'Deeply nested schemas are also restricted according to policy', async () => {
+  it('Deeply nested schemas are restricted according to policy', async () => {
       const manifest = await Manifest.parse(`
         schema Name
           first: Text

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -1193,4 +1193,114 @@ recipe ThingWriter
     assert.equal(handle.getTtl().toDebugString(), '3d');
     assert.isTrue(handle.capabilities.isEncrypted());
   });
+
+  it('restricts handle types with inline entities according to policies', async () => {
+    const schemaString = `
+schema Location
+  coarse: Text
+  fine: Text
+
+schema ThingDesc
+  name: Text
+  desc: Text
+  weight: Number
+  location: inline Location
+
+schema AnotherDesc
+  name: Text
+  secret: Text
+
+schema Thing
+  a: inline ThingDesc
+  b: List<inline AnotherDesc>
+  c: Text
+  d: Text
+  e: Text`;
+    const policiesManifestStr = `
+${schemaString}
+policy Policy0 {
+  @allowedRetention(medium: 'Ram', encryption: false)
+  @maxAge('10d')
+  from Thing access {
+    a {
+      name,
+      desc
+    }
+  }
+}
+policy Policy1 {
+  @allowedRetention(medium: 'Ram', encryption: true)
+  @maxAge('5d')
+  from Thing access {
+    a {
+      weight
+    }
+    b {
+      name
+    },
+    c
+  }
+}
+policy Policy2 {
+  @allowedRetention(medium: 'Ram', encryption: true)
+  @maxAge('5d')
+  from Thing access {
+    a {
+      location { coarse }
+    }
+  }
+}`;
+    const manifest = await Manifest.parse(`
+${schemaString}
+particle Writer
+  things: writes [Thing {a, b, c, d}]
+particle Reader
+  things: reads [Thing {a: inline ThingDesc {name, weight, location: inline Location {coarse}}, b: List<inline AnotherDesc {name}>}]
+recipe ThingWriter
+  handle0: create 'my-things' @ttl('3d') @inMemory @encrypted
+  Writer
+    things: handle0
+  Reader
+    things: handle0`);
+    const policiesManifest = await Manifest.parse(policiesManifestStr);
+    const resolver = new AllocatorRecipeResolver(manifest, randomSalt, policiesManifest);
+    const recipes = await resolver.resolve();
+    const writer = recipes[0].particles.find(p => p.name === 'Writer');
+    const writerFields = writer.connections['things'].type.getEntitySchema().fields;
+    assert.deepEqual(Object.keys(writerFields), ['a', 'b', 'c', 'd']);
+    // Check that writer type has all the fields mentioned.
+    const writerAFields = writerFields['a'].getEntityType().getEntitySchema().fields
+    assert.deepEqual(
+      Object.keys(writerAFields),
+      ['name', 'desc', 'weight', 'location']);
+    assert.deepEqual(
+      Object.keys(writerAFields['location'].getEntityType().getEntitySchema().fields),
+      ['coarse', 'fine']
+    )
+    assert.deepEqual(
+      Object.keys(writerFields['b'].getEntityType().getEntitySchema().fields),
+      ['name', 'secret']);
+    const reader = recipes[0].particles.find(p => p.name === 'Reader');
+    assert.deepEqual(Object.keys(reader.connections['things'].type.getEntitySchema().fields), ['a', 'b']);
+    const handle = recipes[0].handles[0];
+    // CHeck that the handle fields are only those that are allowed by policy.
+    const handleFields = handle.type.getEntitySchema().fields;
+    assert.deepEqual(Object.keys(handleFields), ['a', 'b']);
+    const handleAFields = handleFields['a'].getEntityType().getEntitySchema().fields
+    // TODO(b/168040363): Field `desc` should be written, but it won't be unless there
+    // are phantom readers.
+    assert.deepEqual(
+      Object.keys(handleAFields),
+      ['name', 'weight', 'location']);
+    assert.deepEqual(
+      Object.keys(handleAFields['location'].getEntityType().getEntitySchema().fields),
+      ['coarse']
+    )
+    assert.deepEqual(
+      Object.keys(handleFields['b'].getEntityType().getEntitySchema().fields),
+      ['name']);
+    assert.equal(handle.getTtl().toDebugString(), '3d');
+    assert.isTrue(handle.capabilities.isEncrypted());
+  });
+
 });

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -1269,14 +1269,14 @@ recipe ThingWriter
     const writerFields = writer.connections['things'].type.getEntitySchema().fields;
     assert.deepEqual(Object.keys(writerFields), ['a', 'b', 'c', 'd']);
     // Check that writer type has all the fields mentioned.
-    const writerAFields = writerFields['a'].getEntityType().getEntitySchema().fields
+    const writerAFields = writerFields['a'].getEntityType().getEntitySchema().fields;
     assert.deepEqual(
       Object.keys(writerAFields),
       ['name', 'desc', 'weight', 'location']);
     assert.deepEqual(
       Object.keys(writerAFields['location'].getEntityType().getEntitySchema().fields),
       ['coarse', 'fine']
-    )
+    );
     assert.deepEqual(
       Object.keys(writerFields['b'].getEntityType().getEntitySchema().fields),
       ['name', 'secret']);
@@ -1286,7 +1286,7 @@ recipe ThingWriter
     // CHeck that the handle fields are only those that are allowed by policy.
     const handleFields = handle.type.getEntitySchema().fields;
     assert.deepEqual(Object.keys(handleFields), ['a', 'b']);
-    const handleAFields = handleFields['a'].getEntityType().getEntitySchema().fields
+    const handleAFields = handleFields['a'].getEntityType().getEntitySchema().fields;
     // TODO(b/168040363): Field `desc` should be written, but it won't be unless there
     // are phantom readers.
     assert.deepEqual(
@@ -1295,7 +1295,7 @@ recipe ThingWriter
     assert.deepEqual(
       Object.keys(handleAFields['location'].getEntityType().getEntitySchema().fields),
       ['coarse']
-    )
+    );
     assert.deepEqual(
       Object.keys(handleFields['b'].getEntityType().getEntitySchema().fields),
       ['name']);


### PR DESCRIPTION
If a schema is nested in a different schema and is also mentioned in the policy. Those nested accesses should be taken into account as well. See the example in test involving `Person` and `Address`.