### PR TITLE
add missing DriverFactory.clearRegistrationsForTesting(); in tests

### DIFF
--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -40,8 +40,15 @@ async function storeResults(consumer: PlanConsumer, suggestions: Suggestion[]) {
 }
 
 describe('plan consumer', () => {
-  it('consumes', async () => {
+  beforeEach(() => {
     DriverFactory.clearRegistrationsForTesting();
+  });
+
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
+  it('consumes', async () => {
     const loader = new Loader();
     const memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
@@ -118,8 +125,6 @@ describe('plan consumer', () => {
 
     consumer.setSuggestFilter(true);
     assert.lengthOf(consumer.getCurrentSuggestions(), 3);
-
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('filters suggestions by modality', async () => {

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -23,6 +23,7 @@ import {Suggestion} from '../../plan/suggestion.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../../../runtime/storage/drivers/ramdisk.js';
 import {ActiveSingletonEntityStore, handleForActiveStore} from '../../../runtime/storage/storage.js';
+import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
 
 class TestPlanProducer extends PlanProducer {
   options;
@@ -82,6 +83,14 @@ class TestPlanProducer extends PlanProducer {
 
 // Run test suite for each storageKeyBase
 describe('plan producer', () => {
+  beforeEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   async function createProducer() {
     const loader = new Loader();
     const memoryProvider = new TestVolatileMemoryProvider();

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -20,6 +20,7 @@ import {storageKeyPrefixForTest} from '../../../runtime/testing/handle-for-test.
 import {Loader} from '../../../platform/loader.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
+import {VolatileStorageDriverProvider} from '../../../runtime/storage/drivers/volatile.js';
 
 describe('planning result', () => {
   let memoryProvider;
@@ -37,6 +38,7 @@ describe('planning result', () => {
     const context = await Manifest.load(manifestFilename, loader, {memoryProvider});
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    VolatileStorageDriverProvider.register(arc);
     const storageService = arc.storageService;
     const suggestions = await StrategyTestHelper.planForArc(arc);
 

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -24,6 +24,7 @@ import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js'
 describe('planning result', () => {
   let memoryProvider;
   beforeEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
@@ -91,8 +92,13 @@ describe('planning result', () => {
 describe('planning result merge', () => {
   let memoryProvider;
   beforeEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
+  });
+
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
   });
 
   const commonManifestStr = `

--- a/src/planning/strategies/tests/coalesce-recipes-test.ts
+++ b/src/planning/strategies/tests/coalesce-recipes-test.ts
@@ -16,12 +16,16 @@ import {RamDiskStorageDriverProvider} from '../../../runtime/storage/drivers/ram
 import {CoalesceRecipes} from '../../strategies/coalesce-recipes.js';
 
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
+import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
 
 describe('CoalesceRecipes', () => {
   let memoryProvider;
   beforeEach(() => {
       memoryProvider = new TestVolatileMemoryProvider();
       RamDiskStorageDriverProvider.register(memoryProvider);
+  });
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
   });
 
   async function tryCoalesceRecipes(manifestStr: string) {

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -15,6 +15,7 @@ import {RamDiskStorageDriverProvider} from '../../../runtime/storage/drivers/ram
 import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {SearchTokensToHandles} from '../../strategies/search-tokens-to-handles.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
+import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
 
 describe('SearchTokensToHandles', () => {
   let memoryProvider;
@@ -22,6 +23,10 @@ describe('SearchTokensToHandles', () => {
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('finds local handle by tags', async () => {
     const manifest = (await Manifest.parse(`
       schema Thing

--- a/src/runtime/recipe/tests/recipe-test.ts
+++ b/src/runtime/recipe/tests/recipe-test.ts
@@ -17,12 +17,17 @@ import {Entity} from '../../entity.js';
 import {Recipe} from '../lib-recipe.js';
 import {TestVolatileMemoryProvider} from '../../testing/test-volatile-memory-provider.js';
 import {RamDiskStorageDriverProvider} from '../../storage/drivers/ramdisk.js';
+import {DriverFactory} from '../../storage/drivers/driver-factory.js';
 
 describe('recipe', () => {
   let memoryProvider;
   beforeEach(() => {
       memoryProvider = new TestVolatileMemoryProvider();
       RamDiskStorageDriverProvider.register(memoryProvider);
+  });
+
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('normalize errors', async () => {

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -64,6 +64,10 @@ async function setup(storageKeyPrefix:  (arcId: ArcId) => StorageKey) {
 }
 
 describe('Arc new storage', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('preserves data when round-tripping through serialization', async () => {
     DriverFactory.clearRegistrationsForTesting();
     // TODO(shans): deserialization currently uses a RamDisk store to deserialize into because we don't differentiate
@@ -195,6 +199,10 @@ describe('Arc new storage', () => {
 const doSetup = async () => setup(arcId => new VolatileStorageKey(arcId, ''));
 
 describe('Arc', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('idle can safely be called multiple times ', async () => {
     const runtime = Runtime.newForNodeTesting();
     const arc = runtime.newArc('test');
@@ -1023,6 +1031,10 @@ describe('Arc', () => {
 });
 
 describe('Arc storage migration', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('supports new StorageKey type', Flags.withDefaultReferenceMode(async () => {
     const {arc, Foo} = await setup(arcId => new VolatileStorageKey(arcId, ''));
     const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');

--- a/src/runtime/tests/capabilities-resolver-test.ts
+++ b/src/runtime/tests/capabilities-resolver-test.ts
@@ -24,7 +24,10 @@ import {Manifest} from '../manifest.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 
 describe('Capabilities Resolver New', () => {
-  after(() => DriverFactory.clearRegistrationsForTesting());
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
 
   type StorageKeyType = typeof VolatileStorageKey|typeof RamDiskStorageKey|typeof DatabaseStorageKey;
   function verifyReferenceModeStorageKey(key: StorageKey, expectedType: StorageKeyType) {

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -55,6 +55,10 @@ describe('manifest', async () => {
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
 
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   const parseManifest = async (content: string, options: ManifestParseOptions = {memoryProvider}): Promise<Manifest> => {
     return Manifest.parse(content, options);
   };
@@ -4375,6 +4379,10 @@ describe('annotations', async () => {
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('parses annotations', async () => {
     const annotationsStr = `
 annotation noParam

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -21,6 +21,7 @@ import {StorageServiceImpl} from '../storage/storage-service.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 import {ramDiskStorageKeyPrefixForTest, volatileStorageKeyPrefixForTest} from '../testing/handle-for-test.js';
 import {Flags} from '../flags.js';
+import {DriverFactory} from '../storage/drivers/driver-factory.js';
 
 // tslint:disable-next-line: no-any
 function unsafe<T>(value: T): any { return value; }
@@ -45,6 +46,10 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
 }
 
 describe('Runtime', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('gets an arc description for an arc', async () => {
     const arc = new Arc({
       slotComposer: new SlotComposer(),

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -15,8 +15,13 @@ import {RamDiskStorageDriverProvider} from '../runtime/storage/drivers/ramdisk.j
 import {Loader} from '../platform/loader.js';
 import {TestVolatileMemoryProvider} from '../runtime/testing/test-volatile-memory-provider.js';
 import {storageKeyPrefixForTest} from '../runtime/testing/handle-for-test.js';
+import {DriverFactory} from '../runtime/storage/drivers/driver-factory.js';
 
 describe('Arc integration', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('copies store tags', async () => {
     const loader = new Loader(null, {
       'p.js': `defineParticle(({Particle}) => class P extends Particle {

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -17,8 +17,12 @@ import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {ActiveCollectionEntityStore, handleForActiveStore} from '../../runtime/storage/storage.js';
+import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 
 describe('common particles test', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
   it('resolves after cloning', async () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.parse(`

--- a/src/tests/particles/dataflow-test.ts
+++ b/src/tests/particles/dataflow-test.ts
@@ -14,6 +14,7 @@ import {analyseDataflow} from '../../dataflow/analysis/analysis.js';
 import {assert} from '../../platform/chai-web.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
+import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 
 // Checks that all of the Dataflow example recipes successfully pass dataflow
 // analysis.
@@ -33,4 +34,5 @@ describe('Dataflow example recipes', () => {
       }
     });
   }
+  DriverFactory.clearRegistrationsForTesting();
 });

--- a/src/tests/particles/particles-test.ts
+++ b/src/tests/particles/particles-test.ts
@@ -28,6 +28,10 @@ describe('Particle definitions', () => {
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
 
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   filenames
     .forEach(filename => {
       // skip experimental Native partices for now as they need a heavyweight build step

--- a/src/tests/particles/products-test.ts
+++ b/src/tests/particles/products-test.ts
@@ -24,8 +24,7 @@ import {CollectionEntityHandle, CollectionEntityType, handleForStoreInfo} from '
 import {StoreInfo} from '../../runtime/storage/store-info.js';
 
 describe('products test', () => {
-
-  beforeEach(() => {
+  afterEach(() => {
     DriverFactory.clearRegistrationsForTesting();
   });
 

--- a/src/tests/particles/transformation-slots-test.ts
+++ b/src/tests/particles/transformation-slots-test.ts
@@ -17,8 +17,13 @@ import {Loader} from '../../platform/loader.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
+import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 
 describe('transformation slots', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('combines hosted particles provided singleton slots into transformation provided set slot', async () => {
     const loader = new Loader();
     const memoryProvider = new TestVolatileMemoryProvider();

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -19,6 +19,7 @@ import {VolatileStorageKey} from '../runtime/storage/drivers/volatile.js';
 import {ArcId} from '../runtime/id.js';
 import {storageKeyPrefixForTest} from '../runtime/testing/handle-for-test.js';
 import {newRecipe} from '../runtime/recipe/lib-recipe.js';
+import {DriverFactory} from '../runtime/storage/drivers/driver-factory.js';
 
 describe('recipe descriptions test', () => {
   // Avoid initialising non-POD variables globally, since they would be constructed even when
@@ -36,6 +37,11 @@ describe('recipe descriptions test', () => {
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
+
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
 
   function createManifestString(options) {
     options = options || {};

--- a/src/tests/slot-composer-test.ts
+++ b/src/tests/slot-composer-test.ts
@@ -21,6 +21,7 @@ import {Runtime} from '../runtime/runtime.js';
 import {storageKeyPrefixForTest} from '../runtime/testing/handle-for-test.js';
 import {TestVolatileMemoryProvider} from '../runtime/testing/test-volatile-memory-provider.js';
 import {RamDiskStorageDriverProvider} from '../runtime/storage/drivers/ramdisk.js';
+import {DriverFactory} from '../runtime/storage/drivers/driver-factory.js';
 
 class TestSlotComposer extends SlotComposer {
   public readonly observer;
@@ -60,6 +61,10 @@ async function initSlotComposer(recipeStr) {
 }
 
 describe('slot composer', () => {
+  afterEach(() => {
+    DriverFactory.clearRegistrationsForTesting();
+  });
+
   it('initialize recipe and render slots', async () => {
     const manifestStr = `
 particle A in 'a.js'


### PR DESCRIPTION
fixes (hopefully) appveyor failure like:
```
1) planning result
       serializes and deserializes Products recipes:
     Uncaught Error: No driver exists to support storage key volatile://!740309714159264:demo:inner15/0.8721415459776243@
      at Function.construct (file:///C:/projects/arcs-3i77k/src/runtime/storage/direct-store.ts:84:13)
```