### PR TITLE
Fix gitignore mistake for Arcs-Live deploy.

### DIFF
--- a/tools/deployment/.gitignore
+++ b/tools/deployment/.gitignore
@@ -4,7 +4,7 @@
 # Include key directories for arcs-live
 !build/
 !concrete-storage/
-concrete-storage/node_modules/**  # Ignore installed dependencies
+concrete-storage/node_modules/  # Ignore installed dependencies
 !devtools/
 !dist/
 !extension/


### PR DESCRIPTION
Attempt to ignore all node_modules in concrete-storage in arcs-live repo.