### PR TITLE
Add close method to ReferenceModeStore

### DIFF
--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -29,7 +29,7 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
   open val versionToken: String? = options.versionToken
 
   /** Suspends until all pending operations are complete. */
-  open suspend fun idle() = Unit
+  abstract suspend fun idle()
 
   /**
    * Registers a [ProxyCallback] with the store and returns a token which can be used to
@@ -44,5 +44,5 @@ abstract class ActiveStore<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
   abstract suspend fun onProxyMessage(message: ProxyMessage<Data, Op, ConsumerData>)
 
   /** Performs any operations that are needed to release resources held by this [ActiveStore]. */
-  open fun close() = Unit
+  abstract fun close()
 }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -95,7 +95,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
 
   override suspend fun idle() {
     /**
-     * TODO: tune the debounce window
+     * TODO(b/172498981): tune the debounce window
      * Once this is enabled, change [DirectStoreMuxer.idle] accordingly to use
      * simultaneous launches.
      */


### PR DESCRIPTION
Help fix memory leakage. When a RefModeStore is closed, we also want to close its container store, and clear its direct store muxers.

- Add close method to ReferenceModeStore.
- Add test for ReferenceModeStore.close method.
- Make close method abstract on ActiveStore.
- Make idle method abstract on ActiveStore.
- Add tracking bug for implementing idle on DirecStore.
