### PR TITLE
remove unused import of arcs.core.entity.toPrimitiveValue from codegen

### DIFF
--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -164,7 +164,6 @@ ${tryImport('arcs.core.data.expression.Expression.*', this.namespace)}
 ${tryImport('arcs.core.data.expression.Expression.BinaryOp.*', this.namespace)}
 ${tryImport('arcs.core.data.Plan.*', this.namespace)}
 ${tryImport('arcs.core.storage.StorageKeyParser', this.namespace)}
-${tryImport('arcs.core.entity.toPrimitiveValue', this.namespace)}
 ${tryImport('arcs.core.util.ArcsInstant', this.namespace)}
 ${tryImport('arcs.core.util.ArcsDuration', this.namespace)}
 ${tryImport('arcs.core.util.BigInt', this.namespace)}

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -53,7 +53,6 @@ export class Schema2Kotlin extends Schema2Base {
         'import arcs.core.data.expression.Expression.*',
         'import arcs.core.data.expression.Expression.BinaryOp.*',
         'import arcs.core.data.util.toReferencable',
-        'import arcs.core.entity.toPrimitiveValue',
         'import arcs.sdk.ArcsDuration',
         'import arcs.sdk.ArcsInstant',
         'import arcs.sdk.BigInt',

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -13,7 +13,6 @@ import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
-import arcs.core.entity.toPrimitiveValue
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -12,7 +12,6 @@ import arcs.core.data.expression.*
 import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.toPrimitiveValue
 import arcs.sdk.ArcsDuration
 import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -12,7 +12,6 @@ import arcs.core.data.expression.*
 import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.util.toReferencable
-import arcs.core.entity.toPrimitiveValue
 import arcs.sdk.ArcsDuration
 import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt

--- a/src/tools/tests/goldens/plan-generator-plans.cgtest
+++ b/src/tools/tests/goldens/plan-generator-plans.cgtest
@@ -39,7 +39,6 @@ import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
-import arcs.core.entity.toPrimitiveValue
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt
@@ -159,7 +158,6 @@ import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
-import arcs.core.entity.toPrimitiveValue
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt
@@ -260,7 +258,6 @@ import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
 import arcs.core.storage.StorageKeyParser
-import arcs.core.entity.toPrimitiveValue
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt


### PR DESCRIPTION
then we can remove the function altogether