### PR TITLE
Created StorageChannelImpl

### DIFF
--- a/java/arcs/android/devtools/StoreSyncMessage.kt
+++ b/java/arcs/android/devtools/StoreSyncMessage.kt
@@ -12,7 +12,7 @@
 package arcs.android.devtools
 
 import arcs.android.devtools.DevToolsMessage.Companion.SYNC_MESSAGE
-import arcs.core.storage.ProxyMessage
+import arcs.core.storage.UntypedProxyMessage
 import arcs.core.util.JsonValue
 
 /**
@@ -20,7 +20,7 @@ import arcs.core.util.JsonValue
  * [SyncRequest].
  */
 class StoreSyncMessage(
-  private val actualMessage: ProxyMessage<*, *, *>,
+  private val actualMessage: UntypedProxyMessage,
   private val storeType: String,
   private val storageKey: String
 ) : DevToolsMessage {

--- a/java/arcs/android/storage/service/BaseStorageChannel.kt
+++ b/java/arcs/android/storage/service/BaseStorageChannel.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/** Base functionality common to all storage channels. */
+abstract class BaseStorageChannel(
+  private val scope: CoroutineScope,
+  private val statisticsSink: BindingContextStatisticsSink
+) : IStorageChannel.Stub() {
+  /** Identifier for the class. Used as the tag for tracing a transaction. */
+  protected abstract val tag: String
+
+  protected val actionLauncher = SequencedActionLauncher(scope)
+
+  protected var listenerToken: Int? = null
+
+  override fun idle(timeoutMillis: Long, resultCallback: IResultCallback?) {
+    // Don't use the SequencedActionLauncher, since we don't want an idle call to wait for other
+    // idle calls to complete.
+    scope.launch {
+      statisticsSink.traceAndMeasure("$tag.idle") {
+        resultCallback?.wrapException("idle failed") {
+          checkChannelIsOpen()
+          withTimeout(timeoutMillis) {
+            actionLauncher.waitUntilDone()
+            idleStore()
+          }
+        }
+      }
+    }
+  }
+
+  override fun close(resultCallback: IResultCallback?) {
+    actionLauncher.launch {
+      statisticsSink.traceAndMeasure("$tag.close") {
+        resultCallback?.wrapException("close failed") {
+          val token = checkNotNull(listenerToken) { "Channel has already been closed" }
+          unregisterFromStore(token)
+          listenerToken = null
+        }
+      }
+    }
+  }
+
+  protected fun checkChannelIsOpen() {
+    checkNotNull(listenerToken) { "Channel is closed" }
+  }
+
+  /** Calls [idle] on the store that this channel communicates with. */
+  abstract suspend fun idleStore()
+
+  /** Unregister from the store that this channel communicates with. */
+  abstract suspend fun unregisterFromStore(token: Int)
+}

--- a/java/arcs/android/storage/service/BindingContext.kt
+++ b/java/arcs/android/storage/service/BindingContext.kt
@@ -23,9 +23,9 @@ import arcs.core.crdt.CrdtOperation
 import arcs.core.storage.ActiveStore
 import arcs.core.storage.DevToolsForStorage
 import arcs.core.storage.DriverFactory
-import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreOptions
+import arcs.core.storage.UntypedProxyMessage
 import arcs.core.storage.WriteBackProvider
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
@@ -72,7 +72,7 @@ class BindingContext(
   private val bindingContextStatisticsSink: BindingContextStatisticsSink,
   private val devTools: DevToolsForStorage?,
   /** Callback to trigger when a proxy message has been received and sent to the store. */
-  private val onProxyMessage: suspend (StorageKey, ProxyMessage<*, *, *>) -> Unit = { _, _ -> }
+  private val onProxyMessage: suspend (StorageKey, UntypedProxyMessage) -> Unit = { _, _ -> }
 ) : IStorageService.Stub() {
   @VisibleForTesting
   val id = nextId.incrementAndGet()

--- a/java/arcs/android/storage/service/DevToolsProxyImpl.kt
+++ b/java/arcs/android/storage/service/DevToolsProxyImpl.kt
@@ -8,6 +8,7 @@ import arcs.core.storage.DirectStore
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.ReferenceModeStore
 import arcs.core.storage.StoreOptions
+import arcs.core.storage.UntypedProxyMessage
 
 /**
  * Implementation of [IDevToolsProxy] to allow communication between the [StorageService] and
@@ -23,7 +24,7 @@ class DevToolsProxyImpl : IDevToolsProxy.Stub(), DevToolsForStorage {
   /**
    * Execute the callbacks to be called when the [ReferenceModeStore] receives a [ProxyMessage]
    */
-  fun onRefModeStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>, options: StoreOptions) {
+  fun onRefModeStoreProxyMessage(proxyMessage: UntypedProxyMessage, options: StoreOptions) {
     onRefModeStoreProxyMessageCallbacks.forEach { (_, callback) ->
       callback.onProxyMessage(proxyMessage.toProto().toByteArray(), options.storageKey.toString())
     }
@@ -32,7 +33,7 @@ class DevToolsProxyImpl : IDevToolsProxy.Stub(), DevToolsForStorage {
   /**
    * Execute the callbacks to be called when the [DirectStore] receives a [ProxyMessage]
    */
-  fun onDirectStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>, options: StoreOptions) {
+  fun onDirectStoreProxyMessage(proxyMessage: UntypedProxyMessage, options: StoreOptions) {
     onDirectStoreProxyMessageCallbacks.forEach { (_, callback) ->
       callback.onProxyMessage(proxyMessage.toProto().toByteArray(), options.storageKey.toString())
     }
@@ -79,7 +80,7 @@ class DevToolsForDirectStoreImpl(
   proxy: DevToolsProxyImpl,
   val options: StoreOptions
 ) : DevToolsForStorageImpl(proxy), DevToolsForDirectStore {
-  override fun onDirectStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>) =
+  override fun onDirectStoreProxyMessage(proxyMessage: UntypedProxyMessage) =
     proxy.onDirectStoreProxyMessage(proxyMessage, options)
 }
 
@@ -88,6 +89,6 @@ class DevToolsForRefModeStoreImpl(
   proxy: DevToolsProxyImpl,
   val options: StoreOptions
 ) : DevToolsForStorageImpl(proxy), DevToolsForRefModeStore {
-  override fun onRefModeStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>) =
+  override fun onRefModeStoreProxyMessage(proxyMessage: UntypedProxyMessage) =
     proxy.onRefModeStoreProxyMessage(proxyMessage, options)
 }

--- a/java/arcs/android/storage/service/StorageChannelImpl.kt
+++ b/java/arcs/android/storage/service/StorageChannelImpl.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service
+
+import arcs.android.storage.StorageServiceMessageProto
+import arcs.android.storage.decode
+import arcs.android.storage.decodeStorageServiceMessageProto
+import arcs.android.storage.toProto
+import arcs.core.storage.StorageKey
+import arcs.core.storage.UntypedActiveStore
+import arcs.core.storage.UntypedProxyMessage
+import kotlinx.coroutines.CoroutineScope
+
+/** Implementation of [IStorageChannel] for communicating with an [ActiveStore]. */
+class StorageChannelImpl(
+  private val store: UntypedActiveStore,
+  scope: CoroutineScope,
+  private val statisticsSink: BindingContextStatisticsSink,
+  /** Callback to trigger when a proxy message has been received and sent to the store. */
+  private val onProxyMessageCallback: suspend (StorageKey, UntypedProxyMessage) -> Unit
+) : BaseStorageChannel(scope, statisticsSink) {
+  override val tag = "StorageChannel"
+
+  override fun sendMessage(encodedMessage: ByteArray, resultCallback: IResultCallback) {
+    actionLauncher.launch {
+      statisticsSink.traceAndMeasure("$tag.sendMessage") {
+        resultCallback.wrapException("sendMessage failed") {
+          checkChannelIsOpen()
+          val proto = encodedMessage.decodeStorageServiceMessageProto()
+          require(proto.messageCase == StorageServiceMessageProto.MessageCase.PROXY_MESSAGE) {
+            "Expected a ProxyMessageProto, but received ${proto.messageCase}"
+          }
+          val message = proto.proxyMessage.decode()
+          store.onProxyMessage(message.withId(listenerToken!!))
+          onProxyMessageCallback(store.storageKey, message)
+        }
+      }
+    }
+  }
+
+  override suspend fun idleStore() {
+    store.idle()
+  }
+
+  override suspend fun unregisterFromStore(token: Int) {
+    store.off(token)
+  }
+
+  companion object {
+    suspend fun create(
+      store: UntypedActiveStore,
+      scope: CoroutineScope,
+      statisticsSink: BindingContextStatisticsSink,
+      callback: IMessageCallback,
+      onProxyMessageCallback: suspend (StorageKey, UntypedProxyMessage) -> Unit
+    ): StorageChannelImpl {
+      return StorageChannelImpl(store, scope, statisticsSink, onProxyMessageCallback).also {
+        it.listenerToken = store.on { message ->
+          callback.onMessage(
+            StorageServiceMessageProto.newBuilder()
+              .setProxyMessage(message.toProto())
+              .build()
+              .toByteArray()
+          )
+        }
+      }
+    }
+  }
+}

--- a/java/arcs/android/storage/service/testing/BUILD
+++ b/java/arcs/android/storage/service/testing/BUILD
@@ -11,6 +11,7 @@ arcs_kt_android_library(
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     deps = [
         "//java/arcs/android/crdt:crdt_exception_android_proto",
+        "//java/arcs/android/storage/service",
         "//java/arcs/android/storage/service:aidl",
         "//java/arcs/android/util",
         "//third_party/kotlin/kotlinx_coroutines",

--- a/java/arcs/android/storage/service/testing/NoopStorageChannel.kt
+++ b/java/arcs/android/storage/service/testing/NoopStorageChannel.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service.testing
+
+import arcs.android.storage.service.BaseStorageChannel
+import arcs.android.storage.service.BindingContextStatisticsSink
+import arcs.android.storage.service.BindingContextStatsImpl
+import arcs.android.storage.service.IResultCallback
+import kotlinx.coroutines.CoroutineScope
+
+/** No-op implementation of [IStorageChannel] used for testing. */
+open class NoopStorageChannel(
+  scope: CoroutineScope,
+  statisticsSink: BindingContextStatisticsSink = BindingContextStatsImpl()
+) : BaseStorageChannel(scope, statisticsSink) {
+  override val tag = "NoopStorageChannel"
+
+  init {
+    // Connection to a store is simulated by setting the listenerToken
+    listenerToken = 0
+  }
+  override suspend fun idleStore() {}
+
+  override suspend fun unregisterFromStore(token: Int) {}
+
+  override fun sendMessage(encodedMessage: ByteArray?, resultCallback: IResultCallback?) {}
+}

--- a/java/arcs/core/storage/ActiveStore.kt
+++ b/java/arcs/core/storage/ActiveStore.kt
@@ -15,6 +15,9 @@ import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 import arcs.core.type.Type
 
+/** An [ActiveStore] that accepts any data type. */
+typealias UntypedActiveStore = ActiveStore<CrdtData, CrdtOperation, Any?>
+
 /**
  * Representation of an *active* store.
  *

--- a/java/arcs/core/storage/DevToolsForStorage.kt
+++ b/java/arcs/core/storage/DevToolsForStorage.kt
@@ -23,7 +23,7 @@ interface DevToolsForDirectStore : DevToolsForStorage {
   /**
    * Function to call when a [DirectStore] receives a [ProxyMessage].
    */
-  fun onDirectStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>)
+  fun onDirectStoreProxyMessage(proxyMessage: UntypedProxyMessage)
 }
 
 /**
@@ -33,5 +33,5 @@ interface DevToolsForRefModeStore : DevToolsForStorage {
   /**
    * Function to call when a [ReferenceModeStore] receives a [ProxyMessage].
    */
-  fun onRefModeStoreProxyMessage(proxyMessage: ProxyMessage<*, *, *>)
+  fun onRefModeStoreProxyMessage(proxyMessage: UntypedProxyMessage)
 }

--- a/java/arcs/core/storage/DirectStore.kt
+++ b/java/arcs/core/storage/DirectStore.kt
@@ -205,7 +205,7 @@ class DirectStore<Data : CrdtData, Op : CrdtOperation, T> /* internal */ constru
       }
     }.also {
       log.verbose { "Model after proxy message: ${localModel.data}" }
-      devTools?.onDirectStoreProxyMessage(proxyMessage = message)
+      devTools?.onDirectStoreProxyMessage(proxyMessage = message as UntypedProxyMessage)
     }
   }
 

--- a/java/arcs/core/storage/ProxyInterface.kt
+++ b/java/arcs/core/storage/ProxyInterface.kt
@@ -14,6 +14,9 @@ package arcs.core.storage
 import arcs.core.crdt.CrdtData
 import arcs.core.crdt.CrdtOperation
 
+/** A [ProxyMessage] of any data type. */
+typealias UntypedProxyMessage = ProxyMessage<CrdtData, CrdtOperation, Any?>
+
 /** A message coming from the storage proxy into one of the [IStore] implementations. */
 sealed class ProxyMessage<Data : CrdtData, Op : CrdtOperation, ConsumerData>(
   /** Identifier for the sender of the [ProxyMessage]. */

--- a/java/arcs/core/storage/ReferenceModeStore.kt
+++ b/java/arcs/core/storage/ReferenceModeStore.kt
@@ -209,7 +209,7 @@ class ReferenceModeStore private constructor(
   ) {
     log.verbose { "onProxyMessage: $message" }
     val refModeMessage = message.sanitizeForRefModeStore(type)
-    devTools?.onRefModeStoreProxyMessage(message)
+    devTools?.onRefModeStoreProxyMessage(message as UntypedProxyMessage)
     receiveQueue.enqueueAndWait {
       handleProxyMessage(refModeMessage)
     }

--- a/java/arcs/core/storage/referencemode/Message.kt
+++ b/java/arcs/core/storage/referencemode/Message.kt
@@ -19,9 +19,10 @@ import arcs.core.crdt.CrdtOperationAtTime
 import arcs.core.crdt.CrdtSet
 import arcs.core.crdt.CrdtSingleton
 import arcs.core.storage.ProxyMessage
+import arcs.core.storage.UntypedProxyMessage
 
 /** Converts a general [ProxyMessage] into a reference mode-safe [ProxyMessage]. */
-fun ProxyMessage<CrdtData, CrdtOperation, Any?>.toReferenceModeMessage():
+fun UntypedProxyMessage.toReferenceModeMessage():
   ProxyMessage<CrdtData, CrdtOperationAtTime, Referencable> {
   return when (this) {
     is ProxyMessage.ModelUpdate ->

--- a/java/arcs/core/storage/testutil/NoopActiveStore.kt
+++ b/java/arcs/core/storage/testutil/NoopActiveStore.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.core.storage.testutil
+
+import arcs.core.crdt.CrdtData
+import arcs.core.crdt.CrdtOperation
+import arcs.core.storage.ProxyCallback
+import arcs.core.storage.StoreOptions
+import arcs.core.storage.UntypedActiveStore
+import arcs.core.storage.UntypedProxyMessage
+
+/** No-op implementation of [ActiveStore] used for testing. */
+open class NoopActiveStore(storeOptions: StoreOptions) : UntypedActiveStore(storeOptions) {
+  override suspend fun idle() {}
+
+  override suspend fun on(callback: ProxyCallback<CrdtData, CrdtOperation, Any?>): Int = 0
+
+  override suspend fun off(callbackToken: Int) {}
+
+  override suspend fun onProxyMessage(message: UntypedProxyMessage) {}
+
+  override fun close() {}
+}

--- a/javatests/arcs/android/storage/service/BaseStorageChannelTest.kt
+++ b/javatests/arcs/android/storage/service/BaseStorageChannelTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.android.storage.service.testing.FakeResultCallback
+import arcs.android.storage.service.testing.NoopStorageChannel
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BaseStorageChannelTest {
+
+  private lateinit var resultCallback: FakeResultCallback
+
+  @Before
+  fun setUp() {
+    resultCallback = FakeResultCallback()
+  }
+
+  @Test
+  fun idle_waitsForStoreIdle() = runBlockingTest {
+    val job = Job()
+    val channel = object : NoopStorageChannel(this) {
+      override suspend fun idleStore() {
+        assertThat(resultCallback.hasBeenCalled).isFalse()
+        job.complete()
+      }
+    }
+
+    channel.idle(1000, resultCallback)
+    job.join()
+
+    val result = resultCallback.waitForResult()
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun idle_propagatesExceptions() = runBlockingTest {
+    val channel = object : NoopStorageChannel(this) {
+      override suspend fun idleStore() {
+        assertThat(resultCallback.hasBeenCalled).isFalse()
+        throw InternalError()
+      }
+    }
+
+    channel.idle(1000, resultCallback)
+
+    val result = resultCallback.waitForResult()
+    assertThat(result).contains("idle failed")
+  }
+
+  @Test
+  fun idle_whenChannelIsClosed_returnsError() = runBlockingTest {
+    val channel = createClosedChannel(this)
+
+    channel.idle(1000, resultCallback)
+
+    val result = resultCallback.waitForResult()
+    assertThat(result).contains("idle failed")
+  }
+
+  @Test
+  fun close_unregistersListener() = runBlockingTest {
+    val job = Job()
+    val channel = object : NoopStorageChannel(this) {
+      override suspend fun unregisterFromStore(token: Int) {
+        assertThat(resultCallback.hasBeenCalled).isFalse()
+        job.complete()
+      }
+    }
+
+    channel.close(resultCallback)
+    job.join()
+
+    val result = resultCallback.waitForResult()
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun close_whenChannelIsClosed_returnsError() = runBlockingTest {
+    val channel = createClosedChannel(this)
+
+    // Attempt to close the channel again
+    channel.close(resultCallback)
+    val secondChannelClosingResult = resultCallback.waitForResult()
+    assertThat(secondChannelClosingResult).contains("close failed")
+  }
+
+  private suspend fun createClosedChannel(scope: CoroutineScope): NoopStorageChannel {
+    val channel = NoopStorageChannel(scope)
+    val callback = FakeResultCallback()
+    channel.close(callback)
+    val result = callback.waitForResult()
+    assertThat(result).isNull()
+    return channel
+  }
+}

--- a/javatests/arcs/android/storage/service/BindingContextTest.kt
+++ b/javatests/arcs/android/storage/service/BindingContextTest.kt
@@ -19,6 +19,7 @@ import arcs.core.data.CountType
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.StorageKey
 import arcs.core.storage.StoreOptions
+import arcs.core.storage.UntypedProxyMessage
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import arcs.core.storage.driver.RamDisk
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -77,7 +78,7 @@ class BindingContextTest {
   }
 
   private fun buildContext(
-    callback: suspend (StorageKey, ProxyMessage<*, *, *>) -> Unit = { _, _ -> }
+    callback: suspend (StorageKey, UntypedProxyMessage) -> Unit = { _, _ -> }
   ) = BindingContext(
     store,
     bindingContextScope,


### PR DESCRIPTION
`StorageChannelImpl` is an implementation of `IStorageChannel` that can communicate with an `ActiveStore`. This is part of the migration to use `IStorageServiceNg` for when a client wants to bind to the `StorageService` to communicate to an `ActiveStore`. There will be an implementation of `IStorageChannelNg` **(not yet implemented)** that will create a `StorageChannelImpl` upon invoking `openStorageChannel`.

Additionally:
- Created a base class (`BaseStorageChannel`) for the common functionality shared between `StorageChannelImpl` and `MuxedStorageChannelImpl`.
- NoopActiveStore for testing.