### PR TITLE
Remove primitive types from db and improve instant tests

### DIFF
--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -205,12 +205,12 @@ class DatabaseImpl(
   private fun initializeDatabase(db: SQLiteDatabase) {
     db.transaction {
       CREATE.forEach(db::execSQL)
-      InitializeTypesTable(db)
+      initializeTypesTable(db)
     }
   }
 
   /* Initializes the types table values. */
-  private fun InitializeTypesTable(db: SQLiteDatabase) {
+  private fun initializeTypesTable(db: SQLiteDatabase) {
     // We used to keep primitive types in the table, and used the sentinel to distinguish between
     // primitive and entity types.
     // Now we only keep entity types here, but the sentinel is kept for backwards compatibility.

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -211,19 +211,9 @@ class DatabaseImpl(
 
   /* Initializes the [PrimitiveType] values. */
   private fun initializePrimitiveTypes(db: SQLiteDatabase) {
-    // Populate the 'types' table with the primitive types. The id of the enum will be
-    // the Type ID used in the database.
-    val content = ContentValues().apply {
-      put("is_primitive", true)
-    }
-    PrimitiveType.values().forEach {
-      content.apply {
-        put("id", it.id)
-        put("name", it.name)
-      }
-      db.insertOrThrow(TABLE_TYPES, null, content)
-    }
-
+    // Populate the 'types' table with the sentinel value for reference types.
+    // The id of the enum will be the Type ID used in the database.
+    // Other primitive types will not be stored (the enum itself will be used).
     val sentinel = ContentValues().apply {
       put("is_primitive", true)
       put("id", REFERENCE_TYPE_SENTINEL)
@@ -2378,10 +2368,6 @@ class DatabaseImpl(
     private val VERSION_6_MIGRATION = arrayOf(
       "ALTER TABLE entity_refs ADD COLUMN is_hard_ref INTEGER;"
     )
-    private val VERSION_7_MIGRATION = arrayOf(
-      "INSERT INTO types (id, name, is_primitive) VALUES (11, \"ArcsInstant\", 1)",
-      "INSERT INTO types (id, name, is_primitive) VALUES (11, \"ArcsDuration\", 1)"
-    )
 
     @VisibleForTesting
     val MIGRATION_STEPS = mapOf(
@@ -2389,8 +2375,7 @@ class DatabaseImpl(
       3 to VERSION_3_MIGRATION,
       4 to VERSION_4_MIGRATION,
       5 to VERSION_5_MIGRATION,
-      6 to VERSION_6_MIGRATION,
-      7 to VERSION_7_MIGRATION
+      6 to VERSION_6_MIGRATION
     )
 
     @VisibleForTesting
@@ -2399,7 +2384,6 @@ class DatabaseImpl(
       4 to CREATE_VERSION_3,
       5 to CREATE_VERSION_3,
       6 to CREATE_VERSION_6
-      // TODO(b/172167055): add 7 when we are ready for that migration.
     )
 
     private val CREATE = checkNotNull(CREATES_BY_VERSION[DB_VERSION])

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -2362,9 +2362,9 @@ class DatabaseImpl(
       listOf(DROP_VERSION_2, CREATE_VERSION_3).flatten().toTypedArray()
     private val VERSION_4_MIGRATION =
       listOf(DROP_VERSION_3, CREATE_VERSION_4).flatten().toTypedArray()
-    private val VERSION_5_MIGRATION = arrayOf(
-      "INSERT INTO types (id, name, is_primitive) VALUES (10, \"BigInt\", 1)"
-    )
+    // This migration was previously needed to update the types table with new primitive types.
+    // It is no longer needed as primitive types are no longer kept in the types table.
+    private val VERSION_5_MIGRATION = emptyArray<String>()
     private val VERSION_6_MIGRATION = arrayOf(
       "ALTER TABLE entity_refs ADD COLUMN is_hard_ref INTEGER;"
     )

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -205,15 +205,15 @@ class DatabaseImpl(
   private fun initializeDatabase(db: SQLiteDatabase) {
     db.transaction {
       CREATE.forEach(db::execSQL)
-      initializePrimitiveTypes(db)
+      InitializeTypesTable(db)
     }
   }
 
-  /* Initializes the [PrimitiveType] values. */
-  private fun initializePrimitiveTypes(db: SQLiteDatabase) {
-    // Populate the 'types' table with the sentinel value for reference types.
-    // The id of the enum will be the Type ID used in the database.
-    // Other primitive types will not be stored (the enum itself will be used).
+  /* Initializes the types table values. */
+  private fun InitializeTypesTable(db: SQLiteDatabase) {
+    // We used to keep primitive types in the table, and used the sentinel to distinguish between
+    // primitive and entity types.
+    // Now we only keep entity types here, but the sentinel is kept for backwards compatibility.
     val sentinel = ContentValues().apply {
       put("is_primitive", true)
       put("id", REFERENCE_TYPE_SENTINEL)

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -2381,8 +2381,8 @@ class DatabaseImpl(
     @VisibleForTesting
     val CREATES_BY_VERSION = mapOf(
       3 to CREATE_VERSION_3,
-      4 to CREATE_VERSION_3,
-      5 to CREATE_VERSION_3,
+      4 to CREATE_VERSION_4,
+      5 to CREATE_VERSION_5,
       6 to CREATE_VERSION_6
     )
 

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -561,7 +561,8 @@ class DatabaseImplTest {
           "double" to FieldType.Double,
           "txtlst" to FieldType.ListOf(FieldType.Text),
           "lnglst" to FieldType.ListOf(FieldType.Long),
-          "bigint" to FieldType.BigInt,
+          "bigintlst" to FieldType.ListOf(FieldType.BigInt),
+          "instantlst" to FieldType.ListOf(FieldType.Instant),
           "inlined" to FieldType.InlineEntity("inlineHash"),
           "inlinelist" to FieldType.ListOf(FieldType.InlineEntity("inlineHash"))
         ),
@@ -620,7 +621,23 @@ class DatabaseImplTest {
           "lnglst" to listOf(1L, 2L, 4L, 4L, 3L).map {
             it.toReferencable()
           }.toReferencable(FieldType.ListOf(FieldType.Long)),
-          "bigint" to BigInt.valueOf(123).toReferencable(),
+          "bigintlst" to listOf(
+            BigInt("10000000000000000000000000000001"),
+            BigInt("10000000000000000000000000000002"),
+            BigInt("4"),
+            BigInt("4"),
+            BigInt("-3"),
+            BigInt("3")
+          ).map {
+            it.toReferencable()
+          }.toReferencable(FieldType.ListOf(FieldType.BigInt)),
+          "instantlst" to listOf(
+            ArcsInstant.ofEpochMilli(1000000000000000001L),
+            ArcsInstant.ofEpochMilli(1000000000000123456L),
+            ArcsInstant.ofEpochMilli(1000000000123123123L)
+          ).map {
+            it.toReferencable()
+          }.toReferencable(FieldType.ListOf(FieldType.Instant)),
           "inlined" to inlineEntity,
           "inlinelist" to listOf(
             toInlineEntity("inlist", 3.0, setOf("A", "Z")),


### PR DESCRIPTION
Removes unused MIGRATION for Instant support along with unused PrimitiveType info from the DB.
This should mean that future primitive types can be added without migrations.

Also adds BigInt and Instant lists to the database store + retrieval entity test as these were missed previously.