### PR TITLE
(ts) fewer runtime globals (step 1)

### DIFF
--- a/shells/pipes-shell/source/dispatcher.js
+++ b/shells/pipes-shell/source/dispatcher.js
@@ -22,8 +22,3 @@ export const dispatcher = {
     }
   }
 };
-
-export const registerHandler = (name, handler) => {
-  dispatcher[`${name}`] = handler;
-  console.log('registered handler: ', name);
-};

--- a/shells/pipes-shell/source/verbs/parse.js
+++ b/shells/pipes-shell/source/verbs/parse.js
@@ -14,15 +14,15 @@ import {logsFactory} from '../../../../build/platform/logs-factory.js';
 const {log} = logsFactory('pipe::parse');
 
 // can provide either a path or literal content for a manifest
-export const parse = async ({id, path, content}, bus) => {
+export const parse = async (runtime, {id, path, content}, bus) => {
   // TODO(sjmiles): catch exceptions and relay over bus?
   let manifest;
   if (path) {
     log(`loading [${path}]`);
-    manifest = await Runtime.parseFile(path);
+    manifest = await runtime.parseFile(path);
   } else if (content) {
     log(`parsing [${content.length}] bytes`);
-    manifest = await Runtime.parse(content);
+    manifest = await runtime.parse(content);
   }
   let recipes = [];
   if (manifest) {

--- a/shells/pipes-shell/web/web.js
+++ b/shells/pipes-shell/web/web.js
@@ -54,7 +54,6 @@ const DeviceSupport = async () => {
     let waits = Math.round(deviceTimeout / delay);
     const wait = () => {
       if (window.DeviceClient) {
-        //console.log(window.DeviceClient);
         resolve(window.DeviceClient);
       } else {
         if (waits-- === 0) {

--- a/shells/pipes-shell/web/web.js
+++ b/shells/pipes-shell/web/web.js
@@ -54,7 +54,7 @@ const DeviceSupport = async () => {
     let waits = Math.round(deviceTimeout / delay);
     const wait = () => {
       if (window.DeviceClient) {
-        console.log(window.DeviceClient);
+        //console.log(window.DeviceClient);
         resolve(window.DeviceClient);
       } else {
         if (waits-- === 0) {

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -86,7 +86,7 @@ describe('Multiplexer', () => {
     const observer = new SlotTestObserver();
     arc.peh.slotComposer.observeSlots(observer);
 
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
 
     // Render 3 posts

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -177,7 +177,7 @@ describe('Multiplexer', () => {
     const arc = runtime.newArc('fooTest', storageKeyPrefixForTest());
     //
     const recipe = context.recipes[0];
-    const plan = await runtime.resolveRecipe(arc, recipe);
+    const plan = await Runtime.resolveRecipe(arc, recipe);
     await arc.instantiate(plan);
     await arc.idle;
 

--- a/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
+++ b/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
@@ -73,7 +73,7 @@ describe('plan consumer', () => {
     `, {loader, fileName: '', memoryProvider});
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
-    let suggestions = await StrategyTestHelper.planForArc(arc);
+    let suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const consumer = await createPlanConsumer(arc);
     let suggestionsChangeCount = 0;
@@ -114,7 +114,7 @@ describe('plan consumer', () => {
     assert.strictEqual(visibleSuggestionsChangeCount, 3);
 
     await suggestions[0].instantiate(arc);
-    suggestions = await StrategyTestHelper.planForArc(arc);
+    suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     await storeResults(consumer, suggestions);
     assert.lengthOf(consumer.result.suggestions, 3);
 

--- a/shells/tests/arcs/ts/runtime/slot-composer-test.ts
+++ b/shells/tests/arcs/ts/runtime/slot-composer-test.ts
@@ -48,7 +48,7 @@ async function initSlotComposer(recipeStr) {
   const arc = runtime.newArc('test-arc');
 
   const planner = new Planner();
-  const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
+  const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
   planner.init(arc, options);
 
   await planner.strategizer.generate();

--- a/shells/tests/arcs/ts/runtime/slot-composer-test.ts
+++ b/shells/tests/arcs/ts/runtime/slot-composer-test.ts
@@ -126,7 +126,7 @@ recipe
     const runtime = new Runtime({loader, context, memoryProvider});
 
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const suggestion = suggestions.find(s => s.plan.name === 'FilterAndDisplayBooks');
     assert.deepEqual(

--- a/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
@@ -49,7 +49,7 @@ describe('transformation slots', () => {
         .expectRenderSlot('ShowFooAnnotation', 'annotation', {times: 2})
         ;
 
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
     await suggestions[0].instantiate(arc);
     await arc.idle;

--- a/src/dataflow/cli/flowcheck.ts
+++ b/src/dataflow/cli/flowcheck.ts
@@ -15,7 +15,7 @@ import {Runtime} from '../../runtime/runtime.js';
 // TODO make this a function and test it; it's big enough now
 
 (async () => {
-  Runtime.init('../../..');
+  const runtime = Runtime.init('../../..');
   const filenames = process.argv.slice(2);
   if (filenames.length === 0) {
     console.error('Usage: flowcheck <manifest files>');
@@ -24,7 +24,7 @@ import {Runtime} from '../../runtime/runtime.js';
 
   for (const filename of filenames) {
     console.log(`Checking file ${filename}`);
-    const manifest = await Runtime.parse(`import '${filename}'`);
+    const manifest = await runtime.parse(`import '${filename}'`);
     for (const recipe of manifest.allRecipes) {
       console.log(`  Checking recipe ${recipe.name}`);
 

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -99,7 +99,8 @@ describe('plan producer', () => {
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const suggestions = await StrategyTestHelper.planForArc(
-        runtime.newArc('demo', storageKeyPrefixForTest())
+      runtime,
+      runtime.newArc('demo', storageKeyPrefixForTest())
     );
     const store = await Planificator['_initSuggestStore'](arc, storageKeyForTest(arc.id));
     assert.isNotNull(store);

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -40,7 +40,7 @@ describe('planning result', () => {
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     VolatileStorageDriverProvider.register(arc);
     const storageManager = arc.storageManager;
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     assert.isNotEmpty(suggestions);
     const result = new PlanningResult({context, loader, storageManager});
@@ -60,7 +60,7 @@ describe('planning result', () => {
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const storageManager = arc.storageManager;
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const result = new PlanningResult({loader, context, storageManager});
     // Appends new suggestion.

--- a/src/planning/testing/strategy-test-helper.ts
+++ b/src/planning/testing/strategy-test-helper.ts
@@ -28,9 +28,9 @@ export class StrategyTestHelper {
   static createTestStrategyArgs(arc: Arc, args?) {
     return {recipeIndex: RecipeIndex.create(arc), ...args};
   }
-  static async planForArc(arc: Arc): Promise<Suggestion[]> {
+  static async planForArc(runtime: Runtime, arc: Arc): Promise<Suggestion[]> {
     const planner = new Planner();
-    planner.init(arc, {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)});
+    planner.init(arc, {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)});
     return planner.suggest();
   }
 

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -103,7 +103,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   const runtime = new Runtime({context: loadedManifest, loader});
   const arc = runtime.newArc('test-plan-arc');
   const planner = new Planner();
-  const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator()};
+  const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator()};
   planner.init(arc, options);
 
   const plans = await planner.suggest(Infinity);

--- a/src/runtime/arc-exceptions.ts
+++ b/src/runtime/arc-exceptions.ts
@@ -136,9 +136,12 @@ export const defaultSystemExceptionHandler = (arc: Arc, exception: Error) => {
       console.log(`Exception in unknown particle, method '${exception.method}'`);
     } else if (exception.cause) {
       console.log(`Exception in unknown particle, cause '${exception.cause.stack}'`, exception.cause);
+    } else {
+      console.log(exception.message || exception);
     }
+  } else {
+    console.log(exception.message || exception);
   }
-  console.log(exception.message || exception);
   arc.dispose();
 };
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -876,6 +876,8 @@ ${e.message}
 
     const processArgTypes = args => {
       for (const arg of args) {
+        // TOOD(sjmiles): extremely noisy warning here, since many canonical schemas
+        // still use deprecated syntax.
         if (arg.type && arg.type.kind === 'type-name'
             // For now let's focus on entities, we should do interfaces next.
             && arg.type.model && arg.type.model.tag === 'Entity') {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -67,11 +67,8 @@ type SpawnArgs = {
   storageManager: StorageEndpointManager
 };
 
-let runtime: Runtime | null = null;
+//let runtime: Runtime | null = null;
 
-// To start with, this class will simply hide the runtime classes that are
-// currently imported by ArcsLib.js. Once that refactoring is done, we can
-// think about what the api should actually look like.
 @SystemTrace
 export class Runtime {
   public context: Manifest;
@@ -91,23 +88,23 @@ export class Runtime {
    * plumbing `runtime` arguments through numerous functions.
    * Some static methods on this class automatically use the default environment.
    */
-  static getRuntime() {
-    if (!runtime) {
-      runtime = new Runtime();
-    }
-    return runtime;
-  }
+  // static getRuntime() {
+  //   if (!runtime) {
+  //     runtime = new Runtime();
+  //   }
+  //   return runtime;
+  // }
 
-  static clearRuntimeForTesting() {
-    if (runtime) {
-      runtime.destroy();
-      runtime = null;
-    }
-  }
+  //static clearRuntimeForTesting() {
+    // if (runtime) {
+    //   runtime.destroy();
+    //   runtime = null;
+    // }
+  //}
 
-  static newForNodeTesting(context?: Manifest) {
-    return new Runtime({context});
-  }
+  // static newForNodeTesting(context?: Manifest) {
+  //   return new Runtime({context});
+  // }
 
   /**
    * Call `init` to establish a default Runtime environment (capturing the return value is optional).
@@ -153,13 +150,13 @@ export class Runtime {
 
   constructor({loader, composerClass, context, pecFactory, memoryProvider, storageManager}: RuntimeOptions = {}) {
     this.cacheService = new RuntimeCacheService();
-    this.loader = loader || new Loader();
     this.pecFactory = pecFactory;
+    this.loader = loader || new Loader();
     this.composerClass = composerClass || SlotComposer;
     this.context = context || new Manifest({id: 'manifest:default'});
     this.memoryProvider = memoryProvider || new SimpleVolatileMemoryProvider();
     this.storageManager = storageManager || new DirectStorageEndpointManager();
-    runtime = this;
+    //runtime = this;
     // user information. One persona per runtime for now.
   }
 
@@ -309,39 +306,41 @@ export class Runtime {
 
   // TODO(sjmiles): redundant vs. newArc, but has some impedance mismatch
   // strategy is to merge first, unify second
-  async spawnArc({id, serialization, context, composer, storage, portFactories, inspectorFactory, storageManager}: SpawnArgs): Promise<Arc> {
-    const arcid = IdGenerator.newSession().newArcId(id);
-    const storageKey = new VolatileStorageKey(arcid, '');
-    const params = {
-      id: arcid,
-      fileName: './serialized.manifest',
-      serialization,
-      context: context || this.context,
-      storageKey,
-      slotComposer: composer,
-      pecFactories: [this.pecFactory, ...(portFactories || [])],
-      loader: this.loader,
-      inspectorFactory,
-      storageManager
-    };
-    return serialization ? Arc.deserialize(params) : new Arc(params);
-  }
+  // async spawnArc({id, serialization, context, composer, storage, portFactories, inspectorFactory, storageManager}: SpawnArgs): Promise<Arc> {
+  //   const arcid = IdGenerator.newSession().newArcId(id);
+  //   const storageKey = new VolatileStorageKey(arcid, '');
+  //   const params = {
+  //     id: arcid,
+  //     fileName: './serialized.manifest',
+  //     serialization,
+  //     context: context || this.context,
+  //     storageKey,
+  //     slotComposer: composer,
+  //     pecFactories: [this.pecFactory, ...(portFactories || [])],
+  //     loader: this.loader,
+  //     inspectorFactory,
+  //     storageManager
+  //   };
+  //   return serialization ? Arc.deserialize(params) : new Arc(params);
+  // }
 
   // static interface for the default runtime environment
 
   static async parse(content: string, options?): Promise<Manifest> {
-    return this.getRuntime().parse(content, options);
+    return gRuntime/*this.getRuntime()*/.parse(content, options);
   }
 
   static async parseFile(path: string, options?): Promise<Manifest> {
-    return this.getRuntime().parseFile(path, options);
+    return gRuntime/*this.getRuntime()*/.parseFile(path, options);
   }
 
-  static async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
-    return this.getRuntime().resolveRecipe(arc, recipe);
-  }
+  // static async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
+  //   return this.getRuntime().resolveRecipe(arc, recipe);
+  // }
 
-  static async spawnArc(args: SpawnArgs): Promise<Arc> {
-    return this.getRuntime().spawnArc(args);
-  }
+  // static async spawnArc(args: SpawnArgs): Promise<Arc> {
+  //   return this.getRuntime().spawnArc(args);
+  // }
 }
+
+const gRuntime = new Runtime();

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -56,19 +56,6 @@ export type RuntimeArcOptions = Readonly<{
   modality?: Modality;
 }>;
 
-// type SpawnArgs = {
-//   id: string,
-//   serialization?: string,
-//   context: Manifest,
-//   composer: SlotComposer,
-//   storage: string,
-//   portFactories: [],
-//   inspectorFactory?: ArcInspectorFactory,
-//   storageManager: StorageEndpointManager
-// };
-
-//let runtime: Runtime | null = null;
-
 @SystemTrace
 export class Runtime {
   public context: Manifest;
@@ -79,32 +66,6 @@ export class Runtime {
   private memoryProvider: VolatileMemoryProvider;
   readonly storageManager: StorageEndpointManager;
   readonly arcById = new Map<string, Arc>();
-
-  /**
-   * `Runtime.getRuntime()` returns the most recently constructed Runtime object
-   * (or creates one if necessary). Therefore, the most recently created Runtime
-   * object represents the default runtime environemnt.
-   * Systems can use `Runtime.getRuntime()` to access this environment instead of
-   * plumbing `runtime` arguments through numerous functions.
-   * Some static methods on this class automatically use the default environment.
-   */
-  // static getRuntime() {
-  //   if (!runtime) {
-  //     runtime = new Runtime();
-  //   }
-  //   return runtime;
-  // }
-
-  //static clearRuntimeForTesting() {
-    // if (runtime) {
-    //   runtime.destroy();
-    //   runtime = null;
-    // }
-  //}
-
-  // static newForNodeTesting(context?: Manifest) {
-  //   return new Runtime({context});
-  // }
 
   /**
    * Call `init` to establish a default Runtime environment (capturing the return value is optional).
@@ -156,7 +117,6 @@ export class Runtime {
     this.context = context || new Manifest({id: 'manifest:default'});
     this.memoryProvider = memoryProvider || new SimpleVolatileMemoryProvider();
     this.storageManager = storageManager || new DirectStorageEndpointManager();
-    //runtime = this;
     // user information. One persona per runtime for now.
   }
 
@@ -301,43 +261,15 @@ export class Runtime {
     return Object.isFrozen(recipe);
   }
 
-  // TODO(sjmiles): redundant vs. newArc, but has some impedance mismatch
-  // strategy is to merge first, unify second
-  // async spawnArc({id, serialization, context, composer, storage, portFactories, inspectorFactory, storageManager}: SpawnArgs): Promise<Arc> {
-  //   const arcid = IdGenerator.newSession().newArcId(id);
-  //   const storageKey = new VolatileStorageKey(arcid, '');
-  //   const params = {
-  //     id: arcid,
-  //     fileName: './serialized.manifest',
-  //     serialization,
-  //     context: context || this.context,
-  //     storageKey,
-  //     slotComposer: composer,
-  //     pecFactories: [this.pecFactory, ...(portFactories || [])],
-  //     loader: this.loader,
-  //     inspectorFactory,
-  //     storageManager
-  //   };
-  //   return serialization ? Arc.deserialize(params) : new Arc(params);
-  // }
-
   // static interface for the default runtime environment
 
   static async parse(content: string, options?): Promise<Manifest> {
-    return gRuntime/*this.getRuntime()*/.parse(content, options);
+    return staticRuntime.parse(content, options);
   }
 
   static async parseFile(path: string, options?): Promise<Manifest> {
-    return gRuntime/*this.getRuntime()*/.parseFile(path, options);
+    return staticRuntime.parseFile(path, options);
   }
-
-  // static async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
-  //   return this.getRuntime().resolveRecipe(arc, recipe);
-  // }
-
-  // static async spawnArc(args: SpawnArgs): Promise<Arc> {
-  //   return this.getRuntime().spawnArc(args);
-  // }
 }
 
-const gRuntime = new Runtime();
+const staticRuntime = new Runtime();

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -56,16 +56,16 @@ export type RuntimeArcOptions = Readonly<{
   modality?: Modality;
 }>;
 
-type SpawnArgs = {
-  id: string,
-  serialization?: string,
-  context: Manifest,
-  composer: SlotComposer,
-  storage: string,
-  portFactories: [],
-  inspectorFactory?: ArcInspectorFactory,
-  storageManager: StorageEndpointManager
-};
+// type SpawnArgs = {
+//   id: string,
+//   serialization?: string,
+//   context: Manifest,
+//   composer: SlotComposer,
+//   storage: string,
+//   portFactories: [],
+//   inspectorFactory?: ArcInspectorFactory,
+//   storageManager: StorageEndpointManager
+// };
 
 //let runtime: Runtime | null = null;
 
@@ -249,9 +249,6 @@ export class Runtime {
     return Manifest.load(fileName, loader, options);
   }
 
-  // TODO(sjmiles): there is redundancy vs `parse/loadManifest` above, but
-  // this is temporary until we polish the Utils->Runtime integration.
-
   // TODO(sjmiles): These methods represent boilerplate factored out of
   // various shells.These needs could be filled other ways or represented
   // by other modules. Suggestions welcome.
@@ -273,7 +270,7 @@ export class Runtime {
     return this.parse(content, opts);
   }
 
-  async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
+  static async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
     if (this.normalize(recipe)) {
       if (recipe.isResolved()) {
         return recipe;
@@ -288,7 +285,7 @@ export class Runtime {
     return null;
   }
 
-  normalize(recipe: Recipe): boolean {
+  static normalize(recipe: Recipe): boolean {
     if (Runtime.isNormalized(recipe)) {
       return true;
     }

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -102,7 +102,7 @@ describe('Volatile Driver', async () => {
 });
 
 describe('VolatileStorageDriverProvider', () => {
-  const runtime = new Runtime(); //Runtime.newForNodeTesting();
+  const runtime = new Runtime();
 
   it('supports VolatileStorageKeys for the same Arc ID', () => {
     const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, 'prefix'));

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -23,7 +23,7 @@ describe('Volatile Driver', async () => {
 
   afterEach(() => {
     memory.entries.clear();
-    Runtime.clearRuntimeForTesting();
+    //Runtime.clearRuntimeForTesting();
   });
 
   it('can be multiply instantiated against the same storage location', () => {
@@ -102,7 +102,7 @@ describe('Volatile Driver', async () => {
 });
 
 describe('VolatileStorageDriverProvider', () => {
-  const runtime = Runtime.newForNodeTesting();
+  const runtime = new Runtime(); //Runtime.newForNodeTesting();
 
   it('supports VolatileStorageKeys for the same Arc ID', () => {
     const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, 'prefix'));

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -23,7 +23,6 @@ describe('Volatile Driver', async () => {
 
   afterEach(() => {
     memory.entries.clear();
-    //Runtime.clearRuntimeForTesting();
   });
 
   it('can be multiply instantiated against the same storage location', () => {

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -38,9 +38,9 @@ describe('ReferenceModeStore Integration', async () => {
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-        Runtime.newForNodeTesting().newArc('testWritesArc'));
+        /*Runtime.newForNodeTesting().*/ new Runtime().newArc('testWritesArc'));
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-        Runtime.newForNodeTesting().newArc('testReadArc'));
+        /*Runtime.newForNodeTesting().*/ new Runtime().newArc('testReadArc'));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -68,7 +68,7 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = Runtime.newForNodeTesting().newArc('testArc');
+    const arc = /*Runtime.newForNodeTesting()*/new Runtime().newArc('testArc');
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -105,7 +105,7 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = Runtime.newForNodeTesting().newArc('testArc');
+    const arc = /*Runtime.newForNodeTesting()*/new Runtime().newArc('testArc');
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -151,9 +151,9 @@ describe('ReferenceModeStore Integration', async () => {
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-        Runtime.newForNodeTesting().newArc('testWriteArc'));
+        /*Runtime.newForNodeTesting()*/new Runtime().newArc('testWriteArc'));
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-        Runtime.newForNodeTesting().newArc('testReadArc'));
+        /*Runtime.newForNodeTesting()*/new Runtime().newArc('testReadArc'));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -181,7 +181,7 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = Runtime.newForNodeTesting().newArc('testArc');
+    const arc = /*Runtime.newForNodeTesting()*/new Runtime().newArc('testArc');
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: {kind: 'schema-ordered-list', schema: {kind: 'schema-primitive', type: 'Text'}}})).collectionOf();
 

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -38,9 +38,9 @@ describe('ReferenceModeStore Integration', async () => {
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-        /*Runtime.newForNodeTesting().*/ new Runtime().newArc('testWritesArc'));
+        new Runtime().newArc('testWritesArc'));
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-        /*Runtime.newForNodeTesting().*/ new Runtime().newArc('testReadArc'));
+        new Runtime().newArc('testReadArc'));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -68,7 +68,7 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = /*Runtime.newForNodeTesting()*/new Runtime().newArc('testArc');
+    const arc = new Runtime().newArc('testArc');
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -105,7 +105,7 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = /*Runtime.newForNodeTesting()*/new Runtime().newArc('testArc');
+    const arc = new Runtime().newArc('testArc');
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -151,9 +151,9 @@ describe('ReferenceModeStore Integration', async () => {
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-        /*Runtime.newForNodeTesting()*/new Runtime().newArc('testWriteArc'));
+        new Runtime().newArc('testWriteArc'));
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-        /*Runtime.newForNodeTesting()*/new Runtime().newArc('testReadArc'));
+        new Runtime().newArc('testReadArc'));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -181,7 +181,7 @@ describe('ReferenceModeStore Integration', async () => {
     const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = /*Runtime.newForNodeTesting()*/new Runtime().newArc('testArc');
+    const arc = new Runtime().newArc('testArc');
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: {kind: 'schema-ordered-list', schema: {kind: 'schema-primitive', type: 'Text'}}})).collectionOf();
 

--- a/src/runtime/storage/tests/storage-key-test.ts
+++ b/src/runtime/storage/tests/storage-key-test.ts
@@ -21,7 +21,7 @@ import {mockFirebaseStorageKeyOptions} from '../testing/mock-firebase.js';
 describe('StorageKey', () => {
 
   beforeEach(() => {
-    const runtime = Runtime.getRuntime();
+    const runtime = new Runtime();
     RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     FirebaseStorageDriverProvider.register(runtime.getCacheService(), mockFirebaseStorageKeyOptions);
   });

--- a/src/runtime/storage/tests/store-sequence-test.ts
+++ b/src/runtime/storage/tests/store-sequence-test.ts
@@ -176,7 +176,7 @@ describe('Store Sequence', async () => {
   it('applies operations to two stores connected by a volatile driver', async () => {
     const sequenceTest = new SequenceTest<{store1: ActiveStore<CRDTCountTypeRecord>, store2: ActiveStore<CRDTCountTypeRecord>}>();
     sequenceTest.setTestConstructor(async () => {
-      const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
+      const runtime = new Runtime();
       const arc = runtime.newArc('arc', null);
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);
@@ -276,7 +276,7 @@ describe('Store Sequence', async () => {
   it.skip('applies model against operations to two stores connected by a volatile driver', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
-      const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
+      const runtime = new Runtime();
       const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, ''));
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);

--- a/src/runtime/storage/tests/store-sequence-test.ts
+++ b/src/runtime/storage/tests/store-sequence-test.ts
@@ -176,7 +176,7 @@ describe('Store Sequence', async () => {
   it('applies operations to two stores connected by a volatile driver', async () => {
     const sequenceTest = new SequenceTest<{store1: ActiveStore<CRDTCountTypeRecord>, store2: ActiveStore<CRDTCountTypeRecord>}>();
     sequenceTest.setTestConstructor(async () => {
-      const runtime = Runtime.newForNodeTesting();
+      const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
       const arc = runtime.newArc('arc', null);
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);
@@ -276,7 +276,7 @@ describe('Store Sequence', async () => {
   it.skip('applies model against operations to two stores connected by a volatile driver', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
-      const runtime = Runtime.newForNodeTesting();
+      const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
       const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, ''));
       DriverFactory.clearRegistrationsForTesting();
       VolatileStorageDriverProvider.register(arc);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -205,7 +205,7 @@ describe('Arc', () => {
   });
 
   it('idle can safely be called multiple times ', async () => {
-    const runtime = Runtime.newForNodeTesting();
+    const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
     const arc = runtime.newArc('test');
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -205,7 +205,7 @@ describe('Arc', () => {
   });
 
   it('idle can safely be called multiple times ', async () => {
-    const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
+    const runtime = new Runtime();
     const arc = runtime.newArc('test');
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -2819,7 +2819,7 @@ resource SomeName
 
   it('can parse a manifest with storage key handle definitions', async () => {
     FirebaseStorageDriverProvider.register(
-        Runtime.getRuntime().getCacheService(),
+        new Runtime().getCacheService(),
         mockFirebaseStorageKeyOptions);
     const manifest = await parseManifest(`
       schema Bar

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -141,7 +141,7 @@ describe('Runtime', () => {
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc1 = runtime.runArc('test-arc-v1', volatileStorageKeyPrefixForTest());
-    const recipe1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
+    const recipe1 = await Runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
     assert.isTrue(recipe1 && recipe1.isResolved());
     await volatileArc1.instantiate(recipe1);
     assert.lengthOf(runtime.context.stores, 6);
@@ -155,7 +155,7 @@ describe('Runtime', () => {
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc2 = runtime.runArc('test-arc-v2', volatileStorageKeyPrefixForTest());
-    const recipe2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
+    const recipe2 = await Runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
     assert.isTrue(recipe2 && recipe2.isResolved());
     await volatileArc2.instantiate(recipe2);
     assert.lengthOf(runtime.context.stores, 6);

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -88,7 +88,7 @@ describe('Runtime', () => {
     assertManifestsEqual(actual, expected);
   });
   it('runs arcs', async () => {
-    const runtime = Runtime.getRuntime();
+    const runtime = new Runtime();
     assert.equal(runtime.arcById.size, 0);
     const arc = runtime.runArc('test-arc', volatileStorageKeyPrefixForTest());
     assert.isNotNull(arc);

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -83,7 +83,7 @@ describe('common particles test', () => {
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
 
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
     const suggestion = suggestions[0];
     assert.equal(suggestion.descriptionText, 'Copy all things!');

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -129,7 +129,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     const key = (id: ArcId) => new VolatileStorageKey(id, '');
     const arc = runtime.newArc('demo', key);
 
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
     const result = suggestions[0].getDescription(arc.modality.names[0]);
     return result;
@@ -197,7 +197,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     const runtime = new Runtime({loader, context, memoryProvider});
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
 
-    await StrategyTestHelper.planForArc(arc).then(() => assert('expected exception for duplicate particles'))
+    await StrategyTestHelper.planForArc(runtime, arc).then(() => assert('expected exception for duplicate particles'))
       .catch((err) => assert.strictEqual(
           err.message, 'Cannot reference duplicate particle \'ShowFoo\' in recipe description.'));
   });
@@ -247,7 +247,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     const key = (id: ArcId) => new VolatileStorageKey(id, '');
     const arc = runtime.newArc('demo', key);
     // Plan for arc
-    const suggestions0 = await StrategyTestHelper.planForArc(arc);
+    const suggestions0 = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions0, 2);
     assert.strictEqual('Show foo.', suggestions0[0].descriptionText);
 
@@ -256,7 +256,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     await arc.idle;
 
     // Plan again.
-    const suggestions1 = await StrategyTestHelper.planForArc(arc);
+    const suggestions1 = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions1, 1);
     assert.strictEqual('Show foo with dummy.', suggestions1[0].descriptionText);
   });
@@ -281,7 +281,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     const key = (id: ArcId) => new VolatileStorageKey(id, '');
     const arc = runtime.newArc('demo', key);
 
-    const suggestions = await StrategyTestHelper.planForArc(arc);
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     assert.lengthOf(suggestions, 3);
     const recipe1 = newRecipe();

--- a/src/tools/manifest2proto-cli.ts
+++ b/src/tools/manifest2proto-cli.ts
@@ -27,7 +27,7 @@ Usage
   $ tools/sigh manifest2proto [options] path/to/manifest.arcs
 
 Description
-  Serializes manifests to a protobuf file. 
+  Serializes manifests to a protobuf file.
 
 Options
   --outfile, -f output filename; required
@@ -56,10 +56,10 @@ if (opts._.some((file) => !file.endsWith('.arcs'))) {
 
 async function main() {
   try {
-    Runtime.init('../..', PATHS);
     fs.mkdirSync(opts.outdir, {recursive: true});
 
-    const buffer = await encodeManifestToProto(opts._[0]);
+    const runtime = Runtime.init('../..', PATHS);
+    const buffer = await encodeManifestToProto(runtime, opts._[0]);
 
     const outPath = path.join(opts.outdir, opts.outfile);
     if (!opts.quiet) {

--- a/src/tools/manifest2proto.ts
+++ b/src/tools/manifest2proto.ts
@@ -22,8 +22,8 @@ import {Policy} from '../runtime/policy/policy.js';
 import {policyToProtoPayload} from './policy2proto.js';
 import {annotationToProtoPayload} from './annotations-utils.js';
 
-export async function encodeManifestToProto(path: string): Promise<Uint8Array> {
-  const manifest = await Runtime.parseFile(path, {throwImportErrors: true});
+export async function encodeManifestToProto(runtime, path: string): Promise<Uint8Array> {
+  const manifest = await runtime.parseFile(path, {throwImportErrors: true});
   return encodePayload(await manifestToProtoPayload(manifest));
 }
 

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -28,7 +28,7 @@ Usage
   $ tools/sigh recipe2plan [options] path/to/manifest.arcs
 
 Description
-  Generates Kotlin plans from recipes in a manifest. 
+  Generates Kotlin plans from recipes in a manifest.
 
 Options
   --outfile, -f  output filename; required
@@ -70,12 +70,12 @@ const outFormat = (() => {
 
 void Flags.withDefaultReferenceMode(async () => {
   try {
-    Runtime.init('../..', PATHS);
+    const runtime = Runtime.init('../..', PATHS);
     fs.mkdirSync(opts.outdir, {recursive: true});
 
-    const manifest = await Runtime.parseFile(opts._[0]);
+    const manifest = await runtime.parseFile(opts._[0]);
     const policiesManifest =
-        opts.policies ? await Runtime.parseFile(opts.policies) : null;
+        opts.policies ? await runtime.parseFile(opts.policies) : null;
     const plans = await recipe2plan(manifest, outFormat, policiesManifest, opts.recipe);
 
     const outPath = path.join(opts.outdir, opts.outfile);

--- a/src/tools/recipe2plan.ts
+++ b/src/tools/recipe2plan.ts
@@ -24,11 +24,11 @@ export enum OutputFormat { Kotlin, Proto }
  * @return Generated Kotlin code.
  */
 export async function recipe2plan(
-  manifest: Manifest,
-  format: OutputFormat,
-  policiesManifest?: Manifest,
-  recipeFilter?: string,
-  salt = `salt_${Math.random()}`): Promise<string | Uint8Array> {
+    manifest: Manifest,
+    format: OutputFormat,
+    policiesManifest?: Manifest,
+    recipeFilter?: string,
+    salt = `salt_${Math.random()}`): Promise<string | Uint8Array> {
   let plans = await (new AllocatorRecipeResolver(manifest, salt, policiesManifest)).resolve();
 
   if (recipeFilter) {

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -16,7 +16,7 @@ import {SchemaGraph, SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/arcs-types/particle-spec.js';
 import {PATHS} from './paths.oss.js';
 
-Runtime.init('../..', PATHS);
+const runtime = Runtime.init('../..', PATHS);
 
 export interface EntityGenerator {
   generate(): string;
@@ -50,7 +50,7 @@ export abstract class Schema2Base {
       return;
     }
 
-    const manifest = await Runtime.parseFile(src);
+    const manifest = await runtime.parseFile(src);
     if (manifest.errors.some(e => e.severity !== 'warning')) {
       return;
     }

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -13,7 +13,8 @@ import {CountType, EntityType, SingletonType, TupleType, Type, TypeVariable} fro
 import {Manifest} from '../../runtime/manifest.js';
 import {fs} from '../../platform/fs-web.js';
 import {ManifestProto, TypeProto} from '../manifest-proto.js';
-import {Loader} from '../../platform/loader.js';
+import {Loader} from '../../runtime/loader.js';
+import {Runtime} from '../../runtime/runtime.js';
 import {assertThrowsAsync} from '../../testing/test-util.js';
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
 
@@ -1518,7 +1519,7 @@ describe('manifest2proto', () => {
   // and deserialized in Kotlin to the extent that they are present in the .textproto file.
   it('encodes the Manifest2ProtoTest manifest', async () => {
     assert.deepStrictEqual(
-      await encodeManifestToProto('java/arcs/core/data/testdata/Manifest2ProtoTest.arcs'),
+      await encodeManifestToProto(new Runtime(), 'java/arcs/core/data/testdata/Manifest2ProtoTest.arcs'),
       fs.readFileSync('java/arcs/core/data/testdata/Manifest2ProtoTest.binarypb'),
       `The output of manifest2proto for Manifest2ProtoTest.arcs does not match the expectation.\n
 If you want to update the expected output please run:\n

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -63,7 +63,7 @@ const buildLS = buildPath('./src/tools/language-server', () => {
 });
 const webpackLS = webpackPkg('webpack-languageserver');
 
-const buildShells = () => buildPkg('shells');
+const buildShells = () => globalOptions.bazel ? true : buildPkg('shells');
 
 const steps: {[index: string]: ((args?: string[]) => boolean|Promise<boolean>)[]} = {
   peg: [peg, railroad],

--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -67,7 +67,7 @@ const buildShells = () => buildPkg('shells');
 
 const steps: {[index: string]: ((args?: string[]) => boolean|Promise<boolean>)[]} = {
   peg: [peg, railroad],
-  test: [peg, build, runTestsOrHealthOnCron],
+  test: [peg, build, buildShells, runTestsOrHealthOnCron],
   testShells: [peg, build, buildShells, webpack, webpackStorage, devServerAsync, testWdioShells],
   testWdioShells: [testWdioShells],
   webpack: [peg, build, buildShells, webpack],
@@ -77,7 +77,7 @@ const steps: {[index: string]: ((args?: string[]) => boolean|Promise<boolean>)[]
   watch: [watch],
   buildifier: [buildifier],
   ktlint: [ktlint],
-  lint: [check, peg, build, lint, tslint, ktlint, cycles, buildifier],
+  lint: [check, peg, build, buildShells, lint, tslint, ktlint, cycles, buildifier],
   cycles: [peg, build, cycles],
   check: [check],
   clean: [clean],
@@ -92,11 +92,11 @@ const steps: {[index: string]: ((args?: string[]) => boolean|Promise<boolean>)[]
   languageServer: [peg, build, buildLS, webpackLS],
   run: [peg, build, runNodeScript],
   buildWeb: [
-    check, peg, railroad, build, lint, tslint, cycles, buildShells, webpack, devServerAsync, testWdioShells
+    check, peg, railroad, build, buildShells, lint, tslint, cycles, webpack, devServerAsync, testWdioShells
   ],
   default: [
-    check, peg, railroad, build, lint, tslint, ktlint, buildifier, cycles, runTestsOrHealthOnCron,
-    buildShells, webpack, webpackTools, webpackStorage, devServerAsync, testWdioShells
+    check, peg, railroad, build, buildShells, lint, tslint, ktlint, buildifier, cycles, runTestsOrHealthOnCron,
+    webpack, webpackTools, webpackStorage, devServerAsync, testWdioShells
   ]
 };
 


### PR DESCRIPTION
Step 2 
- get rid of remaining `staticRuntime` objects (runtime.ts, planner.ts)
- attempt to convert some globals like RamDiskStorageDriverProvider into runtime instances
- attempt to convert Planner statics into instance methods (or require `runtime` parameter)