### PR TITLE
Created StorageServiceNgImpl

### DIFF
--- a/java/arcs/android/storage/ParcelableStoreOptions.kt
+++ b/java/arcs/android/storage/ParcelableStoreOptions.kt
@@ -71,3 +71,22 @@ fun Parcel.writeStoreOptions(
 /** Reads [StoreOptions] from the [Parcel]. */
 fun Parcel.readStoreOptions(): StoreOptions? =
   readTypedObject(ParcelableStoreOptions)?.actual
+
+/** Writes [StoreOptions] to a [Parcel] and return the raw bytes of the [Parcel]. */
+fun StoreOptions.toParcelByteArray(crdtType: ParcelableCrdtType): ByteArray {
+  val storeOptions = this
+  return with(Parcel.obtain()) {
+    writeStoreOptions(storeOptions, crdtType, 0)
+    marshall()
+  }
+}
+
+/** Unmarshal [ParcelableStoreOptions] and reads the [StoreOptions] from the resulting [Parcel]. */
+fun ByteArray.readStoreOptions(): StoreOptions {
+  val parcelableStoreOptions = this
+  return with(Parcel.obtain()) {
+    unmarshall(parcelableStoreOptions, 0, parcelableStoreOptions.size)
+    setDataPosition(0)
+    checkNotNull(readStoreOptions()) { "StoreOptions read from Parcel were null." }
+  }
+}

--- a/java/arcs/android/storage/service/StorageChannelImpl.kt
+++ b/java/arcs/android/storage/service/StorageChannelImpl.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 
 /** Implementation of [IStorageChannel] for communicating with an [ActiveStore]. */
 class StorageChannelImpl(
-  private val store: UntypedActiveStore,
+  val store: UntypedActiveStore,
   scope: CoroutineScope,
   private val statisticsSink: BindingContextStatisticsSink,
   /** Callback to trigger when a proxy message has been received and sent to the store. */

--- a/java/arcs/android/storage/service/StorageServiceNgImpl.kt
+++ b/java/arcs/android/storage/service/StorageServiceNgImpl.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service
+
+import arcs.android.storage.readStoreOptions
+import arcs.core.storage.ActiveStore
+import arcs.core.storage.DriverFactory
+import arcs.core.storage.StorageKey
+import arcs.core.storage.UntypedActiveStore
+import arcs.core.storage.UntypedProxyMessage
+import arcs.core.storage.WriteBackProvider
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Implementation of the [IStorageServiceNg] AIDL interface. Responsible for forwarding messages
+ * to [ActiveStore]s and back again.
+ */
+class StorageServiceNgImpl(
+  private val scope: CoroutineScope,
+  private val driverFactory: DriverFactory,
+  private val writeBackProvider: WriteBackProvider,
+  private val devToolsProxy: DevToolsProxyImpl?,
+  /** Callback to trigger when a proxy message has been received and sent to the store. */
+  private val onProxyMessageCallback: suspend (StorageKey, UntypedProxyMessage) -> Unit
+) : IStorageServiceNg.Stub() {
+  // TODO(b/173754821): Clean up stores when the channels are all closed/dead.
+  // TODO(b/173755216): Implement link/unlinkToDeath handlers.
+  private val stores = ConcurrentHashMap<StorageKey, UntypedActiveStore>()
+
+  private val stats = BindingContextStatsImpl()
+
+  /** Collection of [StorageKey]s of the stores the [StorageServiceNgImpl] provides a binding for */
+  val activeStorageKeys: Collection<StorageKey>
+    get() = stores.keys
+
+  override fun openStorageChannel(
+    parcelableStoreOptions: ByteArray,
+    channelCallback: IStorageChannelCallback,
+    messageCallback: IMessageCallback
+  ) {
+    val storeOptions = parcelableStoreOptions.readStoreOptions()
+
+    scope.launch {
+      // TODO(b/173671643): Remove potential for race condition when creating a store.
+      var store = stores[storeOptions.storageKey]
+      if (store == null) {
+        store = ActiveStore(
+          storeOptions,
+          scope,
+          driverFactory,
+          writeBackProvider,
+          devToolsProxy
+        )
+        stores[storeOptions.storageKey] = store
+      }
+      channelCallback.onCreate(
+        StorageChannelImpl.create(store, scope, stats, messageCallback, onProxyMessageCallback)
+      )
+    }
+  }
+}

--- a/java/arcs/android/storage/service/testing/FakeMessageCallback.kt
+++ b/java/arcs/android/storage/service/testing/FakeMessageCallback.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service.testing
+
+import arcs.android.storage.service.IMessageCallback
+
+/**
+ * Implementation of [IMessageCallback] for testing.
+ */
+class FakeMessageCallback : IMessageCallback.Stub() {
+  override fun onMessage(encodedMessage: ByteArray?) {}
+}

--- a/java/arcs/android/storage/service/testing/FakeStorageChannelCallback.kt
+++ b/java/arcs/android/storage/service/testing/FakeStorageChannelCallback.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service.testing
+
+import arcs.android.storage.service.IStorageChannel
+import arcs.android.storage.service.IStorageChannelCallback
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Implementation of [IStorageChannelCallback] for testing. Records the channel that has been
+ * created and provides a helper method for waiting for the `onCreate` method to be called.
+ */
+class FakeStorageChannelCallback : IStorageChannelCallback.Stub() {
+  private val deferredChannel = CompletableDeferred<IStorageChannel>()
+
+  override fun onCreate(channel: IStorageChannel) {
+    deferredChannel.complete(channel)
+  }
+
+  suspend fun waitForOnCreate(): IStorageChannel {
+    return deferredChannel.await()
+  }
+}

--- a/javatests/arcs/android/storage/service/BUILD
+++ b/javatests/arcs/android/storage/service/BUILD
@@ -13,6 +13,7 @@ arcs_kt_android_test_suite(
     manifest = "//java/arcs/android/common:AndroidManifest.xml",
     package = "arcs.android.storage.service",
     deps = [
+        "//java/arcs/android/crdt",
         "//java/arcs/android/crdt:crdt_exception_android_proto",
         "//java/arcs/android/storage",
         "//java/arcs/android/storage:proxy_message_android_proto",

--- a/javatests/arcs/android/storage/service/StorageServiceNgImplTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceNgImplTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+package arcs.android.storage.service
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import arcs.android.crdt.ParcelableCrdtType
+import arcs.android.storage.service.testing.FakeMessageCallback
+import arcs.android.storage.service.testing.FakeStorageChannelCallback
+import arcs.android.storage.toParcelByteArray
+import arcs.core.data.CountType
+import arcs.core.storage.FixedDriverFactory
+import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StoreOptions
+import arcs.core.storage.UntypedProxyMessage
+import arcs.core.storage.keys.RamDiskStorageKey
+import arcs.core.storage.testutil.MockDriverProvider
+import arcs.core.storage.testutil.testWriteBackProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StorageServiceNgImplTest {
+
+  private val driverFactory = FixedDriverFactory(MockDriverProvider())
+  private val onProxyMessageCallback: suspend (StorageKey, UntypedProxyMessage) -> Unit =
+    { _: StorageKey, _: UntypedProxyMessage -> }
+  private val messageCallback = FakeMessageCallback()
+  private val channelCallback = FakeStorageChannelCallback()
+
+  private val scope = TestCoroutineScope()
+  private lateinit var storageService: StorageServiceNgImpl
+
+  @Before
+  fun setUp() {
+    StorageKeyParser.addParser(RamDiskStorageKey)
+    storageService = StorageServiceNgImpl(
+      scope,
+      driverFactory,
+      ::testWriteBackProvider,
+      null,
+      onProxyMessageCallback
+    )
+  }
+
+  @After
+  fun tearDown() {
+    scope.cleanupTestCoroutines()
+  }
+
+  @Test
+  fun openStorageChannel_invokesOnCreateCallback_andCreatesChannel() = scope.runBlockingTest {
+    val encodedStoreOptions = createEncodedStoreOptions(DUMMY_STORAGE_KEY)
+
+    storageService.openStorageChannel(encodedStoreOptions, channelCallback, messageCallback)
+
+    val channel = channelCallback.waitForOnCreate()
+
+    assertThat(channel).isInstanceOf(StorageChannelImpl::class.java)
+  }
+
+  @Test
+  fun openingTwoChannels_forSameStore_resultsInTwoDistinctChannels() = scope.runBlockingTest {
+    val encodedStoreOptions = createEncodedStoreOptions(DUMMY_STORAGE_KEY)
+
+    val channelCallback1 = FakeStorageChannelCallback()
+    val channelCallback2 = FakeStorageChannelCallback()
+
+    storageService.openStorageChannel(encodedStoreOptions, channelCallback1, messageCallback)
+    storageService.openStorageChannel(encodedStoreOptions, channelCallback2, messageCallback)
+
+    val channel1 = channelCallback1.waitForOnCreate()
+    val channel2 = channelCallback2.waitForOnCreate()
+    assertThat(channel2).isNotSameInstanceAs(channel1)
+  }
+
+  @Test
+  fun openStorageChannel_createsAStore() = scope.runBlockingTest {
+    val storageKey = RamDiskStorageKey("store1")
+    val encodedStoreOptions = createEncodedStoreOptions(storageKey)
+
+    storageService.openStorageChannel(encodedStoreOptions, channelCallback, messageCallback)
+    channelCallback.waitForOnCreate() as StorageChannelImpl
+
+    assertThat(storageService.activeStorageKeys).containsExactly(storageKey)
+  }
+
+  @Test
+  fun openingTwoChannels_forDifferentStores_createsTwoStores() = scope.runBlockingTest {
+    // Define the store options for two different stores.
+    val storageKey1 = RamDiskStorageKey("store1")
+    val storageKey2 = RamDiskStorageKey("store2")
+    val encodedStoreOptions1 = createEncodedStoreOptions(storageKey1)
+    val encodedStoreOptions2 = createEncodedStoreOptions(storageKey2)
+    val channelCallback1 = FakeStorageChannelCallback()
+    val channelCallback2 = FakeStorageChannelCallback()
+
+    // Open two storage channels for two distinct stores
+    storageService.openStorageChannel(encodedStoreOptions1, channelCallback1, messageCallback)
+    storageService.openStorageChannel(encodedStoreOptions2, channelCallback2, messageCallback)
+
+    // check two stores have been created
+    val channel1 = channelCallback1.waitForOnCreate() as StorageChannelImpl
+    val channel2 = channelCallback2.waitForOnCreate() as StorageChannelImpl
+
+    assertThat(storageService.activeStorageKeys).containsExactly(storageKey1, storageKey2)
+
+    // Check the channels are communicating with the expected stores.
+    assertThat(channel1.store).isNotSameInstanceAs(channel2.store)
+    assertThat(channel1.store.storageKey).isEqualTo(storageKey1)
+    assertThat(channel2.store.storageKey).isEqualTo(storageKey2)
+  }
+
+  @Test
+  fun openingTwoChannels_forSameStore_onlyCreatesOneStore() = scope.runBlockingTest {
+    val storageKey = RamDiskStorageKey("store1")
+    val encodedStoreOptions = createEncodedStoreOptions(storageKey)
+    val channelCallback1 = FakeStorageChannelCallback()
+    val channelCallback2 = FakeStorageChannelCallback()
+
+    storageService.openStorageChannel(encodedStoreOptions, channelCallback1, messageCallback)
+    storageService.openStorageChannel(encodedStoreOptions, channelCallback2, messageCallback)
+
+    val channel1 = channelCallback1.waitForOnCreate() as StorageChannelImpl
+    val channel2 = channelCallback2.waitForOnCreate() as StorageChannelImpl
+
+    assertThat(storageService.activeStorageKeys).containsExactly(storageKey)
+    assertThat(channel1.store).isSameInstanceAs(channel2.store)
+  }
+
+  private fun createEncodedStoreOptions(storageKey: StorageKey): ByteArray {
+    return StoreOptions(storageKey, CountType()).toParcelByteArray(ParcelableCrdtType.Count)
+  }
+
+  companion object {
+    val DUMMY_STORAGE_KEY = RamDiskStorageKey("myCount")
+  }
+}


### PR DESCRIPTION
Implementation of the IStorageServiceNg AIDL interface which will be responsible for forwarding messages to ActiveStores and back again. This class is not utilised at the moment but it is intended to replace the use of BindingContext.  