### PR TITLE
Refactor StorageCommunicationEndpointProvider to return StorageCommunicationEndpoint per StoreInfo

### DIFF
--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -65,7 +65,7 @@ export class PlanProducer {
     this.searchStore = searchStore;
     this.inspector = inspector;
     if (this.searchStore) {
-      this.handle = handleForActiveStore(this.searchStore, this.arc);
+      this.handle = handleForActiveStore(this.searchStore.storeInfo, this.searchStore, this.arc);
       this.searchStoreCallbackId = this.searchStore.on(() => this.onSearchChanged());
     }
     this.debug = debug;

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -192,7 +192,7 @@ export class Planificator {
   }
 
   async _storeSearch(): Promise<void> {
-    const handle = handleForActiveStore(this.searchStore, this.arc);
+    const handle = handleForActiveStore(this.searchStore.storeInfo, this.searchStore, this.arc);
     const handleValue = await handle.fetch();
     const values = handleValue ? JSON.parse(handleValue.current) : [];
 

--- a/src/planning/plan/planning-result.ts
+++ b/src/planning/plan/planning-result.ts
@@ -52,7 +52,7 @@ export class PlanningResult {
     assert(envOptions.storageManager, `storageManager cannot be null`);
     this.store = store;
     if (this.store) {
-      this.handle = handleForActiveStore(store, {...envOptions.context, storageManager: envOptions.storageManager});
+      this.handle = handleForActiveStore(store.storeInfo, store, {...envOptions.context, storageManager: envOptions.storageManager});
       this.storeCallbackId = this.store.on(() => this.load());
     }
   }

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -164,7 +164,7 @@ describe('plan producer - search', () => {
     }
 
     async setNextSearch(search: string) {
-      const handle = handleForActiveStore(this.searchStore, this.arc);
+      const handle = handleForActiveStore(this.searchStore.storeInfo, this.searchStore, this.arc);
       await handle.setFromData({current: JSON.stringify([{arc: this.arc.id.idTreeAsString(), search}])});
       return this.onSearchChanged();
     }

--- a/src/runtime/storage/active-store.ts
+++ b/src/runtime/storage/active-store.ts
@@ -64,11 +64,11 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
   abstract async onProxyMessage(message: ProxyMessage<T>): Promise<void>;
   abstract reportExceptionInHost(exception: PropagatedException): void;
 
-  getStorageEndpoint() {
+  getStorageEndpoint(storeInfo: StoreInfo<CRDTTypeRecordToType<T>>) {
     const store = this;
     let id: number;
     return {
-      get storeInfo() { return store.storeInfo; },
+      get storeInfo() { return storeInfo; },
       async onProxyMessage(message: ProxyMessage<T>): Promise<void> {
         message.id = id!;
         noAwait(store.onProxyMessage(message));
@@ -103,8 +103,6 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
       }
     };
   }
-  // getStorageEndpoint() {
-  // }
 }
 
 export type StoreConstructor = {

--- a/src/runtime/storage/direct-storage-endpoint.ts
+++ b/src/runtime/storage/direct-storage-endpoint.ts
@@ -17,7 +17,7 @@ import {PropagatedException} from '../arc-exceptions.js';
 import {noAwait} from '../../utils/lib-utils.js';
 
 export class DirectStorageEndpoint<T extends CRDTTypeRecord> implements StorageCommunicationEndpoint<T> {
-  private id: number = 0;
+  private id = 0;
 
   constructor(private readonly store: ActiveStore<T>) {}
 

--- a/src/runtime/storage/direct-storage-endpoint.ts
+++ b/src/runtime/storage/direct-storage-endpoint.ts
@@ -1,0 +1,60 @@
+
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {StorageCommunicationEndpoint, ProxyMessage, ProxyCallback, StorageCommunicationEndpointProvider} from './store-interface.js';
+import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
+import {ActiveStore} from './active-store.js';
+import {ChannelConstructor} from '../channel-constructor.js';
+import {PropagatedException} from '../arc-exceptions.js';
+import {noAwait} from '../../utils/lib-utils.js';
+
+export class DirectStorageEndpoint<T extends CRDTTypeRecord> implements StorageCommunicationEndpoint<T> {
+  private id: number = 0;
+
+  constructor(private readonly store: ActiveStore<T>) {}
+
+  get storeInfo() { return this.store.storeInfo; }
+
+  async onProxyMessage(message: ProxyMessage<T>): Promise<void> {
+    message.id = this.id!;
+    noAwait(this.store.onProxyMessage(message));
+  }
+
+  setCallback(callback: ProxyCallback<T>) {
+    this.id = this.store.on(callback);
+  }
+  reportExceptionInHost(exception: PropagatedException): void {
+    this.store.reportExceptionInHost(exception);
+  }
+
+  getChannelConstructor(): ChannelConstructor {
+    const store = this.store;
+    // TODO(shans): implement so that we can use references outside of the PEC.
+    return {
+      generateID() {
+        return null;
+      },
+      idGenerator: null,
+      getStorageProxyMuxer() {
+        throw new Error('References not yet supported outside of the PEC');
+      },
+      reportExceptionInHost(exception: PropagatedException): void {
+        store.reportExceptionInHost(exception);
+      }
+    };
+  }
+  async idle(): Promise<void> { return this.store.idle(); }
+  async close(): Promise<void> {
+    if (this.id) {
+      return this.store.off(this.id);
+    }
+  }
+}

--- a/src/runtime/storage/storage-proxy.ts
+++ b/src/runtime/storage/storage-proxy.ts
@@ -45,13 +45,14 @@ export class StorageProxy<T extends CRDTTypeRecord> {
 
   constructor(
       apiChannelId: string,
+      storeInfo: StoreInfo<CRDTTypeRecordToType<T>>,
       storeProvider: StorageCommunicationEndpointProvider<T>,
       ttl = Ttl.infinite()) {
     this.apiChannelId = apiChannelId;
-    this.store = storeProvider.getStorageEndpoint(this);
-    this.type = storeProvider.storeInfo.type;
+    this.store = storeProvider.getStorageEndpoint(storeInfo, this);
+    this.type = storeInfo.type;
     this.crdt = new (this.type.crdtInstanceConstructor<T>())();
-    this.storageKey = storeProvider.storeInfo.storageKey ? storeProvider.storeInfo.storageKey.toString() : null;
+    this.storageKey = storeInfo.storageKey ? storeInfo.storageKey.toString() : null;
     this.ttl = ttl;
     this.scheduler = new StorageProxyScheduler<T>();
   }
@@ -305,8 +306,11 @@ export class StorageProxy<T extends CRDTTypeRecord> {
 
 export class NoOpStorageProxy<T extends CRDTTypeRecord> extends StorageProxy<T> {
   constructor() {
-    // tslint:disable-next-line: no-any
-    super(null, {getStorageEndpoint() {}, storeInfo: new StoreInfo({id: null, type: EntityType.make([], {}) as any as CRDTTypeRecordToType<T>})} as ActiveStore<T>);
+    super(null,
+      // tslint:disable-next-line: no-any
+      new StoreInfo({id: null, type: EntityType.make([], {}) as any as CRDTTypeRecordToType<T>}),
+      {getStorageEndpoint(storeInfo: StoreInfo<CRDTTypeRecordToType<T>>) {}} as ActiveStore<T>
+    );
   }
   async idle(): Promise<void> {
     return new Promise(resolve => {});

--- a/src/runtime/storage/storage-proxy.ts
+++ b/src/runtime/storage/storage-proxy.ts
@@ -43,6 +43,10 @@ export class StorageProxy<T extends CRDTTypeRecord> {
   readonly storageKey: string;
   readonly ttl: Ttl;
 
+  // Note: as a next step StorageProxy ctor will be accepting `StorageCommunicationEndpoint`
+  // as parameter, instead of currently `StorageCommunicationEndpointProvider` and
+  // `StorInfo`. `StorageEndpointManager` will implement `StorageCommunicationEndpointProvider`
+  // and creating `ActiveStore`, which will be implementing `StorageCommunicationEndpoint`.
   constructor(
       apiChannelId: string,
       storeInfo: StoreInfo<CRDTTypeRecordToType<T>>,

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -27,7 +27,6 @@ import {DirectStoreMuxer} from './direct-store-muxer.js';
 import {StoreInfo} from './store-info.js';
 import {StorageEndpointManager} from './storage-manager.js';
 import {StorageCommunicationEndpointProvider} from './store-interface.js';
-import { Referenceable } from '../../crdt/internal/crdt';
 
 type HandleOptions = {
   type?: Type;

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -27,6 +27,7 @@ import {DirectStoreMuxer} from './direct-store-muxer.js';
 import {StoreInfo} from './store-info.js';
 import {StorageEndpointManager} from './storage-manager.js';
 import {StorageCommunicationEndpointProvider} from './store-interface.js';
+import { Referenceable } from '../../crdt/internal/crdt';
 
 type HandleOptions = {
   type?: Type;
@@ -123,12 +124,13 @@ export async function newHandle<T extends Type>(
 }
 
 export function handleForActiveStore<T extends CRDTTypeRecord>(
+  storeInfo: StoreInfo<CRDTTypeRecordToType<T>>,
   store: StorageCommunicationEndpointProvider<T>,
   arc: ArcLike,
   options: HandleOptions = {}
 ): ToHandle<T> {
-  const type = options.type || store.storeInfo.type;
-  const storageKey = store.storeInfo.storageKey.toString();
+  const type = options.type || storeInfo.type;
+  const storageKey = storeInfo.storageKey.toString();
 
   const idGenerator = arc.idGenerator;
   const particle = options.particle || null;
@@ -138,10 +140,11 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
   const generateID = arc.generateID ? () => arc.generateID().toString() : () => '';
   if (store instanceof DirectStoreMuxer) {
     const proxyMuxer = new StorageProxyMuxer<CRDTMuxEntity>(
+      storeInfo as StoreInfo<MuxEntityType>,
       store as StorageCommunicationEndpointProvider<CRDTMuxEntity>);
     return new EntityHandleFactory(proxyMuxer) as ToHandle<T>;
   } else {
-    const proxy = new StorageProxy<T>(store.storeInfo.id, store, options.ttl);
+    const proxy = new StorageProxy<T>(storeInfo.id, storeInfo, store, options.ttl);
     if (type instanceof SingletonType) {
       // tslint:disable-next-line: no-any
       return new SingletonHandle(generateID(), proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<T>;
@@ -153,6 +156,11 @@ export function handleForActiveStore<T extends CRDTTypeRecord>(
 }
 
 export async function handleForStoreInfo<T extends Type>(storeInfo: StoreInfo<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<TypeToCRDTTypeRecord<T>>> {
-  return handleForActiveStore(await arc.storageManager.getActiveStore(storeInfo), arc, options) as ToHandle<TypeToCRDTTypeRecord<T>>;
+  return handleForActiveStore(
+      storeInfo as unknown as StoreInfo<CRDTTypeRecordToType<TypeToCRDTTypeRecord<T>>>,
+      await arc.storageManager.getActiveStore(storeInfo),
+      arc,
+      options
+    ) as ToHandle<TypeToCRDTTypeRecord<T>>;
 }
 

--- a/src/runtime/storage/store-interface.ts
+++ b/src/runtime/storage/store-interface.ts
@@ -61,6 +61,5 @@ export interface StorageCommunicationEndpoint<T extends CRDTTypeRecord> {
 }
 
 export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> {
-  storeInfo: StoreInfo<CRDTTypeRecordToType<T>>;
-  getStorageEndpoint(storageProxy?: StorageProxy<T> | StorageProxyMuxer<T>): StorageCommunicationEndpoint<T>;
+  getStorageEndpoint(storeInfo: StoreInfo<CRDTTypeRecordToType<T>>, storageProxy?: StorageProxy<T> | StorageProxyMuxer<T>): StorageCommunicationEndpoint<T>;
 }

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -53,7 +53,10 @@ describe('entity handle factory', () => {
     fooEntity2CRDT.applyOperation({type: EntityOpTypes.Set, field: 'value', value: {id: 'Text', value: 'OtherText'}, actor: 'me', versionMap: {'me': 1}});
 
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTMuxEntity>(new MuxType(fooEntityType));
-    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>);
+    const storageProxyMuxer = new StorageProxyMuxer(
+      mockDirectStoreMuxer.storeInfo,
+      mockDirectStoreMuxer as DirectStoreMuxer<Identified, Identified, CRDTMuxEntity>
+    );
     const entityHandleProducer = new EntityHandleFactory(storageProxyMuxer);
 
     const entityHandle1 = entityHandleProducer.getHandle(fooMuxId1);

--- a/src/runtime/storage/tests/handle-test.ts
+++ b/src/runtime/storage/tests/handle-test.ts
@@ -20,7 +20,7 @@ import {MockParticle, MockStore} from '../testing/test-storage.js';
 import {Manifest} from '../../manifest.js';
 import {EntityClass, Entity, SerializedEntity} from '../../entity.js';
 import {SYMBOL_INTERNALS} from '../../symbols.js';
-import {CRDTEntityCollection, ActiveCollectionEntityStore, CollectionEntityType} from '../storage.js';
+import {CRDTEntityCollection, ActiveCollectionEntityStore, CollectionEntityType, CRDTEntitySingleton, CRDTMuxEntity} from '../storage.js';
 import {Reference} from '../../reference.js';
 import {VersionMap, CollectionOperation, CollectionOpTypes, CRDTCollectionTypeRecord,
         CRDTCollection, CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes, CRDTSingleton,
@@ -31,12 +31,10 @@ import {StoreInfo} from '../store-info.js';
 async function getCollectionHandle(primitiveType: EntityType, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<CollectionHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const store = new MockStore<CRDTEntityCollection>(new CollectionType(primitiveType)) as unknown as ActiveCollectionEntityStore;
+  const mockStore = new MockStore<CRDTEntityCollection>(new CollectionType(primitiveType));
   const handle = new CollectionHandle(
       'me',
-      new StorageProxy(
-          'id',
-          new MockStore<CRDTCollectionTypeRecord<SerializedEntity>>(new CollectionType(primitiveType))),
+      new StorageProxy('id', mockStore.storeInfo, mockStore),
       IdGenerator.newSession(),
       fakeParticle,
       canRead,
@@ -53,11 +51,10 @@ async function getCollectionHandle(primitiveType: EntityType, particle?: MockPar
 async function getSingletonHandle(primitiveType: EntityType, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<SingletonHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
+  const mockStore = new MockStore<CRDTEntitySingleton>(new SingletonType(primitiveType));
   const handle = new SingletonHandle(
       'me',
-      new StorageProxy(
-          'id',
-          new MockStore<CRDTSingletonTypeRecord<SerializedEntity>>(new SingletonType(primitiveType))),
+      new StorageProxy('id', mockStore.storeInfo, mockStore),
       IdGenerator.newSession(),
       fakeParticle,
       canRead,
@@ -74,9 +71,8 @@ async function getSingletonHandle(primitiveType: EntityType, particle?: MockPart
 async function getEntityHandle(schema: Schema, muxId: string, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<EntityHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const storageProxy = new StorageProxy(
-    'id',
-    new MockStore<CRDTEntityTypeRecord<Identified, Identified>>(new MuxType<EntityType>(new EntityType(schema))));
+  const mockStore = new MockStore<CRDTMuxEntity>(new MuxType<EntityType>(new EntityType(schema)));
+  const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
   const handle = new EntityHandle<Entity>(
     'me',
     storageProxy,

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -104,7 +104,7 @@ describe('ReferenceModeStore Integration', async () => {
 
     // Set up a common store and host both handles on top. This will result in one store but two different proxies.
     const activestore = await arc.getActiveStore(new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'}));
-    const proxy = new StorageProxy('proxy', activestore);
+    const proxy = new StorageProxy('proxy', activestore.storeInfo, activestore);
     const writeHandle = new CollectionHandle('write-handle', proxy, arc.idGenerator, null, false, true, 'write-handle');
     const particle = new Particle();
     const readHandle = new CollectionHandle('read-handle', proxy, arc.idGenerator, particle, true, false, 'read-handle');

--- a/src/runtime/storage/tests/storage-proxy-muxer-test.ts
+++ b/src/runtime/storage/tests/storage-proxy-muxer-test.ts
@@ -29,7 +29,7 @@ describe('StorageProxyMuxer', async () => {
 
   it('creation of storage proxies', async () => {
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>(new MuxType(fooEntityType));
-    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer);
+    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer.storeInfo, mockDirectStoreMuxer);
 
     const mockHandle = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id'));
     const mockHandle2 = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id'));
@@ -41,7 +41,7 @@ describe('StorageProxyMuxer', async () => {
   });
   it('can direct ProxyMessages from storage proxy to direct store muxer', async () => {
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>(new MuxType(fooEntityType));
-    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer);
+    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer.storeInfo, mockDirectStoreMuxer);
     const storageProxy = storageProxyMuxer.getStorageProxy('foo-id');
 
     // Ensure backing store receives SyncRequest proxy messages
@@ -73,7 +73,7 @@ describe('StorageProxyMuxer', async () => {
   });
   it('propagates exceptions to the direct store muxer', async () => {
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>(new MuxType(fooEntityType));
-    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer);
+    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer.storeInfo, mockDirectStoreMuxer);
     mockDirectStoreMuxer.mockCRDTData['foo-id'] = fooEntityCRDT.getData();
 
     const mockHandle = new MockHandle(storageProxyMuxer.getStorageProxy('foo-id'));
@@ -93,7 +93,7 @@ describe('StorageProxyMuxer', async () => {
   });
   it('can direct ModelUpdate ProxyMessages from the direct store muxer to correct storage proxies', async () => {
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>(new MuxType(fooEntityType));
-    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer);
+    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer.storeInfo, mockDirectStoreMuxer);
 
     const fooStorageProxy = storageProxyMuxer.getStorageProxy('foo-id');
     const foo2StorageProxy = storageProxyMuxer.getStorageProxy('foo-id-2');
@@ -119,7 +119,7 @@ describe('StorageProxyMuxer', async () => {
   });
   it('can direct Operations ProxyMessages from the direct store muxer to correct storage proxies', async () => {
     const mockDirectStoreMuxer = new MockDirectStoreMuxer<CRDTEntityTypeRecord<Identified, Identified>>(new MuxType(fooEntityType));
-    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer);
+    const storageProxyMuxer = new StorageProxyMuxer(mockDirectStoreMuxer.storeInfo, mockDirectStoreMuxer);
     const fooStorageProxy = storageProxyMuxer.getStorageProxy('foo-id');
     const foo2StorageProxy = storageProxyMuxer.getStorageProxy('foo-id-2');
 

--- a/src/runtime/storage/tests/storage-proxy-test.ts
+++ b/src/runtime/storage/tests/storage-proxy-test.ts
@@ -30,7 +30,7 @@ const initialData = {values: {'1': {value: {id: 'e1'}, version: {A: 1}}}, versio
 describe('StorageProxy', async () => {
   it('will apply and propagate operation', async () => {
     const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore);
+    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
 
     // Register a handle to verify updates are sent back.
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -55,7 +55,7 @@ describe('StorageProxy', async () => {
   it('does not notify keepSynced handles if desynced', async () => {
     // Don't pass any data to the MockStore.
     const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType);
-    const storageProxy = new StorageProxy('id', mockStore);
+    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
 
     // Register a keepSynced handle and a !keepSynced one.
     const handle1 = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -80,7 +80,7 @@ describe('StorageProxy', async () => {
 
   it('will sync if desynced before returning the particle view', async () => {
     const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore);
+    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
 
     // Register a handle to verify updates are sent back.
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -103,7 +103,7 @@ describe('StorageProxy', async () => {
 
   it('can exchange models with the store', async () => {
     const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore);
+    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
 
     // Registering a handle trigger the proxy to connect to the store and fetch the model.
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -127,7 +127,7 @@ describe('StorageProxy', async () => {
 
   it('propagates exceptions to the store', async () => {
     const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore);
+    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
 
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
     handle.onSync = () => {
@@ -145,7 +145,7 @@ describe('StorageProxy', async () => {
 describe('NoOpStorageProxy', () => {
   it('overrides all methods in StorageProxy', async () => {
     const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType);
-    const storageProxy = new StorageProxy('id', mockStore);
+    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
     const noOpStorageProxy = getNoOpStorageProxy();
 
     const properties = [];

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -17,7 +17,6 @@ import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {handleForActiveStore, CollectionEntityType} from '../../runtime/storage/storage.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 import {StoreInfo} from '../../runtime/storage/store-info.js';
 
 describe('common particles test', () => {

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -16,7 +16,9 @@ import {Loader} from '../../platform/loader.js';
 import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
-import {ActiveCollectionEntityStore, handleForActiveStore} from '../../runtime/storage/storage.js';
+import {handleForActiveStore, CollectionEntityType} from '../../runtime/storage/storage.js';
+import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
+import {StoreInfo} from '../../runtime/storage/store-info.js';
 
 describe('common particles test', () => {
   afterEach(() => {
@@ -89,9 +91,9 @@ describe('common particles test', () => {
     await suggestion.instantiate(arc);
     await arc.idle;
 
-    const endpointProvider = await arc.getActiveStore(
-        arc.findStoreById(arc.stores[2].id))  as ActiveCollectionEntityStore;
-    const handle = handleForActiveStore(endpointProvider, arc);
+    const storeInfo = arc.findStoreById(arc.stores[2].id) as StoreInfo<CollectionEntityType>;
+    const endpointProvider = await arc.getActiveStore(storeInfo);
+    const handle = handleForActiveStore(storeInfo, endpointProvider, arc);
     assert.strictEqual((await handle.toList()).length, 5);
   });
 });


### PR DESCRIPTION

This patch moves the StoreInfo argument from the
getStorageEndpointProvider() call to the getStorageEndpoint() call, which means that
a single StorageEndpointProvider can be used for a set of StorageProxies.

Eventually this single StorageEndpointProvider will become a separate
StorageEndpointManager, rather than being a responsibility of Stores directly.
This will allow the same manager to be used in both direct communication mode
and in hosted (via PEC) mode.

A short-term consequence is that both StoreInfo and an ActiveStore are passed
into the StorageProxy constructor (the ActiveStore is currently still the
StorageEndpointProvider and StoreInfo is needed to get the endpoint). This
duplication will be resolved in a subsequent patch (the ActiveStore argument
will become a StorageEndpoint instead, vended by a StorageEndpointManager
which will have responsibility for creating ActiveStores on demand).
________________________________________________________________________________________________

next steps:
- DirectStorageEndpointManager should implement StorageCommunicationEndpointProvider, and ActiveStore StorageCommunicationEndpoint instead.