### PR TITLE
Replace 'undefined' filename in error messages with '<no filename>' for clarity

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -465,8 +465,8 @@ export class Manifest {
         } else {
           preamble = `Post-parse processing ${severity} caused by`;
         }
-        const fileNameStr = fileName ? `'${fileName}' ` : '';
-        message = `${preamble} ${fileNameStr}line ${e.location.start.line}.
+        const fileNameStr = fileName ? `'${fileName}'` : '<no filename>';
+        message = `${preamble} ${fileNameStr} line ${e.location.start.line}.
 ${e.message}
   ${line}
   ${highlight}`;

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -465,7 +465,8 @@ export class Manifest {
         } else {
           preamble = `Post-parse processing ${severity} caused by`;
         }
-        message = `${preamble} '${fileName}' line ${e.location.start.line}.
+        const fileNameStr = fileName ? `'${fileName}' ` : '';
+        message = `${preamble} ${fileNameStr}line ${e.location.start.line}.
 ${e.message}
   ${line}
   ${highlight}`;

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -2026,7 +2026,7 @@ recipe SomeRecipe
       store Store0 of [Thing] in EntityList`);
       assert(false);
     } catch (e) {
-      assert.deepEqual(e.message, `Post-parse processing error caused by 'undefined' line 7.
+      assert.deepEqual(e.message, `Post-parse processing error caused by line 7.
 Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         store Store0 of [Thing] in EntityList
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`);
@@ -3784,7 +3784,7 @@ resource SomeName
           particle Foo
             data: reads {*}
       `), `\
-Post-parse processing error caused by 'undefined' line 3.
+Post-parse processing error caused by line 3.
 Only type variables may have '*' fields.
               data: reads {*}
                           ^^^`);
@@ -3792,7 +3792,7 @@ Only type variables may have '*' fields.
           particle Foo
             data: reads {name: Text, *}
       `), `\
-Post-parse processing error caused by 'undefined' line 3.
+Post-parse processing error caused by line 3.
 Only type variables may have '*' fields.
               data: reads {name: Text, *}
                           ^^^^^^^^^^^^^^^`);

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -2026,7 +2026,7 @@ recipe SomeRecipe
       store Store0 of [Thing] in EntityList`);
       assert(false);
     } catch (e) {
-      assert.deepEqual(e.message, `Post-parse processing error caused by line 7.
+      assert.deepEqual(e.message, `Post-parse processing error caused by <no filename> line 7.
 Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         store Store0 of [Thing] in EntityList
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`);
@@ -3784,7 +3784,7 @@ resource SomeName
           particle Foo
             data: reads {*}
       `), `\
-Post-parse processing error caused by line 3.
+Post-parse processing error caused by <no filename> line 3.
 Only type variables may have '*' fields.
               data: reads {*}
                           ^^^`);
@@ -3792,7 +3792,7 @@ Only type variables may have '*' fields.
           particle Foo
             data: reads {name: Text, *}
       `), `\
-Post-parse processing error caused by line 3.
+Post-parse processing error caused by <no filename> line 3.
 Only type variables may have '*' fields.
               data: reads {name: Text, *}
                           ^^^^^^^^^^^^^^^`);


### PR DESCRIPTION
Already had these as separate commits so reuploading as different CLs so we can roll them back etc.