### PR TITLE
[Refactor] Expose maxReadSchemas to be a property of IngressValidation.

### DIFF
--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -18,6 +18,7 @@ import {Dictionary} from '../../utils/lib-utils.js';
 // Helper class for validating ingress fields and capabilities.
 export class IngressValidation {
   private readonly capabilityByFieldPath = new Map<string, Capabilities[]>();
+  public readonly maxReadSchemas: Dictionary<Schema> = {};
 
   constructor(public readonly policies: Policy[]) {
     for (const policy of this.policies) {
@@ -28,6 +29,7 @@ export class IngressValidation {
         }
       }
     }
+    this.maxReadSchemas = IngressValidation.getMaxReadSchemas(this.policies);
   }
 
   private initCapabilitiesMap(fieldPaths: string[], field: PolicyField, capabilities: Capabilities[]) {
@@ -165,7 +167,7 @@ export class IngressValidation {
   }
 
   // Returns the max readable schemas for all schemas mentioned in the policies.
-  static getMaxReadSchemas(policies: Policy[]): Dictionary<Schema> {
+  private static getMaxReadSchemas(policies: Policy[]): Dictionary<Schema> {
     const maxReadSchemas: Dictionary<Schema> = {};
     for (const policy of policies) {
       for (const target of policy.targets) {

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -478,7 +478,8 @@ policy MyPolicy {
             }
           }
         }`);
-      const maxReadSchemas = IngressValidation.getMaxReadSchemas(manifest.policies);
+      const ingressValidation = new IngressValidation(manifest.policies);
+      const maxReadSchemas = ingressValidation.maxReadSchemas;
       const expectedSchemas = (await Manifest.parse(`
         schema Name
           last: Text
@@ -557,7 +558,8 @@ policy MyPolicy {
           state
         }
       }`)).policies;
-    const maxReadSchemas = IngressValidation.getMaxReadSchemas(policies);
+    const ingressValidation = new IngressValidation(policies);
+    const maxReadSchemas = ingressValidation.maxReadSchemas;
     const expectedSchemas = (await Manifest.parse(`
       schema Address
         number: Number
@@ -615,7 +617,8 @@ policy MyPolicy {
             country
         }
       }`);
-    const maxReadSchemas = IngressValidation.getMaxReadSchemas(manifest.policies);
+    const ingressValidation = new IngressValidation(manifest.policies);
+    const maxReadSchemas = ingressValidation.maxReadSchemas;
     const expectedSchemas = (await Manifest.parse(`
       schema Address
         city: Text
@@ -658,7 +661,8 @@ policy MyPolicy {
             }
           }
         }`);
-      const maxReadSchemas = IngressValidation.getMaxReadSchemas(manifest.policies);
+      const ingressValidation = new IngressValidation(manifest.policies);
+      const maxReadSchemas = ingressValidation.maxReadSchemas;
       const expectedSchemas = (await Manifest.parse(`
         schema Name
           last: Text


### PR DESCRIPTION
It makes more sense to make `maxReadSchemas to be part of the `IngressValidation` as it is determined by the policies of the `IngressValidation` object. 

This PR introduces no change in functionality.