### PR TITLE
Updated IntelliJ Bazelproject file for Blaze compatibility.

### DIFF
--- a/ij.bazelproject
+++ b/ij.bazelproject
@@ -2,3 +2,6 @@ import .bazelproject
 additional_languages:
   typescript
 
+ts_config_rules:
+  //:tsconfig
+


### PR DESCRIPTION
Added `ts_config_rules` section, which is required for Blaze project imports (see go/project-views#ts-config-rules for reference).