### PR TITLE
Adds an API to get max read type according to policies in ingress restricting.

### DIFF
--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -300,7 +300,7 @@ export class IngressValidation {
           return type;
         } else {
           return TypeVariable.make(
-            "",
+            '',
             /* canWriteSuperset = */ maxReadType,
             /* canReadSubset = */ canReadSubset,
             typeVar.resolveToMaxType

--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {Policy, PolicyField} from './policy.js';
 import {Capability, Capabilities} from '../capabilities.js';
-import {EntityType, Type, Schema, FieldType} from '../../types/lib-types.js';
+import {EntityType, Type, Schema, FieldType, SingletonType, CollectionType, ReferenceType, TupleType} from '../../types/lib-types.js';
 import {Recipe, Handle, HandleConnection} from '../recipe/lib-recipe.js';
 import {Dictionary} from '../../utils/lib-utils.js';
 
@@ -224,6 +224,63 @@ export class IngressValidation {
         maxReadSchemas[name] = Schema.union(
           currentMaxReadSchema, targetSchema);
       }
+    }
+  }
+
+  // Return a new type where all the top-level schemas have been replaced
+  // with the max read schema according to the given `policies`. Returns
+  // null if the given type cannot be handled.
+  //
+  // Suppose that we have types `Foo {a, b, c, d, e, f}` and `Bar {w, x, y, z}`.
+  // Policy is as follows:
+  //   policy MyPolicy {
+  //     from Foo access {a, c, e}
+  //     from Bar access {w, z}
+  //   }
+  //
+  // For various types, the return value of this method is as follows:
+  //
+  //    Foo -> Foo {a, c, e}
+  //   [Foo] -> [Foo {a, c, e}]
+  //   [&Foo] -> [&Foo {a, c, e}]
+  //   (Foo, Bar) -> (Foo {a, c, e}, Bar {w, z})
+  //   List<inline Foo> -> List<inline Foo {a, c, e}>
+  //   Blah -> null
+  //   (Foo, Blah) -> null
+  //   ...
+  public getMaxReadType(type: Type): Type|null {
+    switch (type.tag) {
+      case 'Entity': {
+        const schema = type.getEntitySchema();
+        assert(schema.names.length === 1,
+               `Cannot deal with schemas with more than one name yet.`);
+        const newSchema = this.maxReadSchemas[schema.names[0]];
+        if (newSchema == null) return null;
+        return new EntityType(newSchema);
+      }
+      case 'Collection': {
+        const newCollectionType = this.getMaxReadType(type.getContainedType());
+        if (newCollectionType == null) return null;
+        return new CollectionType(newCollectionType);
+      }
+      case 'Tuple': {
+        const newInnerTypes = type.getContainedTypes().map(
+          t => this.getMaxReadType(t));
+        if (newInnerTypes.includes(null)) return null;
+        return new TupleType(newInnerTypes);
+      }
+      case 'Reference': {
+        const newReferredType = this.getMaxReadType(type.getContainedType());
+        if (newReferredType == null) return null;
+        return new ReferenceType(newReferredType);
+      }
+      case 'Singleton': {
+        const newInnerType = this.getMaxReadType(type.getContainedType());
+        if (newInnerType == null) return null;
+        return new SingletonType(newInnerType);
+      }
+      default:
+        return null;
     }
   }
 }

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -16,6 +16,7 @@ import {mapToDictionary} from '../../../utils/lib-utils.js';
 import {TtlUnits, Persistence, Encryption, Capabilities, Ttl} from '../../capabilities.js';
 import {IngressValidation} from '../ingress-validation.js';
 import {deleteFieldRecursively} from '../../../utils/lib-utils.js';
+import {EntityType, SingletonType, CollectionType, ReferenceType, TupleType} from '../../../types/lib-types.js';
 
 const customAnnotation = `
 annotation custom
@@ -510,54 +511,61 @@ policy MyPolicy {
       assert.deepEqual(maxReadSchemas['Address'], expectedSchemas['Address']);
   });
 
+  const manifestWithMultiplePolicies = `
+    schema Address
+      number: Number
+      street: Text
+      city: Text
+      zip: Number
+      state: Text
+      country: Text
+
+    schema Person
+      name: Text
+      phone: Text
+      address: &Address
+      otherAddresses: [&Address {street, city, country}]
+
+    schema SensitiveInfo
+      name: Text
+      ssn: Text
+
+    policy PolicyOne {
+      from Person access {
+        name,
+        address {
+          number,
+          street
+        }
+      }
+    }
+
+    policy PolicyTwo {
+      from Person access {
+        address {
+          street,
+          city
+        },
+        otherAddresses {city}
+      }
+    }
+
+    policy PolicyThree {
+      from Person access {
+        name,
+        otherAddresses {country}
+      }
+    }
+
+    policy PolicyFour {
+      from Address access {
+        state
+      }
+    }`;
+
   it('restricts types according to multiple policies', async () => {
-    const policies = (await Manifest.parse(`
-      schema Address
-        number: Number
-        street: Text
-        city: Text
-        zip: Number
-        state: Text
-        country: Text
-
-      schema Person
-        name: Text
-        phone: Text
-        address: &Address
-        otherAddresses: [&Address {street, city, country}]
-
-      policy PolicyOne {
-        from Person access {
-          name,
-          address {
-            number,
-            street
-          }
-        }
-      }
-
-      policy PolicyTwo {
-        from Person access {
-          address {
-            street,
-            city
-          },
-          otherAddresses {city}
-        }
-      }
-
-      policy PolicyThree {
-        from Person access {
-          name,
-          otherAddresses {country}
-        }
-      }
-
-      policy PolicyFour {
-        from Address access {
-          state
-        }
-      }`)).policies;
+    const policies =
+      (await Manifest.parse(manifestWithMultiplePolicies)).policies;
     const ingressValidation = new IngressValidation(policies);
     const maxReadSchemas = ingressValidation.maxReadSchemas;
     const expectedSchemas = (await Manifest.parse(`
@@ -687,4 +695,94 @@ policy MyPolicy {
       assert.isFalse('Person' in maxReadSchemas);
       assert.deepEqual(maxReadSchemas['Name'], expectedSchemas['Name']);
     });
+
+  it('returns max read type according to multiple policies', async () => {
+    const manifest = await Manifest.parse(manifestWithMultiplePolicies);
+    const expectedSchemas = (await Manifest.parse(`
+      schema Address
+        number: Number
+        street: Text
+        city: Text
+        state: Text
+        country: Text
+
+      schema Person
+        name: Text
+        address: &Address {number, street, city}
+        otherAddresses: [&Address {city, country}]
+`)).schemas;
+    const ingressValidation = new IngressValidation(manifest.policies);
+    deleteFieldRecursively(expectedSchemas['Person'], 'location', {replaceWithNulls: true});
+    deleteFieldRecursively(expectedSchemas['Address'], 'location', {replaceWithNulls: true});
+    const manifestPerson = new EntityType(manifest.schemas['Person']);
+    const manifestAddress = new EntityType(manifest.schemas['Address']);
+    const manifestSensitiveInfo =
+      new EntityType(manifest.schemas['SensitiveInfo']);
+    const maxReadPerson = new EntityType(expectedSchemas['Person']);
+    const maxReadAddress = new EntityType(expectedSchemas['Address']);
+
+    // Entity type.
+    assert.deepEqual(
+      ingressValidation.getMaxReadType(manifestPerson),
+      maxReadPerson);
+
+    // Singleton type.
+    assert.deepEqual(
+      ingressValidation.getMaxReadType(
+        new SingletonType(manifestPerson)),
+      new SingletonType(maxReadPerson));
+
+    // Reference type.
+    assert.deepEqual(
+      ingressValidation.getMaxReadType(
+        new ReferenceType(manifestPerson)),
+      new ReferenceType(maxReadPerson));
+
+    // Tuple type.
+    const manifestTuple = new TupleType([manifestPerson, manifestAddress]);
+    const maxReadTuple = new TupleType([maxReadPerson, maxReadAddress]);
+    assert.deepEqual(
+      ingressValidation.getMaxReadType(manifestTuple),
+      maxReadTuple);
+
+    // Collection type.
+    const manifestCollection = new CollectionType(manifestPerson);
+    const maxReadCollection = new CollectionType(maxReadPerson);
+    assert.deepEqual(
+      ingressValidation.getMaxReadType(manifestCollection),
+      maxReadCollection);
+  });
+
+  it('returns null for max read type if type has inaccessible schemas', async () => {
+    const manifest = await Manifest.parse(manifestWithMultiplePolicies);
+    const ingressValidation = new IngressValidation(manifest.policies);
+    const manifestPerson = new EntityType(manifest.schemas['Person']);
+    const manifestSensitiveInfo =
+      new EntityType(manifest.schemas['SensitiveInfo']);
+
+    // Entity type.
+    assert.isNull(
+      ingressValidation.getMaxReadType(manifestSensitiveInfo));
+
+    // Singleton type.
+    assert.isNull(
+      ingressValidation.getMaxReadType(
+        new SingletonType(manifestSensitiveInfo)));
+
+    // Reference type.
+    assert.isNull(
+      ingressValidation.getMaxReadType(
+        new ReferenceType(manifestSensitiveInfo)));
+
+    // Tuple type.
+    assert.isNull(
+      ingressValidation.getMaxReadType(
+        new TupleType([manifestPerson, manifestSensitiveInfo])));
+
+    // Collection type.
+    assert.isNull(
+      ingressValidation.getMaxReadType(
+        new CollectionType(manifestSensitiveInfo)));
+  });
+
 });

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -730,14 +730,12 @@ policy MyPolicy {
 
     // Singleton type.
     assert.deepEqual(
-      ingressValidation.getMaxReadType(
-        new SingletonType(manifestPerson)),
+      ingressValidation.getMaxReadType(new SingletonType(manifestPerson)),
       new SingletonType(maxReadPerson));
 
     // Reference type.
     assert.deepEqual(
-      ingressValidation.getMaxReadType(
-        new ReferenceType(manifestPerson)),
+      ingressValidation.getMaxReadType(new ReferenceType(manifestPerson)),
       new ReferenceType(maxReadPerson));
 
     // Tuple type.
@@ -757,17 +755,17 @@ policy MyPolicy {
     // Type variable.
     // Only the canWriteSuperset will be replaced with the max read type.
     const typeVar = TypeVariable.make(
-      "",
+      '',
       /* canWriteSuperset = */manifestCollection,
       /* canReadSubset = */manifestCollection);
     const maxReadTypeVar = TypeVariable.make(
-      "",
+      '',
       /* canWriteSuperset = */maxReadCollection,
       /* canReadsubset = */manifestCollection);
     assert.deepEqual(ingressValidation.getMaxReadType(typeVar), maxReadTypeVar);
 
     const noWriteTypeVar = TypeVariable.make(
-      "",
+      '',
       /* canWriteSuperset = */manifestCollection,
       /* canReadSubset = */null);
     assert.deepEqual(ingressValidation.getMaxReadType(noWriteTypeVar), noWriteTypeVar);
@@ -793,7 +791,7 @@ policy MyPolicy {
       personSubsetSchema.isAtLeastAsSpecificAs(expectedSchemas['Person']));
     const personSubset = new EntityType(personSubsetSchema);
     const subsetTypeVar = TypeVariable.make(
-      "",
+      '',
       /* canWriteSuperset = */manifestPerson,
       /* canReadSubset = */personSubset);
     assert.deepEqual(ingressValidation.getMaxReadType(subsetTypeVar), subsetTypeVar);
@@ -834,7 +832,7 @@ policy MyPolicy {
     assert.isNull(
       ingressValidation.getMaxReadType(
         TypeVariable.make(
-          "",
+          '',
           /* canWriteSuperset = */manifestSensitiveInfo,
           /* canReadSubset = */manifestSensitiveInfo)));
   });


### PR DESCRIPTION
This PR adds an API to replace all the top-level schemas in a type with the max read schema according to a given set of `policies`. Returns null if the given type cannot be handled.   
                                                                                                                                                                                                                                                                                                             
Suppose that we have types `Foo {a, b, c, d, e, f}` and `Bar {w, x, y, z}` and the following policy: 
```
  policy MyPolicy {
     from Foo access {a, c, e}
     from Bar access {w, z}
  }
```
For various types, the return value of this method is as follows:
```
    Foo -> Foo {a, c, e}
   [Foo] -> [Foo {a, c, e}]
   [&Foo] -> [&Foo {a, c, e}]
   (Foo, Bar) -> (Foo {a, c, e}, Bar {w, z})
   List<inline Foo> -> List<inline Foo {a, c, e}>
   Blah -> null
   (Foo, Blah) -> null
   ...
```
This API is useful for auto generating phantom readers.