### PR TITLE
Add phantom readers based on the given set of policies

### DIFF
--- a/src/runtime/field-path.ts
+++ b/src/runtime/field-path.ts
@@ -114,4 +114,4 @@ function parseTupleAccessor(field: string): number {
   return result;
 }
 
-class FieldPathError extends Error {}
+export class FieldPathError extends Error {}

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -55,6 +55,7 @@ export class AllocatorRecipeResolver {
    * @returns Resolved recipes (with Storage Keys).
    */
   async resolve(): Promise<Recipe[]> {
+    // TODO(b/174815541): Break the `resolve` method into a bunch of smaller methods.
     const opts = {errors: new Map<Recipe | RecipeComponent, string>()};
 
     const originalRecipes = [];

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -123,7 +123,7 @@ export class AllocatorRecipeResolver {
       const allTypes = handles.map(h => h.type);
       if (this.ingressValidation) {
         // For every `create` handle `h`, simulate a phantom reader.  This is
-        // accomplished by adding a max read type corresponding to the type of
+        // accomplished by adding the max read type corresponding to the type of
         // the create handle `h` to `allTypes`.
         handles.forEach(handle => {
           if (handle.fate !== 'create') return;
@@ -131,7 +131,6 @@ export class AllocatorRecipeResolver {
             throw new AllocatorRecipeResolverError(
               `No type for handle '${handle.id}'.`);
           }
-          console.log(`Handle ${handle.id} type is  ${JSON.stringify(handle.type, null, 2)}`);
           const maxHandleReadType =
             this.ingressValidation.getMaxReadType(handle.type);
           if (maxHandleReadType == null) {
@@ -145,9 +144,7 @@ export class AllocatorRecipeResolver {
         allTypes.push(store.type);
       }
       const restrictedType = this.restrictHandleType(handleId, allTypes);
-      console.log(`Restricted type is ${restrictedType.resolvedType()}`);
       assert(restrictedType.maybeEnsureResolved({restrictToMinBound: true}));
-      console.log(`After resoluton: Restricted type is ${restrictedType.resolvedType()}`);
 
       for (const handle of handles) {
         handle.restrictType(restrictedType);

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -748,8 +748,8 @@ particle ReaderB
   };
 
   const verifyWritingRecipe = async (manifestStr: string, expectedSchema: string) => {
-    return verifyWritingRecipeWithPolicy(manifestStr, null, expectedSchema)
-  }
+    return verifyWritingRecipeWithPolicy(manifestStr, null, expectedSchema);
+  };
 
   it('restricts writer fields by one writer-reader recipe', async () => {
     const recipe = `
@@ -1187,7 +1187,7 @@ recipe ReadingRecipeAD
     await verifyWritingRecipeWithPolicy(recipe, policies, expected);
   };
 
-  it('adds correct phantom readers that is consistent with writes', async() => {
+  it('adds correct phantom readers that is consistent with writes', async () => {
     const thingSchema = `
       schema Thing
         a: Text
@@ -1218,7 +1218,7 @@ recipe ReadingRecipeAD
     });
   });
 
-  it('writes nothing if allowed fields do not overlap with writes', async() => {
+  it('writes nothing if allowed fields do not overlap with writes', async () => {
     const thingSchema = `
       schema Thing
         a: Text
@@ -1277,7 +1277,7 @@ recipe ReadingRecipeAD
     });
   });
 
-  it('adds phantom readers for ordered lists', async() => {
+  it('adds phantom readers for ordered lists', async () => {
     const thingSchemaWithLists = `
       schema Thing
         a: List<Text>
@@ -1300,7 +1300,7 @@ recipe ReadingRecipeAD
     });
   });
 
-  it('adds phantom readers for inline entities', async() => {
+  it('adds phantom readers for inline entities', async () => {
     // Inline entity tests
     const thingSchemaWithInline = `
       schema Thing
@@ -1332,7 +1332,7 @@ recipe ReadingRecipeAD
     });
   });
 
-  it('adds phantom readers for lists of inline entities', async() => {
+  it('adds phantom readers for lists of inline entities', async () => {
     // List of inline entity tests
     const thingSchemaWithInlineList = `
       schema Thing
@@ -1358,7 +1358,7 @@ recipe ReadingRecipeAD
     });
   });
 
-  it('fails when adding phantom readers for tuples', async() => {
+  it('fails when adding phantom readers for tuples', async () => {
     const thingSchemaWithTuples = `
       schema Thing
         a: (Text, Number)
@@ -1387,7 +1387,7 @@ recipe ReadingRecipeAD
     );
   });
 
-  it('fails when adding phantom readers for schema not in policy', async() => {
+  it('fails when adding phantom readers for schema not in policy', async () => {
     const thingSchema = `
       schema Thing
         a: Text

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -1187,6 +1187,61 @@ recipe ReadingRecipeAD
     await verifyWritingRecipeWithPolicy(recipe, policies, expected);
   };
 
+  it('adds correct phantom readers that is consistent with writes', async() => {
+    const thingSchema = `
+      schema Thing
+        a: Text
+        b: Text
+        c: Text
+        d: Text
+        e: Text
+    `;
+    await verifyWritingRecipeWithPhantomReader({
+      schemas: thingSchema,
+      policy: 'from Thing access { a }',
+      writes: 'Thing {a: Text}',
+      expected: 'Thing {a: Text}'
+    });
+
+    await verifyWritingRecipeWithPhantomReader({
+      schemas: thingSchema,
+      policy: 'from Thing access { a, b }',
+      writes: 'Thing {a: Text}',
+      expected: 'Thing {a: Text}'
+    });
+
+    await verifyWritingRecipeWithPhantomReader({
+      schemas: thingSchema,
+      policy: 'from Thing access { a, d }',
+      writes: 'Thing {a: Text, b: Text, c: Text}',
+      expected: 'Thing {a: Text}'
+    });
+  });
+
+  it('writes nothing if allowed fields do not overlap with writes', async() => {
+    const thingSchema = `
+      schema Thing
+        a: Text
+        b: Text
+        c: Text
+        d: Text
+        e: Text
+    `;
+    await verifyWritingRecipeWithPhantomReader({
+      schemas: thingSchema,
+      policy: 'from Thing access { }',
+      writes: 'Thing {a: Text}',
+      expected: 'Thing {}'
+    });
+
+    await verifyWritingRecipeWithPhantomReader({
+      schemas: thingSchema,
+      policy: 'from Thing access { b }',
+      writes: 'Thing {a: Text}',
+      expected: 'Thing {}'
+    });
+  });
+
   it('adds phantom readers for simple types', async () => {
     const thingSchema = `
       schema Thing


### PR DESCRIPTION
Instead of creating actual phantom reader recipes, this PR _simulates_ phantom readers during ingress restricting.