### PR TITLE
Makes it painfully obvious where the global StorageKeyManager is being used

### DIFF
--- a/java/arcs/android/common/resurrection/DbHelper.kt
+++ b/java/arcs/android/common/resurrection/DbHelper.kt
@@ -23,7 +23,7 @@ import arcs.android.common.forEach
 import arcs.android.common.map
 import arcs.android.common.transaction
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
 
 /**
@@ -118,7 +118,7 @@ class DbHelper(
     val deletionArgs = arrayOf(component.packageName, component.className, targetId)
     execSQL(
       """
-                DELETE FROM requested_notifiers 
+                DELETE FROM requested_notifiers
                 WHERE component_package = ? AND component_class = ? AND target_id = ?
             """,
       deletionArgs
@@ -143,10 +143,10 @@ class DbHelper(
     return readableDatabase.transaction {
       rawQuery(
         """
-                    SELECT 
-                        component_package, component_class, notification_key, target_id 
+                    SELECT
+                        component_package, component_class, notification_key, target_id
                     FROM requested_notifiers
-                """.trimIndent(),
+        """.trimIndent(),
         null
       ).forEach {
         val componentName = ComponentName(it.getString(0), it.getString(1))
@@ -157,21 +157,21 @@ class DbHelper(
         val notifiers =
           notifiersByComponentName[requestedNotifier]
             ?: mutableListOf()
-        notifiers.add(StorageKeyParser.parse(key))
+        notifiers.add(StorageKeyManager.GLOBAL_INSTANCE.parse(key))
         notifiersByComponentName[requestedNotifier] = notifiers
       }
 
       rawQuery(
         """
-                    SELECT 
-                        component_package, 
-                        component_class, 
-                        component_type, 
-                        intent_action, 
+                    SELECT
+                        component_package,
+                        component_class,
+                        component_type,
+                        intent_action,
                         intent_extras,
                         target_id
                     FROM resurrection_requests
-                """.trimIndent(),
+        """.trimIndent(),
         null
       ).map {
         val componentName = ComponentName(it.getString(0), it.getString(1))
@@ -223,7 +223,7 @@ class DbHelper(
                     intent_extras BLOB,
                     PRIMARY KEY (component_package, component_class, target_id)
                 )
-            """.trimIndent(),
+      """.trimIndent(),
       """
                 CREATE TABLE requested_notifiers (
                     component_package TEXT NOT NULL,
@@ -231,15 +231,15 @@ class DbHelper(
                     target_id TEXT NOT NULL,
                     notification_key TEXT NOT NULL
                 )
-            """.trimIndent(),
+      """.trimIndent(),
       """
                 CREATE INDEX notifiers_by_component_and_id
                 ON requested_notifiers (
-                    component_package, 
+                    component_package,
                     component_class,
                     target_id
                 )
-            """.trimIndent()
+      """.trimIndent()
     )
 
     private val VERSION_2_MIGRATION = arrayOf(

--- a/java/arcs/android/common/resurrection/ResurrectionRequest.kt
+++ b/java/arcs/android/common/resurrection/ResurrectionRequest.kt
@@ -19,7 +19,7 @@ import android.content.Intent
 import android.os.PersistableBundle
 import androidx.annotation.VisibleForTesting
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 
 /**
  * Represents a request to the [ResurrectorService] from a client which wishes to be resurrected
@@ -180,7 +180,7 @@ data class ResurrectionRequest(
       val componentTypeName = extras.getString(EXTRA_REGISTRATION_COMPONENT_TYPE)
         ?: return null
       val notifiers = extras.getStringArrayList(EXTRA_REGISTRATION_NOTIFIERS)
-        ?.map { StorageKeyParser.parse(it) } ?: emptyList()
+        ?.map { StorageKeyManager.GLOBAL_INSTANCE.parse(it) } ?: emptyList()
       val targetId = extras.getString(EXTRA_REGISTRATION_TARGET_ID) ?: return null
 
       val componentType = try {

--- a/java/arcs/android/crdt/ReferenceProto.kt
+++ b/java/arcs/android/crdt/ReferenceProto.kt
@@ -3,12 +3,12 @@ package arcs.android.crdt
 import android.os.Parcel
 import arcs.android.util.readProto
 import arcs.core.storage.Reference
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 
 /** Constructs a [Reference] from the given [ReferenceProto]. */
 fun ReferenceProto.toReference() = Reference(
   id = id,
-  storageKey = StorageKeyParser.parse(storageKey),
+  storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey),
   version = if (hasVersionMap()) fromProto(versionMap) else null,
   _creationTimestamp = creationTimestampMs,
   _expirationTimestamp = expirationTimestampMs,

--- a/java/arcs/android/host/parcelables/ParcelableHandle.kt
+++ b/java/arcs/android/host/parcelables/ParcelableHandle.kt
@@ -16,7 +16,7 @@ import android.os.Parcelable
 import arcs.android.type.readType
 import arcs.android.type.writeType
 import arcs.core.data.Plan
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 
 /** [Parcelable] variant of [Plan.Handle]. */
 data class ParcelableHandle(
@@ -40,7 +40,7 @@ data class ParcelableHandle(
       }
       val annotations = parcel.readAnnotations()
       return ParcelableHandle(
-        Plan.Handle(StorageKeyParser.parse(storageKeyString), type, annotations)
+        Plan.Handle(StorageKeyManager.GLOBAL_INSTANCE.parse(storageKeyString), type, annotations)
       )
     }
 

--- a/java/arcs/android/storage/ParcelableStoreOptions.kt
+++ b/java/arcs/android/storage/ParcelableStoreOptions.kt
@@ -16,7 +16,7 @@ import android.os.Parcelable
 import arcs.android.crdt.ParcelableCrdtType
 import arcs.android.type.readType
 import arcs.android.type.writeType
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StoreOptions
 
 /** [Parcelable] variant for [StoreOptions]. */
@@ -36,7 +36,7 @@ data class ParcelableStoreOptions(
   companion object CREATOR : Parcelable.Creator<ParcelableStoreOptions> {
     override fun createFromParcel(parcel: Parcel): ParcelableStoreOptions {
       val crdtType = ParcelableCrdtType.values()[parcel.readInt()]
-      val storageKey = StorageKeyParser.parse(requireNotNull(parcel.readString()))
+      val storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(requireNotNull(parcel.readString()))
       val type = requireNotNull(parcel.readType()) { "Could not extract Type from Parcel" }
       val versionToken = parcel.readString()
 

--- a/java/arcs/android/storage/StoreOptionsProto.kt
+++ b/java/arcs/android/storage/StoreOptionsProto.kt
@@ -3,14 +3,14 @@ package arcs.android.storage
 import arcs.android.util.decodeProto
 import arcs.core.data.proto.decode
 import arcs.core.data.proto.encode
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StoreOptions
 import com.google.protobuf.StringValue
 
 /** Constructs a [StoreOptions] from the given [StoreOptionsProto]. */
 fun StoreOptionsProto.decode(): StoreOptions {
   return StoreOptions(
-    storageKey = StorageKeyParser.parse(storageKey),
+    storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey),
     type = type.decode(),
     versionToken = if (hasVersionToken()) versionToken.value else null
   )

--- a/java/arcs/android/storage/database/DatabaseImpl.kt
+++ b/java/arcs/android/storage/database/DatabaseImpl.kt
@@ -52,7 +52,7 @@ import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.database.Database
 import arcs.core.storage.database.DatabaseClient
 import arcs.core.storage.database.DatabaseData
@@ -435,7 +435,7 @@ class DatabaseImpl(
           } else {
             Reference(
               id = it.getString(6),
-              storageKey = StorageKeyParser.parse(it.getString(7)),
+              storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(it.getString(7)),
               version = it.getVersionMap(8),
               _creationTimestamp = it.getLong(9),
               _expirationTimestamp = it.getLong(10),
@@ -944,7 +944,7 @@ class DatabaseImpl(
       if (storageKey is InlineStorageKey) {
         throw UnsupportedOperationException(
           "Invalid attempt to delete inline storage key $storageKey." +
-          " Inline entities should not be removed using delete()."
+            " Inline entities should not be removed using delete()."
         )
       }
       counters.increment(DatabaseCounters.GET_STORAGE_KEY_ID)
@@ -1052,7 +1052,7 @@ class DatabaseImpl(
         arrayOf()
       ).forEach {
         val storageKeyId = it.getLong(0)
-        val storageKey = StorageKeyParser.parse(it.getString(1))
+        val storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(it.getString(1))
         val orphan = it.getNullableBoolean(2) ?: false
         val noRef = it.getBoolean(3)
         if (orphan && noRef) {
@@ -1379,7 +1379,7 @@ class DatabaseImpl(
         )
 
         (storageKeys union updatedContainersStorageKeys).map { storageKey ->
-          notifyClients(StorageKeyParser.parse(storageKey)) {
+          notifyClients(StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey)) {
             it.onDatabaseDelete(null)
           }
         }
@@ -1720,7 +1720,7 @@ class DatabaseImpl(
     ReferenceWithVersion(
       Reference(
         id = it.getString(0),
-        storageKey = StorageKeyParser.parse(it.getString(3)),
+        storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(it.getString(3)),
         version = it.getVersionMap(4),
         _creationTimestamp = it.getLong(1),
         _expirationTimestamp = it.getLong(2)

--- a/java/arcs/core/data/Recipe.kt
+++ b/java/arcs/core/data/Recipe.kt
@@ -11,7 +11,7 @@
 
 package arcs.core.data
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.type.Type
 
 /** Representation of recipe in an Arcs manifest. */
@@ -70,7 +70,7 @@ fun Recipe.toPlan() = Plan(
 /** Translates a [Recipe.Handle] into a [Plan.Handle] */
 fun Recipe.Handle.toPlanHandle() = Plan.Handle(
   type = type,
-  storageKey = StorageKeyParser.parse(requireNotNull(storageKey)),
+  storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(requireNotNull(storageKey)),
   annotations = annotations
 )
 
@@ -99,6 +99,6 @@ fun Recipe.Particle.HandleConnection.toPlanHandleConnection() = Plan.HandleConne
 
 /** Translates a [Recipe.Handle] into a [StorageKey] */
 fun Recipe.Handle.toStorageKey() = when {
-  storageKey != null -> StorageKeyParser.parse(storageKey)
+  storageKey != null -> StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey)
   else -> CreatableStorageKey(name)
 }

--- a/java/arcs/core/host/ArcHostContextParticle.kt
+++ b/java/arcs/core/host/ArcHostContextParticle.kt
@@ -25,7 +25,7 @@ import arcs.core.host.api.Particle
 import arcs.core.host.generated.AbstractArcHostContextParticle
 import arcs.core.host.generated.ArcHostContextPlan
 import arcs.core.storage.CapabilitiesResolver
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.type.Tag
 import arcs.core.type.Type
 import arcs.core.util.plus
@@ -198,7 +198,7 @@ class ArcHostContextParticle(
     }
     handle.connectionName to Plan.HandleConnection(
       Plan.Handle(
-        StorageKeyParser.parse(planHandle.storageKey),
+        StorageKeyManager.GLOBAL_INSTANCE.parse(planHandle.storageKey),
         // TODO(b/161818462): Properly serialize serialize Handle Type's schema.
         fromTag(arcId, particle, planHandle.type, handle.connectionName),
         emptyList()

--- a/java/arcs/core/storage/StorageKeyParser.kt
+++ b/java/arcs/core/storage/StorageKeyParser.kt
@@ -38,6 +38,11 @@ interface StorageKeyManager {
    * Remove all currently registered parsers, and replace them with the values provided.
    */
   fun reset(vararg initialSet: StorageKeyParser<*>)
+
+  companion object {
+    // TODO(b/174432505): Delete this property.
+    val GLOBAL_INSTANCE: StorageKeyManager = DefaultStorageKeyManager
+  }
 }
 
 /**
@@ -63,15 +68,10 @@ interface StorageKeyParser<T : StorageKey> {
    *   provided, so callers should verify this themselves before using the parser.
    */
   fun parse(rawKeyString: String): T
-
-  /**
-   * Expose the [DefaultStorageKeyManager] via the [StorageKeyParser] type. We can later
-   * change the usage points to refer to [DefaultStorageKeyManager] directly, and remove this.
-   */
-  companion object : StorageKeyManager by DefaultStorageKeyManager
 }
 
 /** A global default thread-safe implementation of [StorageKeyManager]. */
+// TODO(b/174432505): Make this a regular class, not a static singleton object.
 private object DefaultStorageKeyManager : StorageKeyManager {
   private val VALID_KEY_PATTERN = "^([\\w-]+)://(.*)$".toRegex()
   private var parsers = mutableMapOf<String, StorageKeyParser<*>>()

--- a/java/arcs/core/storage/StorageKeyUtils.kt
+++ b/java/arcs/core/storage/StorageKeyUtils.kt
@@ -40,8 +40,11 @@ class StorageKeyUtils {
   }
 }
 
-private fun String.unEmbed(): StorageKey =
-  StorageKeyParser.parse(replace("\\{\\{".toRegex(), "{").replace("\\}\\}".toRegex(), "}"))
+private fun String.unEmbed(): StorageKey {
+  return StorageKeyManager.GLOBAL_INSTANCE.parse(
+    replace("\\{\\{".toRegex(), "{").replace("\\}\\}".toRegex(), "}")
+  )
+}
 
 /* internal */ fun StorageKey.embed() =
   toString().replace("\\{".toRegex(), "{{").replace("\\}".toRegex(), "}}")

--- a/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
+++ b/java/arcs/core/storage/api/DriverAndKeyConfigurator.kt
@@ -16,6 +16,7 @@ import arcs.core.data.SchemaRegistry
 import arcs.core.storage.CapabilitiesResolver
 import arcs.core.storage.DefaultDriverFactory
 import arcs.core.storage.DriverProvider
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StorageKeyParser
 import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.driver.DatabaseDriverProvider
@@ -62,7 +63,7 @@ object DriverAndKeyConfigurator {
    */
   fun configureKeyParsersAndFactories() {
     // Start fresh.
-    StorageKeyParser.reset(
+    StorageKeyManager.GLOBAL_INSTANCE.reset(
       VolatileStorageKey,
       RamDiskStorageKey,
       DatabaseStorageKey.Persistent,

--- a/java/arcs/core/storage/testutil/DummyStorageKey.kt
+++ b/java/arcs/core/storage/testutil/DummyStorageKey.kt
@@ -12,11 +12,14 @@
 package arcs.core.storage.testutil
 
 import arcs.core.storage.StorageKey
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StorageKeyParser
 
 /** Fake [StorageKey] implementation for use in unit tests. */
 class DummyStorageKey(val key: String) : StorageKey(protocol) {
-  init { StorageKeyParser.addParser(DummyStorageKey) }
+  init {
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DummyStorageKey)
+  }
 
   override fun toKeyString(): String = key
 

--- a/java/arcs/sdk/android/labs/host/ArcHostHelper.kt
+++ b/java/arcs/sdk/android/labs/host/ArcHostHelper.kt
@@ -33,7 +33,7 @@ import arcs.core.host.ArcHostException
 import arcs.core.host.ArcState
 import arcs.core.host.ArcStateChangeRegistration
 import arcs.core.host.ParticleIdentifier
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.util.TaggedLog
 import kotlin.reflect.KClass
 import kotlinx.coroutines.CoroutineName
@@ -107,7 +107,7 @@ class ArcHostHelper(
 
     arcHost.onResurrected(
       targetId,
-      notifiers.map(StorageKeyParser.Companion::parse) ?: emptyList()
+      notifiers.map(StorageKeyManager.GLOBAL_INSTANCE::parse)
     )
   }
 

--- a/java/arcs/sdk/storage/StorageKey.kt
+++ b/java/arcs/sdk/storage/StorageKey.kt
@@ -11,7 +11,7 @@
 
 package arcs.sdk.storage
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 
 /**
  * Represents a location in Arcs' storage system where an [Entity], [Collection], [Singleton], or a
@@ -21,5 +21,7 @@ import arcs.core.storage.StorageKeyParser
 inline class StorageKey(val raw: String) {
   /** Converts this SDK [StorageKey] into a core [arcs.core.storage.StorageKey]. */
   /* internal */
-  fun toCoreStorageKey(): arcs.core.storage.StorageKey = StorageKeyParser.parse(raw)
+  fun toCoreStorageKey(): arcs.core.storage.StorageKey {
+    return StorageKeyManager.GLOBAL_INSTANCE.parse(raw)
+  }
 }

--- a/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectionRequestTest.kt
@@ -18,7 +18,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import arcs.android.common.resurrection.ResurrectionRequest.UnregisterRequest
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.testutil.fail
 import com.google.common.truth.Truth.assertThat
@@ -34,7 +34,7 @@ class ResurrectionRequestTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(RamDiskStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
+++ b/javatests/arcs/android/common/resurrection/ResurrectorServiceTest.kt
@@ -19,7 +19,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.ACTION_RESURRECT
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_TARGET_ID
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_RESURRECT_NOTIFIER
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import java.io.PrintWriter
@@ -44,7 +44,7 @@ class ResurrectorServiceTest {
 
   @Before
   fun setUp() {
-    StorageKeyParser.reset(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(RamDiskStorageKey)
     context = ApplicationProvider.getApplicationContext<Application>()
     resurrectionRequest = ResurrectionRequest.createDefault(context, storageKeys, "test")
     resurrectionRequestIntent = Intent(context, ResurrectorServiceImpl::class.java)
@@ -83,7 +83,7 @@ class ResurrectorServiceTest {
                       ]
                     ]
                     
-                """.trimIndent()
+        """.trimIndent()
       )
   }
 

--- a/javatests/arcs/android/crdt/ReferenceProtoTest.kt
+++ b/javatests/arcs/android/crdt/ReferenceProtoTest.kt
@@ -17,7 +17,7 @@ import arcs.android.util.writeProto
 import arcs.core.crdt.VersionMap
 import arcs.core.data.RawEntity
 import arcs.core.storage.Reference
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 class ReferenceProtoTest {
   @Before
   fun setUp() {
-    StorageKeyParser.addParser(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(RamDiskStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/host/ArcHostHelperTest.kt
+++ b/javatests/arcs/android/host/ArcHostHelperTest.kt
@@ -34,7 +34,7 @@ import arcs.core.host.ArcStateChangeCallback
 import arcs.core.host.ArcStateChangeRegistration
 import arcs.core.host.ParticleIdentifier
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.storage.testutil.DummyStorageKey
 import arcs.core.util.guardedBy
@@ -171,7 +171,7 @@ class ArcHostHelperTest {
     service = Robolectric.setupService(TestAndroidArcHostService::class.java)
     arcHost = TestArcHost(context)
     helper = ArcHostHelper(service, arcHost)
-    StorageKeyParser.addParser(DummyStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DummyStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableHandleConnectionTest.kt
@@ -24,7 +24,7 @@ import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
 import arcs.core.data.expression.asExpr
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
 import java.lang.IllegalArgumentException
@@ -47,7 +47,7 @@ class ParcelableHandleConnectionTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(VolatileStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(VolatileStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/host/parcelables/ParcelableHandleTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableHandleTest.kt
@@ -21,7 +21,7 @@ import arcs.core.data.Plan.Handle
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
@@ -41,7 +41,7 @@ class ParcelableHandleTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(VolatileStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(VolatileStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/host/parcelables/ParcelableParticleTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelableParticleTest.kt
@@ -21,7 +21,7 @@ import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.keys.VolatileStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith
 class ParcelableParticleTest {
   @Before
   fun setup() {
-    StorageKeyParser.reset(
+    StorageKeyManager.GLOBAL_INSTANCE.reset(
       ReferenceModeStorageKey,
       RamDiskStorageKey,
       VolatileStorageKey

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanPartitionTest.kt
@@ -21,7 +21,7 @@ import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
@@ -34,7 +34,7 @@ class ParcelablePlanPartitionTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(VolatileStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(VolatileStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/host/parcelables/ParcelablePlanTest.kt
+++ b/javatests/arcs/android/host/parcelables/ParcelablePlanTest.kt
@@ -22,7 +22,7 @@ import arcs.core.data.Plan
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.VolatileStorageKey
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
@@ -44,7 +44,7 @@ class ParcelablePlanTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(VolatileStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(VolatileStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
+++ b/javatests/arcs/android/storage/ParcelableStoreOptionsTest.kt
@@ -15,7 +15,7 @@ import android.os.Parcel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import arcs.android.crdt.ParcelableCrdtType
 import arcs.core.data.CountType
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.keys.RamDiskStorageKey
 import arcs.core.storage.referencemode.ReferenceModeStorageKey
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith
 class ParcelableStoreOptionsTest {
   @Before
   fun setup() {
-    StorageKeyParser.reset(
+    StorageKeyManager.GLOBAL_INSTANCE.reset(
       ReferenceModeStorageKey,
       RamDiskStorageKey
     )

--- a/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
+++ b/javatests/arcs/android/storage/ReferenceModeStoreDatabaseImplIntegrationTest.kt
@@ -33,7 +33,7 @@ import arcs.core.storage.MuxedProxyMessage
 import arcs.core.storage.ProxyMessage
 import arcs.core.storage.Reference
 import arcs.core.storage.ReferenceModeStore
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.database.ReferenceWithVersion
@@ -101,7 +101,7 @@ class ReferenceModeStoreDatabaseImplIntegrationTest {
   fun setUp() = runBlockingTest {
     SchemaRegistry.register(inlineSchema)
     databaseFactory = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
-    StorageKeyParser.reset(DatabaseStorageKey.Persistent)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(DatabaseStorageKey.Persistent)
     DatabaseDriverProvider.configure(databaseFactory) {
       when (it) {
         hash -> schema

--- a/javatests/arcs/android/storage/StoreOptionsProtoTest.kt
+++ b/javatests/arcs/android/storage/StoreOptionsProtoTest.kt
@@ -12,7 +12,7 @@
 package arcs.android.storage
 
 import arcs.core.data.TypeVariable
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.testutil.DummyStorageKey
 import com.google.common.truth.Truth.assertThat
@@ -25,7 +25,7 @@ import org.junit.runners.JUnit4
 class StoreOptionsProtoTest {
   @Before
   fun setUp() {
-    StorageKeyParser.addParser(DummyStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DummyStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
+++ b/javatests/arcs/android/storage/database/AndroidSqliteDatabaseManagerTest.kt
@@ -20,7 +20,7 @@ import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.Reference
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.database.DatabaseManager
 import arcs.core.storage.testutil.DummyStorageKey
@@ -61,7 +61,7 @@ class AndroidSqliteDatabaseManagerTest {
   fun setUp() {
     manager = AndroidSqliteDatabaseManager(ApplicationProvider.getApplicationContext())
     random = Random(System.currentTimeMillis())
-    StorageKeyParser.addParser(DummyStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DummyStorageKey)
   }
 
   @Test

--- a/javatests/arcs/android/storage/database/DatabaseImplTest.kt
+++ b/javatests/arcs/android/storage/database/DatabaseImplTest.kt
@@ -32,7 +32,7 @@ import arcs.core.data.util.ReferencablePrimitive
 import arcs.core.data.util.toReferencable
 import arcs.core.storage.Reference
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.database.DatabaseClient
 import arcs.core.storage.database.DatabaseData
 import arcs.core.storage.database.ReferenceWithVersion
@@ -66,14 +66,14 @@ class DatabaseImplTest {
   fun setUp() {
     database = DatabaseImpl(ApplicationProvider.getApplicationContext(), "test.sqlite3")
     db = database.writableDatabase
-    StorageKeyParser.addParser(DummyStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DummyStorageKey)
   }
 
   @After
   fun tearDown() {
     database.reset()
     database.close()
-    StorageKeyParser.reset()
+    StorageKeyManager.GLOBAL_INSTANCE.reset()
     SchemaRegistry.clearForTest()
   }
 

--- a/javatests/arcs/android/storage/service/StorageServiceNgImplTest.kt
+++ b/javatests/arcs/android/storage/service/StorageServiceNgImplTest.kt
@@ -19,7 +19,7 @@ import arcs.android.storage.toParcelByteArray
 import arcs.core.data.CountType
 import arcs.core.storage.FixedDriverFactory
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.StoreOptions
 import arcs.core.storage.UntypedProxyMessage
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -58,7 +58,7 @@ class StorageServiceNgImplTest {
   fun setUp() {
     BuildFlags.STORAGE_SERVICE_NG = true
 
-    StorageKeyParser.addParser(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(RamDiskStorageKey)
     storageService = StorageServiceNgImpl(
       scope,
       driverFactory,

--- a/javatests/arcs/core/data/CreatableStorageKeyTest.kt
+++ b/javatests/arcs/core/data/CreatableStorageKeyTest.kt
@@ -11,7 +11,7 @@
 
 package arcs.core.data
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
@@ -34,7 +34,7 @@ class CreatableStorageKeyTest {
   @Test
   fun parsesFromString() {
     val name = "abc"
-    val storageKey = StorageKeyParser.parse("create://$name")
+    val storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse("create://$name")
     assertThat(storageKey).isInstanceOf(CreatableStorageKey::class.java)
     storageKey as CreatableStorageKey
     assertThat(storageKey.nameFromManifest).isEqualTo(name)
@@ -45,7 +45,7 @@ class CreatableStorageKeyTest {
     val name = "recipePerson"
 
     val key = CreatableStorageKey(name)
-    val parsedKey = StorageKeyParser.parse(key.toString())
+    val parsedKey = StorageKeyManager.GLOBAL_INSTANCE.parse(key.toString())
     assertThat(parsedKey).isEqualTo(key)
   }
 }

--- a/javatests/arcs/core/data/RecipeTest.kt
+++ b/javatests/arcs/core/data/RecipeTest.kt
@@ -13,7 +13,7 @@ package arcs.core.data
 import arcs.core.data.Recipe.Handle.Fate
 import arcs.core.data.expression.EvaluatorParticle
 import arcs.core.data.expression.asExpr
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.api.DriverAndKeyConfigurator
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
@@ -92,7 +92,7 @@ class RecipeTest {
         storageKey = storageKey
       ).toStorageKey()
     ).isEqualTo(
-      StorageKeyParser.parse(storageKey)
+      StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey)
     )
   }
 
@@ -112,7 +112,7 @@ class RecipeTest {
         )
       ).toStorageKey()
     ).isEqualTo(
-      StorageKeyParser.parse(storageKey)
+      StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey)
     )
   }
 
@@ -229,7 +229,7 @@ class RecipeTest {
       ).toPlanHandle()
     ).isEqualTo(
       Plan.Handle(
-        storageKey = StorageKeyParser.parse(storageKey),
+        storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(storageKey),
         type = personCollectionType,
         annotations = emptyList()
       )
@@ -286,7 +286,6 @@ class RecipeTest {
    */
   @Test
   fun recipeToPlan_fullExample() {
-
     val peopleStorageKey =
       "reference-mode://{db://abcd@arcs/Person}{db://abcd@arcs//handle/people}"
     val peopleHandle = Recipe.Handle(
@@ -322,7 +321,7 @@ class RecipeTest {
     )
 
     val peoplePlanHandle = Plan.Handle(
-      storageKey = StorageKeyParser.parse(peopleStorageKey),
+      storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse(peopleStorageKey),
       type = personCollectionType,
       annotations = emptyList()
     )

--- a/javatests/arcs/core/storage/StorageKeyParserTest.kt
+++ b/javatests/arcs/core/storage/StorageKeyParserTest.kt
@@ -29,21 +29,21 @@ import org.junit.runners.JUnit4
 class StorageKeyParserTest {
   @Test
   fun addParser_registersParser() {
-    StorageKeyParser.reset(MyStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(MyStorageKey)
 
-    val parsed = StorageKeyParser.parse("myParser://foo/bar")
+    val parsed = StorageKeyManager.GLOBAL_INSTANCE.parse("myParser://foo/bar")
     assertThat(parsed).isInstanceOf(MyStorageKey::class.java)
     assertThat((parsed as MyStorageKey).components).containsExactly("foo", "bar")
   }
 
   @Test
   fun reset_resetsToDefaults() {
-    StorageKeyParser.addParser(MyStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(MyStorageKey)
 
-    StorageKeyParser.reset()
+    StorageKeyManager.GLOBAL_INSTANCE.reset()
     var thrownError: Exception? = null
     try {
-      StorageKeyParser.parse("myParser://foo")
+      StorageKeyManager.GLOBAL_INSTANCE.parse("myParser://foo")
     } catch (e: Exception) {
       thrownError = e
     }
@@ -63,7 +63,7 @@ class StorageKeyParserTest {
     }
     launch(threadTwo) {
       (1..1000).forEach {
-        StorageKeyParser.parse("${RamDiskStorageKey.protocol}://someKey")
+        StorageKeyManager.GLOBAL_INSTANCE.parse("${RamDiskStorageKey.protocol}://someKey")
       }
     }
   }

--- a/javatests/arcs/core/storage/StorageKeyUtilsTest.kt
+++ b/javatests/arcs/core/storage/StorageKeyUtilsTest.kt
@@ -25,7 +25,7 @@ class StorageKeyUtilsTest {
     e = assertFailsWith<IllegalArgumentException> { StorageKeyUtils.extractKeysFromString("}bar}") }
     assertThat(e).hasMessageThat().contains("missing opening curly brace")
 
-    StorageKeyParser.reset(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(RamDiskStorageKey)
     val key1 = RamDiskStorageKey("key1")
     e = assertFailsWith<IllegalArgumentException> {
       StorageKeyUtils.extractKeysFromString("{${key1.embed()}}aaa")
@@ -60,7 +60,7 @@ class StorageKeyUtilsTest {
 
   @Test
   fun extractKeysFromString_singleKey_success() {
-    StorageKeyParser.reset(VolatileStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(VolatileStorageKey)
     val key1 = VolatileStorageKey(ArcId.newForTest("foo"), "key1")
     val rawString = "{${key1.embed()}}"
 
@@ -69,7 +69,7 @@ class StorageKeyUtilsTest {
 
   @Test
   fun extractKeysFromString_ramdisk_success() {
-    StorageKeyParser.reset(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(RamDiskStorageKey)
     val key1 = RamDiskStorageKey("key1")
     val key2 = RamDiskStorageKey("key2")
     val rawString = "{${key1.embed()}}{${key2.embed()}}"
@@ -79,7 +79,11 @@ class StorageKeyUtilsTest {
 
   @Test
   fun extractKeysFromString_reference_success() {
-    StorageKeyParser.reset(VolatileStorageKey, RamDiskStorageKey, ReferenceModeStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(
+      VolatileStorageKey,
+      RamDiskStorageKey,
+      ReferenceModeStorageKey
+    )
     val arcId = ArcId.newForTest("foo")
     val key1 = ReferenceModeStorageKey(
       VolatileStorageKey(arcId, "backing1"),

--- a/javatests/arcs/core/storage/keys/DatabaseStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/DatabaseStorageKeyTest.kt
@@ -11,7 +11,7 @@
 
 package arcs.core.storage.keys
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.testutil.fail
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
@@ -24,8 +24,8 @@ import org.junit.runners.JUnit4
 class DatabaseStorageKeyTest {
   @Before
   fun setUp() {
-    StorageKeyParser.addParser(DatabaseStorageKey.Memory)
-    StorageKeyParser.addParser(DatabaseStorageKey.Persistent)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DatabaseStorageKey.Memory)
+    StorageKeyManager.GLOBAL_INSTANCE.addParser(DatabaseStorageKey.Persistent)
   }
 
   @Test
@@ -173,7 +173,7 @@ class DatabaseStorageKeyTest {
   @Test
   fun persistentParse_viaRegistration_parsesCorrectly() {
     val keyString = "${DatabaseStorageKey.Persistent.protocol}://1234a@myDb/foo"
-    val key = StorageKeyParser.parse(keyString) as? DatabaseStorageKey.Persistent
+    val key = StorageKeyManager.GLOBAL_INSTANCE.parse(keyString) as? DatabaseStorageKey.Persistent
       ?: fail("Expected a DatabaseStorageKey")
     assertThat(key.dbName).isEqualTo("myDb")
     assertThat(key.entitySchemaHash).isEqualTo("1234a")
@@ -183,7 +183,7 @@ class DatabaseStorageKeyTest {
   @Test
   fun memoryParse_viaRegistration_parsesCorrectly() {
     val keyString = "${DatabaseStorageKey.Memory.protocol}://1234a@myDb/foo"
-    val key = StorageKeyParser.parse(keyString) as? DatabaseStorageKey.Memory
+    val key = StorageKeyManager.GLOBAL_INSTANCE.parse(keyString) as? DatabaseStorageKey.Memory
       ?: fail("Expected a DatabaseStorageKey")
     assertThat(key.dbName).isEqualTo("myDb")
     assertThat(key.entitySchemaHash).isEqualTo("1234a")

--- a/javatests/arcs/core/storage/keys/ForeignStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/ForeignStorageKeyTest.kt
@@ -13,7 +13,7 @@ package arcs.core.storage.keys
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -25,14 +25,14 @@ import org.junit.runners.JUnit4
 class ForeignStorageKeyTest {
   @Before
   fun setup() {
-    StorageKeyParser.reset(ForeignStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(ForeignStorageKey)
   }
 
   @Test
   fun toString_rendersCorrectly() {
     val key = ForeignStorageKey("foo")
     assertThat(key.toString()).isEqualTo("foreign://foo")
-    assertThat(StorageKeyParser.parse(key.toString())).isEqualTo(key)
+    assertThat(StorageKeyManager.GLOBAL_INSTANCE.parse(key.toString())).isEqualTo(key)
   }
 
   @Test

--- a/javatests/arcs/core/storage/keys/JoinStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/JoinStorageKeyTest.kt
@@ -10,7 +10,7 @@
  */
 package arcs.core.storage.keys
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.embed
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
@@ -24,7 +24,7 @@ import org.junit.runners.JUnit4
 class JoinStorageKeyTest {
   @Before
   fun setup() {
-    StorageKeyParser.reset(
+    StorageKeyManager.GLOBAL_INSTANCE.reset(
       JoinStorageKey,
       RamDiskStorageKey
     )
@@ -62,7 +62,9 @@ class JoinStorageKeyTest {
     val key1Reference = JoinStorageKey(listOf(key1, key2))
     val key2Reference = JoinStorageKey(listOf(key2, key1))
 
-    assertThat(StorageKeyParser.parse(key1Reference.toString())).isEqualTo(key1Reference)
+    assertThat(
+      StorageKeyManager.GLOBAL_INSTANCE.parse(key1Reference.toString())
+    ).isEqualTo(key1Reference)
     val key1ReferenceKeyString = "2/{ramdisk://key1}{ramdisk://key2}"
     assertThat(key1Reference.toKeyString()).isEqualTo(key1ReferenceKeyString)
     assertThat(key1Reference.toString()).isEqualTo("join://$key1ReferenceKeyString")
@@ -80,7 +82,7 @@ class JoinStorageKeyTest {
     val key2Reference = JoinStorageKey(listOf(key2, key1))
     val parent = JoinStorageKey(listOf(key1Reference, key2Reference))
 
-    assertThat(StorageKeyParser.parse(parent.toString())).isEqualTo(parent)
+    assertThat(StorageKeyManager.GLOBAL_INSTANCE.parse(parent.toString())).isEqualTo(parent)
     val parentKeyString = "2/{join://2/{{ramdisk://key1}}{{ramdisk://key2}}}" +
       "{join://2/{{ramdisk://key2}}{{ramdisk://key1}}}"
     assertThat(parent.toKeyString()).isEqualTo(parentKeyString)

--- a/javatests/arcs/core/storage/keys/RamDiskStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/RamDiskStorageKeyTest.kt
@@ -10,7 +10,7 @@
  */
 package arcs.core.storage.keys
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -23,7 +23,7 @@ class RamDiskStorageKeyTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(RamDiskStorageKey)
   }
 
   @Test
@@ -42,7 +42,7 @@ class RamDiskStorageKeyTest {
   @Test
   fun registersSelf_withStorageKeyParser() {
     val key = RamDiskStorageKey("foo")
-    assertThat(StorageKeyParser.parse(key.toString())).isEqualTo(key)
+    assertThat(StorageKeyManager.GLOBAL_INSTANCE.parse(key.toString())).isEqualTo(key)
   }
 
   @Test

--- a/javatests/arcs/core/storage/keys/VolatileStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/keys/VolatileStorageKeyTest.kt
@@ -12,9 +12,8 @@ package arcs.core.storage.keys
 
 import arcs.core.common.ArcId
 import arcs.core.common.toArcId
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import com.google.common.truth.Truth.assertThat
-import java.lang.IllegalArgumentException
 import kotlin.test.assertFailsWith
 import org.junit.Before
 import org.junit.Test
@@ -26,7 +25,7 @@ import org.junit.runners.JUnit4
 class VolatileStorageKeyTest {
   @Before
   fun setup() {
-    StorageKeyParser.reset(VolatileStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(VolatileStorageKey)
   }
 
   @Test
@@ -49,7 +48,7 @@ class VolatileStorageKeyTest {
   fun registersSelf_withStorageKeyParser() {
     val arcId = ArcId.newForTest("arc")
     val key = VolatileStorageKey(arcId, "foo")
-    assertThat(StorageKeyParser.parse(key.toString())).isEqualTo(key)
+    assertThat(StorageKeyManager.GLOBAL_INSTANCE.parse(key.toString())).isEqualTo(key)
   }
 
   @Test

--- a/javatests/arcs/core/storage/referencemode/ReferenceModeStorageKeyTest.kt
+++ b/javatests/arcs/core/storage/referencemode/ReferenceModeStorageKeyTest.kt
@@ -10,7 +10,7 @@
  */
 package arcs.core.storage.referencemode
 
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.embed
 import arcs.core.storage.keys.DatabaseStorageKey
 import arcs.core.storage.keys.RamDiskStorageKey
@@ -27,7 +27,7 @@ class ReferenceModeStorageKeyTest {
 
   @Before
   fun setup() {
-    StorageKeyParser.reset(
+    StorageKeyManager.GLOBAL_INSTANCE.reset(
       ReferenceModeStorageKey,
       RamDiskStorageKey
     )
@@ -79,9 +79,11 @@ class ReferenceModeStorageKeyTest {
     val parent = ReferenceModeStorageKey(backingReference, directReference)
 
     // Check the simple case.
-    assertThat(StorageKeyParser.parse(backingReference.toString())).isEqualTo(backingReference)
+    assertThat(
+      StorageKeyManager.GLOBAL_INSTANCE.parse(backingReference.toString())
+    ).isEqualTo(backingReference)
 
     // Check the embedded/nested case.
-    assertThat(StorageKeyParser.parse(parent.toString())).isEqualTo(parent)
+    assertThat(StorageKeyManager.GLOBAL_INSTANCE.parse(parent.toString())).isEqualTo(parent)
   }
 }

--- a/javatests/arcs/sdk/android/storage/ResurrectionHelperTest.kt
+++ b/javatests/arcs/sdk/android/storage/ResurrectionHelperTest.kt
@@ -23,7 +23,7 @@ import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGI
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_PACKAGE_NAME
 import arcs.android.common.resurrection.ResurrectionRequest.Companion.EXTRA_REGISTRATION_TARGET_ID
 import arcs.core.storage.StorageKey
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.storage.keys.RamDiskStorageKey
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
@@ -41,7 +41,7 @@ class ResurrectionHelperTest {
 
   @Before
   fun setUp() {
-    StorageKeyParser.reset(RamDiskStorageKey)
+    StorageKeyManager.GLOBAL_INSTANCE.reset(RamDiskStorageKey)
     service = Robolectric.setupService(ResurrectionHelperDummyService::class.java)
     context = InstrumentationRegistry.getInstrumentation().targetContext
 

--- a/javatests/arcs/tools/PlanGeneratorTest.kt
+++ b/javatests/arcs/tools/PlanGeneratorTest.kt
@@ -44,7 +44,7 @@ class PlanGeneratorTest {
     ).isEqualTo(
       """
             arcs.core.data.Plan.Handle(
-                storageKey = arcs.core.storage.StorageKeyParser.parse("AKey"),
+                storageKey = arcs.core.storage.StorageKeyManager.GLOBAL_INSTANCE.parse("AKey"),
                 type = arcs.core.data.EntityType(arcs.core.data.Schema(
                     names = setOf(arcs.core.data.SchemaName("Foo")),
                     fields = arcs.core.data.SchemaFields(
@@ -70,7 +70,7 @@ class PlanGeneratorTest {
           storageKey = "AKey"
         )
       ).toString().normalize()
-    ).contains("""storageKey=arcs.core.storage.StorageKeyParser.parse("AKey")""")
+    ).contains("""storageKey=arcs.core.storage.StorageKeyManager.GLOBAL_INSTANCE.parse("AKey")""")
 
     assertThat(
       buildHandleBlock(
@@ -92,11 +92,11 @@ class PlanGeneratorTest {
       """
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(
-                    names = setOf(arcs.core.data.SchemaName("Foo")), 
+                    names = setOf(arcs.core.data.SchemaName("Foo")),
                     fields = arcs.core.data.SchemaFields(
-                        singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                        singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                         collections = emptyMap()
-                    ), 
+                    ),
                     hash = "fooHash"
                 )
             )
@@ -113,11 +113,11 @@ class PlanGeneratorTest {
             arcs.core.data.SingletonType(
                 arcs.core.data.EntityType(
                     arcs.core.data.Schema(
-                        names = setOf(arcs.core.data.SchemaName("Foo")), 
+                        names = setOf(arcs.core.data.SchemaName("Foo")),
                         fields = arcs.core.data.SchemaFields(
-                            singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                            singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                             collections = emptyMap()
-                        ), 
+                        ),
                         hash = "fooHash"
                     )
                 )
@@ -135,11 +135,11 @@ class PlanGeneratorTest {
             arcs.core.data.CollectionType(
                 arcs.core.data.EntityType(
                     arcs.core.data.Schema(
-                        names = setOf(arcs.core.data.SchemaName("Foo")), 
+                        names = setOf(arcs.core.data.SchemaName("Foo")),
                         fields = arcs.core.data.SchemaFields(
-                            singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                            singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                             collections = emptyMap()
-                        ), 
+                        ),
                         hash = "fooHash"
                     )
                 )
@@ -157,11 +157,11 @@ class PlanGeneratorTest {
             arcs.core.data.ReferenceType(
                 arcs.core.data.EntityType(
                     arcs.core.data.Schema(
-                        names = setOf(arcs.core.data.SchemaName("Foo")), 
+                        names = setOf(arcs.core.data.SchemaName("Foo")),
                         fields = arcs.core.data.SchemaFields(
-                            singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                            singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                             collections = emptyMap()
-                        ), 
+                        ),
                         hash = "fooHash"
                     )
                 )
@@ -183,11 +183,11 @@ class PlanGeneratorTest {
                     arcs.core.data.SingletonType(
                         arcs.core.data.EntityType(
                             arcs.core.data.Schema(
-                                names = setOf(arcs.core.data.SchemaName("Foo")), 
+                                names = setOf(arcs.core.data.SchemaName("Foo")),
                                 fields = arcs.core.data.SchemaFields(
-                                    singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                                    singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                                     collections = emptyMap()
-                                ), 
+                                ),
                                 hash = "fooHash"
                             )
                         )
@@ -195,11 +195,11 @@ class PlanGeneratorTest {
                     arcs.core.data.SingletonType(
                         arcs.core.data.EntityType(
                             arcs.core.data.Schema(
-                                names = setOf(arcs.core.data.SchemaName("Foo")), 
+                                names = setOf(arcs.core.data.SchemaName("Foo")),
                                 fields = arcs.core.data.SchemaFields(
-                                    singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                                    singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                                     collections = emptyMap()
-                                ), 
+                                ),
                                 hash = "fooHash"
                             )
                         )
@@ -223,17 +223,17 @@ class PlanGeneratorTest {
                 arcs.core.data.SingletonType(
                     arcs.core.data.EntityType(
                         arcs.core.data.Schema(
-                            names = setOf(arcs.core.data.SchemaName("Foo")), 
+                            names = setOf(arcs.core.data.SchemaName("Foo")),
                             fields = arcs.core.data.SchemaFields(
-                                singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                                singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                                 collections = emptyMap()
-                            ), 
+                            ),
                             hash = "fooHash"
                         )
                     )
                 ),
                 false
-            )    
+            )
             """.normalize()
     )
   }
@@ -258,17 +258,17 @@ class PlanGeneratorTest {
                 arcs.core.data.SingletonType(
                     arcs.core.data.EntityType(
                         arcs.core.data.Schema(
-                            names = setOf(arcs.core.data.SchemaName("Foo")), 
+                            names = setOf(arcs.core.data.SchemaName("Foo")),
                             fields = arcs.core.data.SchemaFields(
-                                singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                                singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                                 collections = emptyMap()
-                            ), 
+                            ),
                             hash = "fooHash"
                         )
                     )
                 ),
                 true
-            )    
+            )
             """.normalize()
     )
   }
@@ -293,11 +293,11 @@ class PlanGeneratorTest {
                         arcs.core.data.ReferenceType(
                             arcs.core.data.EntityType(
                                 arcs.core.data.Schema(
-                                    names = setOf(arcs.core.data.SchemaName("Foo")), 
+                                    names = setOf(arcs.core.data.SchemaName("Foo")),
                                     fields = arcs.core.data.SchemaFields(
-                                        singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                                        singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                                         collections = emptyMap()
-                                    ), 
+                                    ),
                                     hash = "fooHash"
                                 )
                             )
@@ -308,11 +308,11 @@ class PlanGeneratorTest {
                         arcs.core.data.SingletonType(
                             arcs.core.data.EntityType(
                                 arcs.core.data.Schema(
-                                    names = setOf(arcs.core.data.SchemaName("Foo")), 
+                                    names = setOf(arcs.core.data.SchemaName("Foo")),
                                     fields = arcs.core.data.SchemaFields(
-                                        singletons = mapOf("sku" to arcs.core.data.FieldType.Int), 
+                                        singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                                         collections = emptyMap()
-                                    ), 
+                                    ),
                                     hash = "fooHash"
                                 )
                             )
@@ -350,7 +350,7 @@ class PlanGeneratorTest {
                     singletons = emptyMap(),
                     collections = emptyMap()
                 )
-            """.trimIndent()
+        """.trimIndent()
       )
   }
 
@@ -367,7 +367,7 @@ class PlanGeneratorTest {
                     singletons = mapOf("sku" to arcs.core.data.FieldType.Int),
                     collections = emptyMap()
                 )
-            """.trimIndent()
+        """.trimIndent()
       )
   }
 
@@ -384,7 +384,7 @@ class PlanGeneratorTest {
                     singletons = emptyMap(),
                     collections = mapOf("bananas" to arcs.core.data.FieldType.Text)
                 )
-            """.trimIndent()
+        """.trimIndent()
       )
   }
 

--- a/src/tools/plan-generator.ts
+++ b/src/tools/plan-generator.ts
@@ -136,13 +136,13 @@ export class PlanGenerator {
   /** Generates a Kotlin `StorageKey` from a recipe Handle. */
   async createStorageKey(handle: Handle): Promise<string> {
     if (handle.storageKey) {
-      return ktUtils.applyFun('StorageKeyParser.parse', [quote(handle.storageKey.toString())]);
+      return ktUtils.applyFun('StorageKeyManager.GLOBAL_INSTANCE.parse', [quote(handle.storageKey.toString())]);
     }
     if (handle.fate === 'join') {
       // TODO(piotrs): Implement JoinStorageKey in TypeScript.
       const components = handle.joinedHandles.map(h => h.storageKey);
       const joinSk = `join://${components.length}/${components.map(sk => `{${sk.embedKey()}}`).join('/')}`;
-      return ktUtils.applyFun('StorageKeyParser.parse', [quote(joinSk)]);
+      return ktUtils.applyFun('StorageKeyManager.GLOBAL_INSTANCE.parse', [quote(joinSk)]);
     }
     throw new PlanGeneratorError(`Problematic handle '${handle.id}': Only 'create' Handles can have null 'StorageKey's.`);
   }
@@ -163,7 +163,7 @@ ${tryImport('arcs.core.data.expression.*', this.namespace)}
 ${tryImport('arcs.core.data.expression.Expression.*', this.namespace)}
 ${tryImport('arcs.core.data.expression.Expression.BinaryOp.*', this.namespace)}
 ${tryImport('arcs.core.data.Plan.*', this.namespace)}
-${tryImport('arcs.core.storage.StorageKeyParser', this.namespace)}
+${tryImport('arcs.core.storage.StorageKeyManager', this.namespace)}
 ${tryImport('arcs.core.util.ArcsInstant', this.namespace)}
 ${tryImport('arcs.core.util.ArcsDuration', this.namespace)}
 ${tryImport('arcs.core.util.BigInt', this.namespace)}

--- a/src/tools/tests/codegen-unit-tests-runner-test.ts
+++ b/src/tools/tests/codegen-unit-tests-runner-test.ts
@@ -40,7 +40,7 @@ function extractTo2LayerDict(regexp: RegExp, results: string[]): Dictionary<Dict
   return dict;
 }
 
-const handleStorageKeyRE = /([^_ ]+)_([^ ]+) by lazy {\n *Handle\(\n *StorageKeyParser.parse\("([^"]*")\)/;
+const handleStorageKeyRE = /([^_ ]+)_([^ ]+) by lazy {\n *Handle\(\n *StorageKeyManager.GLOBAL_INSTANCE.parse\(\n *"([^"]*")\n/;
 const handleForParticleRE = /"([^\n"]+)".*\n.*\n.*\n *"([^"]+)" to HandleConnection\(\n *([^,]+),/;
 
 /**

--- a/src/tools/tests/goldens/WriterReaderExample.kt
+++ b/src/tools/tests/goldens/WriterReaderExample.kt
@@ -12,14 +12,14 @@ import arcs.core.data.expression.*
 import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt
 
 val IngestionOnly_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse(
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
             "reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"
         ),
         arcs.core.data.SingletonType(
@@ -67,7 +67,7 @@ val IngestionOnlyPlan by lazy {
 }
 val Ingestion_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse(
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
             "reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingArcId/handle/my-handle-id}"
         ),
         arcs.core.data.SingletonType(
@@ -130,7 +130,7 @@ val IngestionPlan by lazy {
 }
 val Consumption_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse(
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
             "reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingArcId/handle/my-handle-id}"
         ),
         arcs.core.data.SingletonType(
@@ -172,7 +172,7 @@ val ConsumptionPlan by lazy {
 }
 val EphemeralWriting_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse("create://my-ephemeral-handle-id"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse("create://my-ephemeral-handle-id"),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(
@@ -218,7 +218,7 @@ val EphemeralWritingPlan by lazy {
 }
 val EphemeralReading_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse(
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
             "reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"
         ),
         arcs.core.data.SingletonType(
@@ -260,7 +260,7 @@ val EphemeralReadingPlan by lazy {
 }
 val ReferencesRecipe_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse(
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
             "db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:referencesArcId/handle/my-refs-id"
         ),
         arcs.core.data.CollectionType(
@@ -287,7 +287,7 @@ val ReferencesRecipe_Handle0 by lazy {
 }
 val ReferencesRecipe_Handle1 by lazy {
     Handle(
-        StorageKeyParser.parse(
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
             "memdb://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:referencesArcId/handle/my-ref-id"
         ),
         arcs.core.data.SingletonType(

--- a/src/tools/tests/goldens/generated-from-kotlin.jvm.kt
+++ b/src/tools/tests/goldens/generated-from-kotlin.jvm.kt
@@ -11,11 +11,11 @@ import arcs.core.data.ReferenceType
 import arcs.core.data.Schema
 import arcs.core.data.SchemaFields
 import arcs.core.data.SchemaName
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 
 val IngestionOnly_handle0: Plan.Handle = Plan.Handle(
             storageKey =
-                StorageKeyParser.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"),
+                StorageKeyManager.GLOBAL_INSTANCE.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"),
             type = EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(
@@ -35,7 +35,7 @@ val IngestionOnlyPlan: Plan = Plan(
 
 val Ingestion_handle0: Plan.Handle = Plan.Handle(
             storageKey =
-                StorageKeyParser.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingArcId/handle/my-handle-id}"),
+                StorageKeyManager.GLOBAL_INSTANCE.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingArcId/handle/my-handle-id}"),
             type = EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(
@@ -55,7 +55,7 @@ val IngestionPlan: Plan = Plan(
 
 val Consumption_handle0: Plan.Handle = Plan.Handle(
             storageKey =
-                StorageKeyParser.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingArcId/handle/my-handle-id}"),
+                StorageKeyManager.GLOBAL_INSTANCE.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingArcId/handle/my-handle-id}"),
             type = EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(
@@ -74,7 +74,7 @@ val ConsumptionPlan: Plan = Plan(
         )
 
 val EphemeralWriting_handle0: Plan.Handle = Plan.Handle(
-            storageKey = StorageKeyParser.parse("create://my-ephemeral-handle-id"),
+            storageKey = StorageKeyManager.GLOBAL_INSTANCE.parse("create://my-ephemeral-handle-id"),
             type = EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(
@@ -94,7 +94,7 @@ val EphemeralWritingPlan: Plan = Plan(
 
 val EphemeralReading_handle0: Plan.Handle = Plan.Handle(
             storageKey =
-                StorageKeyParser.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"),
+                StorageKeyManager.GLOBAL_INSTANCE.parse("reference-mode://{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/Thing}{db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:writingOnlyArcId/handle/my-handle-id-writing}"),
             type = EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(
@@ -114,7 +114,7 @@ val EphemeralReadingPlan: Plan = Plan(
 
 val ReferencesRecipe_handle0: Plan.Handle = Plan.Handle(
             storageKey =
-                StorageKeyParser.parse("db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:referencesArcId/handle/my-refs-id"),
+                StorageKeyManager.GLOBAL_INSTANCE.parse("db://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:referencesArcId/handle/my-refs-id"),
             type = CollectionType(ReferenceType(EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(
@@ -128,7 +128,7 @@ val ReferencesRecipe_handle0: Plan.Handle = Plan.Handle(
 
 val ReferencesRecipe_handle1: Plan.Handle = Plan.Handle(
             storageKey =
-                StorageKeyParser.parse("memdb://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:referencesArcId/handle/my-ref-id"),
+                StorageKeyManager.GLOBAL_INSTANCE.parse("memdb://503ee2172e4a0ec16b2c7245ae8b7dd30fe9315b@arcs/!:referencesArcId/handle/my-ref-id"),
             type = ReferenceType(EntityType(Schema(
             names = setOf(SchemaName("Thing")),
             fields = SchemaFields(

--- a/src/tools/tests/goldens/plan-generator-handles.cgtest
+++ b/src/tools/tests/goldens/plan-generator-handles.cgtest
@@ -26,7 +26,7 @@ recipe MyRecipe
 -----[results]-----
 val MyRecipe_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(

--- a/src/tools/tests/goldens/plan-generator-plans.cgtest
+++ b/src/tools/tests/goldens/plan-generator-plans.cgtest
@@ -38,14 +38,16 @@ import arcs.core.data.expression.*
 import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt
 
 val Ingest_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse("db://e9e37c085f88c1508b5e7a1574360f1af349a149@arcs/!:ingestion/handle/data"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
+            "db://e9e37c085f88c1508b5e7a1574360f1af349a149@arcs/!:ingestion/handle/data"
+        ),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(
@@ -85,7 +87,9 @@ val IngestPlan by lazy {
 }
 val Retrieve_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse("db://e9e37c085f88c1508b5e7a1574360f1af349a149@arcs/!:ingestion/handle/data"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse(
+            "db://e9e37c085f88c1508b5e7a1574360f1af349a149@arcs/!:ingestion/handle/data"
+        ),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(
@@ -157,14 +161,14 @@ import arcs.core.data.expression.*
 import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt
 
 val R_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse("create://67835270998a62139f8b366f1cb545fb9b72a90b"),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(
@@ -257,14 +261,14 @@ import arcs.core.data.expression.*
 import arcs.core.data.expression.Expression.*
 import arcs.core.data.expression.Expression.BinaryOp.*
 import arcs.core.data.Plan.*
-import arcs.core.storage.StorageKeyParser
+import arcs.core.storage.StorageKeyManager
 import arcs.core.util.ArcsInstant
 import arcs.core.util.ArcsDuration
 import arcs.core.util.BigInt
 
 val R_Handle0 by lazy {
     Handle(
-        StorageKeyParser.parse("create://id-2"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse("create://id-2"),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(
@@ -284,7 +288,7 @@ val R_Handle0 by lazy {
 }
 val R_Handle1 by lazy {
     Handle(
-        StorageKeyParser.parse("create://id-1"),
+        StorageKeyManager.GLOBAL_INSTANCE.parse("create://id-1"),
         arcs.core.data.SingletonType(
             arcs.core.data.EntityType(
                 arcs.core.data.Schema(


### PR DESCRIPTION
Replaces the StorageKeyParser companion object (which is actually a StorageKeyManager instance, not a StorageKeyParser instance) with a GLOBAL_INSTANCE field on StorageKeyManager, and removes the old companion object. This will make it really easy to find everywhere where the global instance is being used, so that they can slowly be migrated to a dependency passing approach.

(Resubmission of cl/345585107 with fixes for golden files.)