### PR TITLE
 (ts) fewer runtime globals (step 2)

### DIFF
--- a/shells/pipes-shell/node/deploy/source/paths.js
+++ b/shells/pipes-shell/node/deploy/source/paths.js
@@ -10,7 +10,7 @@
 export const paths = {
   root: '.',
   map: {
-    'https://$build/': `./`
+    'https://$worker/': `./`
   }
 };
 

--- a/shells/pipes-shell/node/paths.js
+++ b/shells/pipes-shell/node/paths.js
@@ -12,7 +12,7 @@ export const paths = {
   map: {
     'https://$arcs/': `../../../`,
     'https://$particles/': `../../../particles/`,
-    'https://$build/': `../../lib/worker/dist/`
+    'https://$worker/': `../../lib/worker/dist/`
   }
 };
 

--- a/shells/pipes-shell/source/pipe.js
+++ b/shells/pipes-shell/source/pipe.js
@@ -44,14 +44,13 @@ export const busReady = async (bus, {manifest}) => {
 
 const configureRuntime = async ({rootPath, urlMap, storage, manifest}, bus) => {
   // configure arcs runtime environment
-  runtime = Runtime.init(rootPath, urlMap);
-  // marshal and bind context
-  const context = await requireContext(manifest);
-  runtime.bindContext(context);
+  runtime = new Runtime({rootPath, urlMap});
+  // marshal context
+  runtime.context = await requireContext(manifest);
   // attach verb-handlers to dispatcher
-  populateDispatcher(dispatcher, storage, context);
+  populateDispatcher(dispatcher, storage, runtime.context);
   // send pipe identifiers to client
-  contextReady(bus, context);
+  contextReady(bus, runtime.context);
 };
 
 const requireContext = async manifest => {

--- a/shells/pipes-shell/surface/deploy/source/paths.js
+++ b/shells/pipes-shell/surface/deploy/source/paths.js
@@ -10,6 +10,6 @@
 export const paths = {
   root: '.',
   map: {
-    'https://$build/': `./`
+    'https://$worker/': `./`
   }
 };

--- a/shells/pipes-shell/web/deploy/source/paths.js
+++ b/shells/pipes-shell/web/deploy/source/paths.js
@@ -10,6 +10,6 @@
 export const paths = {
   root: '.',
   map: {
-    'https://$build/': `./`
+    'https://$worker/': `./`
   }
 };

--- a/shells/pipes-shell/web/paths.js
+++ b/shells/pipes-shell/web/paths.js
@@ -8,11 +8,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 export const paths = {
-  root: '.',
+  //root: '.',
   map: {
     'https://$arcs/': `../../../`,
     'https://$shells/': `../../`,
-    'https://$build/': `../../lib/worker/dist/`,
+    'https://$worker/': `../../lib/worker/dist/`,
     'https://$particles/': {
       root: `../../../`,
       path: `/particles/`,

--- a/shells/tests/arcs/ts/runtime/arc-test.ts
+++ b/shells/tests/arcs/ts/runtime/arc-test.ts
@@ -16,7 +16,7 @@ import {Manifest} from '../../../../../build/runtime/manifest.js';
 import {SlotComposer} from '../../../../../build/runtime/slot-composer.js';
 import {Entity} from '../../../../../build/runtime/entity.js';
 import {EntityType} from '../../../../../build/types/lib-types.js';
-import {DriverFactory} from '../../../../../build/runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {VolatileStorageKey} from '../../../../../build/runtime/storage/drivers/volatile.js';
 import {DirectStorageEndpointManager} from '../../../../../build/runtime/storage/direct-storage-endpoint-manager.js';
 import {StoreInfo} from '../../../../../build/runtime/storage/store-info.js';
@@ -25,7 +25,7 @@ import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('Arc', () => {
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('deserializing a serialized arc with a Transformation produces that arc', async () => {

--- a/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
@@ -35,8 +35,8 @@ describe('Hot Code Reload for JS Particle', async () => {
         };
       });`
     });
-
     const runtime = new Runtime({loader, context});
+
     const arc = runtime.newArc('HotReload');
 
     const [recipe] = arc.context.recipes;

--- a/shells/tests/arcs/ts/runtime/multiplexer-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-test.ts
@@ -19,7 +19,8 @@ import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('Multiplexer', () => {
   it('processes multiple inputs', async () => {
-    const manifest = await Manifest.parse(`
+    const runtime = new Runtime();
+    const manifest = await runtime.parse(`
       import 'shells/tests/artifacts/Common/Multiplexer.manifest'
       import 'shells/tests/artifacts/test-particles.manifest'
 
@@ -30,12 +31,11 @@ describe('Multiplexer', () => {
           hostedParticle: ConsumerParticle
           annotation: consumes slot0
           list: reads handle0
-    `, {loader: new Loader(), fileName: ''});
+    `);
 
     const recipe = manifest.recipes[0];
     const barType = checkDefined(manifest.findTypeByName('Bar')) as EntityType;
 
-    const runtime = new Runtime({context: manifest, loader: new Loader()});
     const arc = runtime.newArc('test');
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
     const barHandle = await handleForStoreInfo(barStore, arc);

--- a/shells/tests/arcs/ts/runtime/particle-api-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-api-test.ts
@@ -15,8 +15,6 @@ import {Runtime} from '../../../../../build/runtime/runtime.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('particle-api', () => {
-
-  // TODO(sjmiles): uses xen particle
   it('loadRecipe returns ids of provided slots', async () => {
     const context = await Manifest.parse(`
       particle TransformationParticle in 'TransformationParticle.js'
@@ -26,7 +24,6 @@ describe('particle-api', () => {
         slot0: slot 'rootslotid-root'
         TransformationParticle
           root: consumes slot0`);
-
     const loader = new Loader(null, {
       'TransformationParticle.js': `defineParticle(({UiParticle}) => {
         return class extends UiParticle {

--- a/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
@@ -23,7 +23,7 @@ import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 describe('particle interface loading with slots', () => {
   async function initializeManifestAndArc(contextContainer?):
     Promise<{manifest: Manifest, recipe: Recipe, observer: SlotTestObserver, arc: Arc}> {
-    const loader = new Loader();
+    //const loader = new Loader();
     const manifestText = `
       import './shells/tests/artifacts/transformations/test-slots-particles.manifest'
       recipe
@@ -34,12 +34,14 @@ describe('particle interface loading with slots', () => {
           foos: reads handle0
           annotationsSet: consumes slot0
     `;
-    const manifest = await Manifest.parse(manifestText, {loader, fileName: ''});
+    const runtime = new Runtime();
+    const manifest = await runtime.parse(manifestText);
+
+    //const manifest = await Manifest.parse(manifestText/*, {loader, fileName: ''}*/);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize(), `can't normalize recipe`);
     assert(recipe.isResolved(), `recipe isn't resolved`);
 
-    const runtime = new Runtime({loader, context: manifest});
     const arc = runtime.newArc('test');
     const observer = new SlotTestObserver();
     arc.peh.slotComposer.observeSlots(observer);

--- a/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
+++ b/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
@@ -32,7 +32,7 @@ async function storeResults(consumer: PlanConsumer, suggestions: Suggestion[]) {
   await new Promise(resolve => setTimeout(resolve, 100));
 }
 
-describe('planFOOB consumer', () => {
+describe('plan consumer', () => {
   beforeEach(() => {
     Runtime.resetDrivers();
   });

--- a/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
+++ b/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
@@ -8,18 +8,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../../../../../build/platform/chai-web.js';
-import {Manifest} from '../../../../../build/runtime/manifest.js';
 import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
-import {Loader} from '../../../../../build/platform/loader.js';
 import {PlanConsumer} from '../../../../../build/planning/plan/plan-consumer.js';
 import {Planificator} from '../../../../../build/planning/plan/planificator.js';
 import {PlanningResult} from '../../../../../build/planning/plan/planning-result.js';
 import {Suggestion} from '../../../../../build/planning/plan/suggestion.js';
 import {StrategyTestHelper} from '../../../../../build/planning/testing/strategy-test-helper.js';
-import {RamDiskStorageDriverProvider} from '../../../../../build/runtime/storage/drivers/ramdisk.js';
-import {TestVolatileMemoryProvider} from '../../../../../build/runtime/testing/test-volatile-memory-provider.js';
-import {DriverFactory} from '../../../../../build/runtime/storage/drivers/driver-factory.js';
 import {Arc} from '../../../../../build/runtime/arc.js';
 import {ActiveSingletonEntityStore} from '../../../../../build/runtime/storage/storage.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
@@ -37,21 +32,17 @@ async function storeResults(consumer: PlanConsumer, suggestions: Suggestion[]) {
   await new Promise(resolve => setTimeout(resolve, 100));
 }
 
-describe('plan consumer', () => {
+describe('planFOOB consumer', () => {
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
-  // TODO(sjmiles): uses xen particle
   it('consumes', async () => {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const context =  await Manifest.parse(`
+    const manifestText = `
       import './shells/tests/artifacts/Products/Products.recipes'
 
       particle Test1 in './shells/tests/artifacts/consumer-particle.js'
@@ -70,8 +61,11 @@ describe('plan consumer', () => {
         Test2
           other: consumes other
         description \`Test Recipe\`
-    `, {loader, fileName: '', memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+    `;
+
+    const runtime = new Runtime();
+    runtime.context = await runtime.parse(manifestText);
+
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     let suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 

--- a/shells/tests/arcs/ts/runtime/products-test.ts
+++ b/shells/tests/arcs/ts/runtime/products-test.ts
@@ -9,16 +9,10 @@
  */
 
 import {assert} from '../../../../../build/platform/chai-web.js';
-import {Loader} from '../../../../../build/platform/loader.js';
 import {Arc} from '../../../../../build/runtime/arc.js';
-import {IdGenerator} from '../../../../../build/runtime/id.js';
-import {Manifest} from '../../../../../build/runtime/manifest.js';
 import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {SlotTestObserver} from '../../../../../build/runtime/testing/slot-test-observer.js';
-import {DriverFactory} from '../../../../../build/runtime/storage/drivers/driver-factory.js';
-import {RamDiskStorageDriverProvider} from '../../../../../build/runtime/storage/drivers/ramdisk.js';
-import {storageKeyForTest, storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
-import {TestVolatileMemoryProvider} from '../../../../../build/runtime/testing/test-volatile-memory-provider.js';
+import {storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
 import {CollectionEntityHandle, CollectionEntityType, handleForStoreInfo} from '../../../../../build/runtime/storage/storage.js';
 import {StoreInfo} from '../../../../../build/runtime/storage/store-info.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
@@ -26,7 +20,7 @@ import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 describe('products test', () => {
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   const manifestFilename = './shells/tests/artifacts/ProductsTestNg.arcs';
@@ -41,14 +35,8 @@ describe('products test', () => {
   };
 
   it('filters', async () => {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const runtime = new Runtime({
-        loader,
-        context: await Manifest.load(manifestFilename, loader, {memoryProvider}),
-        memoryProvider
-      });
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile(manifestFilename);
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const recipe = arc.context.recipes.find(r => r.name === 'FilterBooks');
     assert.isTrue(recipe.normalize() && recipe.isResolved());
@@ -58,11 +46,8 @@ describe('products test', () => {
   });
 
   it('filters and displays', async () => {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const id = IdGenerator.newSession().newArcId('demo');
-    const runtime = new Runtime({loader, context: await Manifest.load(manifestFilename, loader, {memoryProvider})});
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile(manifestFilename);
     const arc = runtime.newArc('demo');
     const recipe = arc.context.recipes.find(r => r.name === 'FilterAndDisplayBooks');
     assert.isTrue(recipe.normalize() && recipe.isResolved());

--- a/shells/tests/arcs/ts/runtime/slot-composer-test.ts
+++ b/shells/tests/arcs/ts/runtime/slot-composer-test.ts
@@ -14,12 +14,8 @@ import {Loader} from '../../../../../build/platform/loader.js';
 import {SlotComposer} from '../../../../../build/runtime/slot-composer.js';
 import {SlotTestObserver} from '../../../../../build/runtime/testing/slot-test-observer.js';
 import {StrategyTestHelper} from '../../../../../build/planning/testing/strategy-test-helper.js';
-import {Manifest} from '../../../../../build/runtime/manifest.js';
 import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
-import {TestVolatileMemoryProvider} from '../../../../../build/runtime/testing/test-volatile-memory-provider.js';
-import {RamDiskStorageDriverProvider} from '../../../../../build/runtime/storage/drivers/ramdisk.js';
-import {DriverFactory} from '../../../../../build/runtime/storage/drivers/driver-factory.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 class TestSlotComposer extends SlotComposer {
@@ -32,7 +28,6 @@ class TestSlotComposer extends SlotComposer {
 }
 
 async function initSlotComposer(recipeStr) {
-  const manifest = await Manifest.parse(recipeStr);
   const loader = new Loader(null, {
     '*': `
       defineParticle(({UiParticle}) => {
@@ -44,7 +39,9 @@ async function initSlotComposer(recipeStr) {
       });
     `
   });
-  const runtime = new Runtime({loader, context: manifest, composerClass: TestSlotComposer});
+  const runtime = new Runtime({loader, composerClass: TestSlotComposer});
+  runtime.context = await runtime.parse(recipeStr);
+
   const arc = runtime.newArc('test-arc');
 
   const planner = new Planner();
@@ -54,15 +51,16 @@ async function initSlotComposer(recipeStr) {
   await planner.strategizer.generate();
   assert.lengthOf(planner.strategizer.population, 1);
 
+  const observer = (arc.peh.slotComposer as TestSlotComposer).observer;
   const plan = planner.strategizer.population[0].result;
 
-  return {arc, observer: (arc.peh.slotComposer as TestSlotComposer).observer, plan};
+  return {arc, observer, plan};
 }
 
 describe('slot composer', () => {
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('initialize recipe and render slots', async () => {
@@ -117,13 +115,9 @@ recipe
   // in the render expectations; rendering uses _eventual correctness_ so it's not necessarily
   // deterministic: we may need to update the expectations system to take this into account.
   it.skip('initialize recipe and render hosted slots', async () => {
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const loader = new Loader();
-    const file = 'ProductsTestNg.arcs';
-    const manifest = `./shells/tests/artifacts/${file}`;
-    const context = await Manifest.load(manifest, loader, {memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+    const manifest = `./shells/tests/artifacts/ProductsTestNg.arcs`;
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile(manifest);
 
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
@@ -183,84 +177,84 @@ recipe
   });
 
   it('renders inner slots in transformations without intercepting', async () => {
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
+    const staticFiles = {
+      './TransformationParticle.js': `defineParticle(({UiParticle}) => {
+        return class extends UiParticle {
+          async setHandles(handles) {
+            super.setHandles(handles);
 
-    const loader = new Loader(null, {
-        'TransformationParticle.js': `defineParticle(({UiParticle}) => {
-          return class extends UiParticle {
-            async setHandles(handles) {
-              super.setHandles(handles);
+            const innerArc = await this.constructInnerArc();
+            const hostedSlotId = await innerArc.createSlot(this, 'root');
 
-              const innerArc = await this.constructInnerArc();
-              const hostedSlotId = await innerArc.createSlot(this, 'root');
+            await innerArc.loadRecipe(\`
+              particle A in './A.js'
+                content: consumes
+                  detail: provides
 
-              await innerArc.loadRecipe(\`
-                particle A in 'A.js'
-                  content: consumes
-                    detail: provides
+              particle B in './B.js'
+                detail: consumes
 
-                particle B in 'B.js'
-                  detail: consumes
+              recipe
+                hosted: slot '\` + hostedSlotId + \`'
+                A
+                  content: consumes hosted
+                    detail: provides detail
+                B
+                  detail: consumes detail
+            \`);
+          }
+          renderHostedSlot(slotName, hostedSlotId, content) {
+            this.setState(content);
+          }
+          shouldRender() {
+            return Boolean(this.state.template);
+          }
+          getTemplate() {
+            return '<div>intercepted-template' + this.state.template + '</div>';
+          }
+          getTemplateName() {
+            return this.state.templateName + '/intercepted';
+          }
+          render() {
+            return Object.assign({}, this.state.model, {a: this.state.model.a + '/intercepted-model'});
+          }
+        };
+      });`,
+      './A.js': `defineParticle(({UiParticle}) => {
+        return class extends UiParticle {
+          get template() {
+            return '<div><span>{{a}}</span><div slotid="detail"></div></div>';
+          }
+          render() {
+            return {a: 'A content'};
+          }
+        };
+      });`,
+      './B.js': `defineParticle(({UiParticle}) => {
+        return class extends UiParticle {
+          get template() {
+            return '<div>{{b}}</div>';
+          }
+          render() {
+            return {b: 'B content'};
+          }
+        };
+      });`
+    };
 
-                recipe
-                  hosted: slot '\` + hostedSlotId + \`'
-                  A
-                    content: consumes hosted
-                      detail: provides detail
-                  B
-                    detail: consumes detail
-              \`);
-            }
-            renderHostedSlot(slotName, hostedSlotId, content) {
-              this.setState(content);
-            }
-            shouldRender() {
-              return Boolean(this.state.template);
-            }
-            getTemplate() {
-              return '<div>intercepted-template' + this.state.template + '</div>';
-            }
-            getTemplateName() {
-              return this.state.templateName + '/intercepted';
-            }
-            render() {
-              return Object.assign({}, this.state.model, {a: this.state.model.a + '/intercepted-model'});
-            }
-          };
-        });`,
-        'A.js': `defineParticle(({UiParticle}) => {
-          return class extends UiParticle {
-            get template() {
-              return '<div><span>{{a}}</span><div slotid="detail"></div></div>';
-            }
-            render() {
-              return {a: 'A content'};
-            }
-          };
-        });`,
-        'B.js': `defineParticle(({UiParticle}) => {
-          return class extends UiParticle {
-            get template() {
-              return '<div>{{b}}</div>';
-            }
-            render() {
-              return {b: 'B content'};
-            }
-          };
-        });`
-    });
-
-    const context = await Manifest.parse(`
-      particle TransformationParticle in 'TransformationParticle.js'
+    const contextText = `
+      particle TransformationParticle in './TransformationParticle.js'
         root: consumes
       recipe
         slot0: slot 'rootslotid-root'
         TransformationParticle
-          root: consumes slot0`, {loader, fileName: '', memoryProvider}
-    );
+          root: consumes slot0
+    `;
 
-    const runtime = new Runtime({loader, context, memoryProvider});
+    const loader = new Loader(null, staticFiles);
+    const runtime = new Runtime({loader});
+    runtime.context = await runtime.parse(contextText);
+
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const [recipe] = arc.context.recipes;
     recipe.normalize();

--- a/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
@@ -9,30 +9,21 @@
  */
 
 import {assert} from '../../../../../build/platform/chai-web.js';
-import {Manifest} from '../../../../../build/runtime/manifest.js';
 import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
 import {SlotTestObserver} from '../../../../../build/runtime/testing/slot-test-observer.js';
-import {Loader} from '../../../../../build/platform/loader.js';
-import {TestVolatileMemoryProvider} from '../../../../../build/runtime/testing/test-volatile-memory-provider.js';
 import {StrategyTestHelper} from '../../../../../build/planning/testing/strategy-test-helper.js';
-import {RamDiskStorageDriverProvider} from '../../../../../build/runtime/storage/drivers/ramdisk.js';
-import {DriverFactory} from '../../../../../build/runtime/storage/drivers/driver-factory.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('transformation slots', () => {
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('combines hosted particles provided singleton slots into transformation provided set slot', async () => {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const context = await Manifest.load(
-        './shells/tests/artifacts/provide-hosted-particle-slots.manifest', loader, {memoryProvider});
-    const runtime = new Runtime({
-        loader, context, memoryProvider});
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile('./shells/tests/artifacts/provide-hosted-particle-slots.manifest');
+
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const slotComposer = arc.peh.slotComposer;
 

--- a/shells/tests/artifacts/Products/test/ProductFilter.manifest
+++ b/shells/tests/artifacts/Products/test/ProductFilter.manifest
@@ -9,13 +9,13 @@
 import '../Product.schema'
 
 interface HostedParticleInterface
-  reads Product
-  writes Product
+  reads Product {name, category, seller, price, shipDays}
+  writes Product {name, category, seller, price, shipDays}
 
 // TODO: This particle should use generic handle type and slot name.
 particle ProductFilter in 'source/ProductFilter.js'
   hostedParticle: hosts HostedParticleInterface
-  products: reads [Product]
-  results: writes [Product]
+  products: reads [Product {name, category, seller, price, shipDays}]
+  results: writes [Product {name, category, seller, price, shipDays}]
   description `show filtered products`
     results `filtered list of products`

--- a/shells/tests/artifacts/Products/test/ProductFilter.manifest
+++ b/shells/tests/artifacts/Products/test/ProductFilter.manifest
@@ -9,13 +9,13 @@
 import '../Product.schema'
 
 interface HostedParticleInterface
-  reads Product {name, category, seller, price, shipDays}
-  writes Product {name, category, seller, price, shipDays}
+  reads Product
+  writes Product
 
 // TODO: This particle should use generic handle type and slot name.
 particle ProductFilter in 'source/ProductFilter.js'
   hostedParticle: hosts HostedParticleInterface
-  products: reads [Product {name, category, seller, price, shipDays}]
-  results: writes [Product {name, category, seller, price, shipDays}]
+  products: reads [Product]
+  results: writes [Product]
   description `show filtered products`
     results `filtered list of products`

--- a/shells/tests/artifacts/Products/test/ProductIsBook.manifest
+++ b/shells/tests/artifacts/Products/test/ProductIsBook.manifest
@@ -9,7 +9,7 @@
 import '../Product.schema'
 
 particle ProductIsBook in 'source/ProductIsBook.js'
-  product: reads Product
-  book: writes Product
+  product: reads Product {name, category, seller, price, shipDays}
+  book: writes Product {name, category, seller, price, shipDays}
   description `filter books`
     book `book`

--- a/shells/tests/artifacts/Products/test/ProductIsBook.manifest
+++ b/shells/tests/artifacts/Products/test/ProductIsBook.manifest
@@ -9,7 +9,7 @@
 import '../Product.schema'
 
 particle ProductIsBook in 'source/ProductIsBook.js'
-  product: reads Product {name, category, seller, price, shipDays}
-  book: writes Product {name, category, seller, price, shipDays}
+  product: reads Product
+  book: writes Product
   description `filter books`
     book `book`

--- a/shells/tests/artifacts/ProductsTestNg.arcs
+++ b/shells/tests/artifacts/ProductsTestNg.arcs
@@ -12,7 +12,7 @@ import './Products/test/ProductIsBook.manifest'
 
 import './Products/Product.schema'
 particle ShowProduct in './Products/source/ShowProduct.js'
-  product: reads Product
+  product: reads Product {name, category, seller, price, shipDays}
   item: consumes Slot
 
 // Filter books and display them.
@@ -55,4 +55,4 @@ resource ProductList
     "locations": {}
   }
 
-store Store0 of [Product] 'mylist' in ProductList
+store Store0 of [Product {name, category, seller, price, shipDays}] 'mylist' in ProductList

--- a/shells/tests/artifacts/ProductsTestNg.arcs
+++ b/shells/tests/artifacts/ProductsTestNg.arcs
@@ -12,7 +12,7 @@ import './Products/test/ProductIsBook.manifest'
 
 import './Products/Product.schema'
 particle ShowProduct in './Products/source/ShowProduct.js'
-  product: reads Product {name, category, seller, price, shipDays}
+  product: reads Product
   item: consumes Slot
 
 // Filter books and display them.
@@ -55,4 +55,4 @@ resource ProductList
     "locations": {}
   }
 
-store Store0 of [Product {name, category, seller, price, shipDays}] 'mylist' in ProductList
+store Store0 of [Product] 'mylist' in ProductList

--- a/shells/tools/broker-shell/index.js
+++ b/shells/tools/broker-shell/index.js
@@ -15,7 +15,7 @@ const config = {
   urlMap: {
     'https://$arcs/': `../../../`,
     'https://$particles/': `../../../particles/`,
-    'https://$build/': `../../lib/build/`
+    'https://$worker/': `../../lib/build/`
   },
   storage: 'volatile://',
   manifest: `

--- a/shells/tools/diagnostic/user-context/index.js
+++ b/shells/tools/diagnostic/user-context/index.js
@@ -19,7 +19,7 @@ import '../../../modalities/dom/components/arc-tools/store-explorer.js';
 const storage = `firebase://arcs-storage.firebaseio.com/AIzaSyBme42moeI-2k8WgXh-6YK_wYyjEXo4Oz8/0_7_0/sjmiles`;
 
 // configure arcs environment
-Runtime.init('../../../');
+const runtime = new Runtime({rootPath: '../../..'});
 
 let context;
 let UserObserverImpl;
@@ -27,7 +27,7 @@ let UserObserverImpl;
 const observe = async () => {
   // prepare context
   if (!context) {
-    context = await Runtime.parse('');
+    context = await runtime.parse('');
     //
     const ArcHandleListenerImpl = ArcHandleDisplayMixin(ArcHandleListener);
     //

--- a/shells/tools/planner-shell/planner-shell.js
+++ b/shells/tools/planner-shell/planner-shell.js
@@ -46,11 +46,11 @@ export class PlannerShellInterface {
     // connect to DevTools if running with --explore
     await maybeConnectToDevTools();
     // create an arcs environment
-    Runtime.init(assetsPath);
+    const runtime = new Runtime({rootPath: assetsPath});
     // observe user's arc list
     const userArcs = new UserArcs(storage, userid);
     // base context (particles & recipes) from static manifest
-    const context = await Runtime.parse(contextManifest);
+    const context = await runtime.parse(contextManifest);
     // userContext continually updates context based on user's arcs
     const userContext = new UserContext();
     // wait for context to spin up

--- a/shells/tools/single-shell/index.html
+++ b/shells/tools/single-shell/index.html
@@ -42,7 +42,7 @@ http://polymer.github.io/PATENTS.txt
   const getUrlParam = name => {
     return new URL(document.location.href).searchParams.get(name);
   }
-  const runtime = Runtime.init('../..');
+  const runtime = new Runtime({rootPath: '../..'});
 
   const composer = new DomSlotComposer({
     rootContainer: document.body

--- a/shells/tools/smoke-shell/smoke.html
+++ b/shells/tools/smoke-shell/smoke.html
@@ -24,7 +24,7 @@
       // read intent
       const manifest = getUrlParam('manifest') || getUrlParam('m') || `Arcs/Login.recipe`;
       // configure arcs environment
-      Runtime.init('../..');
+      const runtime = new Runtime({rootPath: '../..'});
       // construct renderer
       const composer = new SlotComposer();
       // establish surface

--- a/shells/tools/smoke-shell/smoke.js
+++ b/shells/tools/smoke-shell/smoke.js
@@ -18,7 +18,7 @@ console.log('\n--- Arcs Shell ---\n');
 (async () => {
   try {
     // configure arcs environment
-    Runtime.init('../..');
+    const runtime = new Runtime({rootPath: '../..'});
     // create a composer
     const composer = new SlotComposer();
     await App(composer, `Arcs/Login.recipe`);

--- a/shells/web-shell/elements/web-shell.js
+++ b/shells/web-shell/elements/web-shell.js
@@ -171,11 +171,11 @@ export class WebShell extends Xen.Debug(Xen.Async, log) {
     };
     return [props, state, renderModel];
   }
-  async configureEnv(root) {
+  async configureEnv(rootPath) {
     // capture anchor-clicks for SPA behavior
     linkJack(document, anchor => this.routeLink(anchor));
     // configure arcs environment
-    return Runtime.init(root);
+    const runtime = new Runtime({rootPath});
   }
   routeLink(anchor) {
     const url = new URL(anchor.href, document.location);

--- a/src/dataflow/analysis/testing/flow-graph-testing.ts
+++ b/src/dataflow/analysis/testing/flow-graph-testing.ts
@@ -9,16 +9,15 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
-import {Manifest} from '../../../runtime/manifest.js';
+import {Runtime} from '../../../runtime/runtime.js';
 import {FlowGraph} from '../flow-graph.js';
 import {CheckCondition} from '../../../runtime/arcs-types/check.js';
 import {Edge, Node, FlowModifier} from '../graph-internals.js';
-import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 
 /** Constructs a FlowGraph from the recipe in the given manifest. */
 export async function buildFlowGraph(manifestContent: string): Promise<FlowGraph> {
-  const memoryProvider = new TestVolatileMemoryProvider();
-  const manifest = await Manifest.parse(manifestContent, {memoryProvider});
+  const runtime = new Runtime();
+  const manifest = await runtime.parse(manifestContent);
   assert.lengthOf(manifest.recipes, 1);
   const recipe = manifest.recipes[0];
   assert(recipe.normalize(), 'Failed to normalize recipe.');

--- a/src/dataflow/cli/flowcheck.ts
+++ b/src/dataflow/cli/flowcheck.ts
@@ -15,7 +15,7 @@ import {Runtime} from '../../runtime/runtime.js';
 // TODO make this a function and test it; it's big enough now
 
 (async () => {
-  const runtime = Runtime.init('../../..');
+  const runtime = new Runtime({rootPath: '../../..'});
   const filenames = process.argv.slice(2);
   if (filenames.length === 0) {
     console.error('Usage: flowcheck <manifest files>');

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -13,17 +13,13 @@ import {ArcId} from '../../../runtime/id.js';
 import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {Runtime} from '../../../runtime/runtime.js';
-import {SlotComposer} from '../../../runtime/slot-composer.js';
 import {storageKeyPrefixForTest, storageKeyForTest} from '../../../runtime/testing/handle-for-test.js';
-import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {PlanProducer} from '../../plan/plan-producer.js';
 import {Planificator} from '../../plan/planificator.js';
 import {PlanningResult} from '../../plan/planning-result.js';
 import {Suggestion} from '../../plan/suggestion.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
-import {RamDiskStorageDriverProvider} from '../../../runtime/storage/drivers/ramdisk.js';
 import {ActiveSingletonEntityStore, handleForActiveStore} from '../../../runtime/storage/storage.js';
-import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
 
 class TestPlanProducer extends PlanProducer {
   options;
@@ -84,19 +80,16 @@ class TestPlanProducer extends PlanProducer {
 // Run test suite for each storageKeyBase
 describe('plan producer', () => {
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   async function createProducer() {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     const suggestions = await StrategyTestHelper.planForArc(
       runtime,
@@ -178,13 +171,11 @@ describe('plan producer - search', () => {
   }
 
   async function init(): Promise<TestSearchPlanProducer> {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    const manifest = await Manifest.parse(`
+    const runtime = new Runtime();
+    runtime.context = await runtime.parse(`
       schema Bar
         value: Text
-    `, {memoryProvider});
-    const runtime = new Runtime({loader, context: manifest, memoryProvider});
+    `);
     const arc = runtime.newArc('test', storageKeyForTest, {id: ArcId.newForTest('test')});
     const searchStore = await Planificator['_initSearchStore'](arc);
 

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -51,14 +51,14 @@ describe.skip('remote planificator', () => {
 
   let memoryProvider;
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
     arcStorageKey = storageKeyPrefixForTest();
     memoryProvider = new TestVolatileMemoryProvider();
     RamDiskStorageDriverProvider.register(memoryProvider);
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   async function createArc(options, storageKey) {

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -22,7 +22,6 @@ import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {VolatileStorageDriverProvider} from '../../../runtime/storage/drivers/volatile.js';
 
 describe('planning result', () => {
-  let memoryProvider;
   beforeEach(() => {
     Runtime.resetDrivers();
   });
@@ -94,7 +93,6 @@ describe('planning result', () => {
 });
 
 describe('planning result merge', () => {
-  let memoryProvider;
   beforeEach(() => {
     Runtime.resetDrivers();
   });

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -19,50 +19,55 @@ import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile
 import {storageKeyPrefixForTest} from '../../../runtime/testing/handle-for-test.js';
 import {Loader} from '../../../platform/loader.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
-import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
 import {VolatileStorageDriverProvider} from '../../../runtime/storage/drivers/volatile.js';
 
 describe('planning result', () => {
   let memoryProvider;
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
-    memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
+    Runtime.resetDrivers();
   });
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('serializes and deserializes Products recipes', async () => {
-    const loader = new Loader();
-    const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
+
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
     VolatileStorageDriverProvider.register(arc);
-    const storageManager = arc.storageManager;
-    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
+    const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.isNotEmpty(suggestions);
+
+    const {loader, context} = runtime;
+    const {storageManager} = arc;
+
     const result = new PlanningResult({context, loader, storageManager});
     result.merge({suggestions}, arc);
 
     const serialization = result.toLiteral();
     assert(serialization.suggestions);
+
     const resultNew = new PlanningResult({context, loader, storageManager});
     assert.isEmpty(resultNew.suggestions);
+
     await resultNew.fromLiteral({suggestions: serialization.suggestions});
     assert.isTrue(resultNew.isEquivalent(suggestions));
   });
 
   it('appends search suggestions', async () => {
-    const loader = new Loader();
-    const context = await Manifest.load('./src/runtime/tests/artifacts/Products/Products.recipes', loader, {memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
+
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
-    const storageManager = arc.storageManager;
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
+    const {loader, context} = runtime;
+    const {storageManager} = arc;
+
     const result = new PlanningResult({loader, context, storageManager});
+
     // Appends new suggestion.
     assert.isTrue(result.merge({suggestions}, arc));
     assert.lengthOf(result.suggestions, 1);
@@ -91,13 +96,11 @@ describe('planning result', () => {
 describe('planning result merge', () => {
   let memoryProvider;
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
-    memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
+    Runtime.resetDrivers();
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   const commonManifestStr = `
@@ -133,8 +136,7 @@ recipe R3
     thing: reads thingHandle
         `;
   async function prepareMerge(manifestStr1, manifestStr2) {
-    const loader = new Loader();
-    const runtime = new Runtime({loader});
+    const runtime = new Runtime();
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
 
     const planToSuggestion = async (plan: Recipe): Promise<Suggestion> => {
@@ -148,8 +150,8 @@ recipe R3
       return suggestion;
     };
     const manifestToResult = async (manifestStr) =>  {
-      const manifest = await Manifest.parse(manifestStr, {loader, fileName: '', memoryProvider});
-      const result = new PlanningResult({context: arc.context, loader, storageManager: arc.storageManager});
+      const manifest = await runtime.parse(manifestStr);
+      const result = new PlanningResult({context: arc.context, loader: runtime.loader, storageManager: arc.storageManager});
 
       const suggestions: Suggestion[] = await Promise.all(
         manifest.recipes.map(async plan => planToSuggestion(plan)) as Promise<Suggestion>[]

--- a/src/planning/plan/tests/test-environment-test.ts
+++ b/src/planning/plan/tests/test-environment-test.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {registerSystemExceptionHandler, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../../../runtime/arc-exceptions.js';
-import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../../runtime/runtime.js';
 
 let exceptions: Error[] = [];
 
@@ -24,5 +24,5 @@ afterEach(function() {
     // Error function not yet included in mocha typescript declarations...
     this.test['error'](exception);
   }
-  DriverFactory.clearRegistrationsForTesting();
+  Runtime.resetDrivers();
 });

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -74,6 +74,8 @@ export interface PlannerInitOptions {
   runtime?: Runtime;
 }
 
+const gRuntime = new Runtime();
+
 export class Planner implements InspectablePlanner {
   public arc: Arc;
   runtime: Runtime;

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -74,8 +74,6 @@ export interface PlannerInitOptions {
   runtime?: Runtime;
 }
 
-const gRuntime = new Runtime();
-
 export class Planner implements InspectablePlanner {
   public arc: Arc;
   runtime: Runtime;

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -109,7 +109,7 @@ export class Planner implements InspectablePlanner {
       Planner.getRuntimeCache(lastRuntime).clear();
     }
   }
-  
+
   getCache() {
     return Planner.getRuntimeCache(this.runtime);
   }

--- a/src/planning/strategies/tests/coalesce-recipes-test.ts
+++ b/src/planning/strategies/tests/coalesce-recipes-test.ts
@@ -8,28 +8,22 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-
 import {assert} from '../../../platform/chai-web.js';
-import {Manifest} from '../../../runtime/manifest.js';
-import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
-import {RamDiskStorageDriverProvider} from '../../../runtime/storage/drivers/ramdisk.js';
 import {CoalesceRecipes} from '../../strategies/coalesce-recipes.js';
-
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
-import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../../runtime/runtime.js';
 
 describe('CoalesceRecipes', () => {
   let memoryProvider;
   beforeEach(() => {
-      memoryProvider = new TestVolatileMemoryProvider();
-      RamDiskStorageDriverProvider.register(memoryProvider);
   });
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   async function tryCoalesceRecipes(manifestStr: string) {
-    const manifest = await Manifest.parse(manifestStr, {memoryProvider});
+    const runtime = new Runtime();
+    const manifest = await runtime.parse(manifestStr);
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     assert.isFalse(recipes.every(recipe => recipe.isResolved()));

--- a/src/planning/strategies/tests/coalesce-recipes-test.ts
+++ b/src/planning/strategies/tests/coalesce-recipes-test.ts
@@ -14,7 +14,6 @@ import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
 import {Runtime} from '../../../runtime/runtime.js';
 
 describe('CoalesceRecipes', () => {
-  let memoryProvider;
   beforeEach(() => {
   });
   afterEach(() => {

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -11,24 +11,21 @@
 import {assert} from '../../../platform/chai-web.js';
 import {Loader} from '../../../platform/loader.js';
 import {Manifest} from '../../../runtime/manifest.js';
-import {RamDiskStorageDriverProvider} from '../../../runtime/storage/drivers/ramdisk.js';
-import {TestVolatileMemoryProvider} from '../../../runtime/testing/test-volatile-memory-provider.js';
 import {SearchTokensToHandles} from '../../strategies/search-tokens-to-handles.js';
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
-import {DriverFactory} from '../../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../../runtime/runtime.js';
 
 describe('SearchTokensToHandles', () => {
-  let memoryProvider;
+  let runtime;
   beforeEach(() => {
-    memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
+    runtime = new Runtime();
   });
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('finds local handle by tags', async () => {
-    const manifest = (await Manifest.parse(`
+    const manifest = await runtime.parse(`
       schema Thing
       particle ShowThing &show in 'A.js'
         inThing: reads Thing
@@ -42,7 +39,7 @@ describe('SearchTokensToHandles', () => {
       resource ThingsJson
         start
         {"root": {}, "locations": {}}
-    `, {memoryProvider}));
+    `);
 
     const arc = StrategyTestHelper.createTestArc(manifest);
     await arc._registerStore(arc.context.findStoreById('thing-id'), ['mything']);
@@ -62,16 +59,15 @@ describe('SearchTokensToHandles', () => {
   });
 
   it('finds remote handle by tags', async () => {
-    const loader = new Loader();
-    const storeManifest = (await Manifest.parse(`
+    const storeManifest = (await runtime.parse(`
 import 'src/runtime/tests/artifacts/test-particles.manifest'
 store Things of Foo #mything in ThingsJson
 store Things of [Foo] #manythings in ThingsJson
   resource ThingsJson
     start
     [{}]
-    `, {loader, fileName: '', memoryProvider}));
-    const manifest = (await Manifest.parse(`
+    `));
+    const manifest = (await runtime.parse(`
 import 'src/runtime/tests/artifacts/test-particles.manifest'
 particle ChooseFoo &choose in 'A.js'
   inFoos: reads [Foo]
@@ -84,7 +80,7 @@ recipe
   ChooseFoo
     inFoos: reads h0
     outFoo: writes h1
-    `, {loader, fileName: '', memoryProvider}));
+    `));
     const arc = StrategyTestHelper.createTestArc(manifest);
     arc.context.imports.push(storeManifest);
     const recipe = manifest.recipes[0];

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -9,7 +9,6 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Arc} from '../../runtime/arc.js';
 import {Particle} from '../../runtime/particle.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../../runtime/manifest.js';
@@ -17,34 +16,29 @@ import {Planner} from '../planner.js';
 import {Speculator} from '../speculator.js';
 import {assertThrowsAsync, ConCap} from '../../testing/test-util.js';
 import {StrategyTestHelper} from '../testing/strategy-test-helper.js';
-import {ArcId} from '../../runtime/id.js';
-import {RamDiskStorageDriverProvider, RamDiskStorageKey} from '../../runtime/storage/drivers/ramdisk.js';
+import {RamDiskStorageKey} from '../../runtime/storage/drivers/ramdisk.js';
 import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
 import {EntityType, SingletonType} from '../../types/lib-types.js';
 import {Entity} from '../../runtime/entity.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 import {Runtime} from '../../runtime/runtime.js';
 
 async function planFromManifest(manifest, {arcFactory, testSteps}: {arcFactory?, testSteps?} = {}) {
-  const loader = new Loader();
-  const memoryProvider = new TestVolatileMemoryProvider();
-  RamDiskStorageDriverProvider.register(memoryProvider);
+  const runtime = new Runtime();
   if (typeof manifest === 'string') {
-    const fileName = './test.manifest';
-    manifest = await Manifest.parse(manifest, {loader, fileName, memoryProvider});
+    manifest = await runtime.parse(manifest);
   }
 
-  arcFactory = arcFactory || ((manifest) => StrategyTestHelper.createTestArc(manifest));
-  testSteps = testSteps || ((planner) => planner.plan(Infinity, []));
+  arcFactory = arcFactory || (manifest => StrategyTestHelper.createTestArc(manifest));
+  testSteps = testSteps || (planner => planner.plan(Infinity, []));
 
   const arc = await arcFactory(manifest);
+
   const planner = new Planner();
   const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
   planner.init(arc, options);
+
   const result = await testSteps(planner);
-
-  DriverFactory.clearRegistrationsForTesting();
-
+  Runtime.resetDrivers();
   return result;
 }
 
@@ -571,20 +565,15 @@ ${recipeManifest}
 });
 
 describe('Type variable resolution', () => {
-  let memoryProvider;
-
   beforeEach(() => {
-    memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
   });
-
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
-  const loadAndPlan = async (manifestStr) => {
-    const loader = new NullLoader();
-    const manifest = (await Manifest.parse(manifestStr, {loader, memoryProvider}));
+  const loadAndPlan = async manifestStr => {
+    const runtime = new Runtime({loader: new NullLoader()});
+    const manifest = await runtime.parse(manifestStr);
     const arc = StrategyTestHelper.createTestArc(manifest);
     const planner = new Planner();
     const options = {strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
@@ -594,7 +583,6 @@ describe('Type variable resolution', () => {
   const verifyResolvedPlan = async (manifestStr) => {
     const plans = await loadAndPlan(manifestStr);
     assert.lengthOf(plans, 1);
-
     const recipe = plans[0];
     recipe.normalize();
     assert.isTrue(recipe.isResolved());

--- a/src/platform/pec-industry-web.ts
+++ b/src/platform/pec-industry-web.ts
@@ -12,7 +12,7 @@ import {PecFactory} from '../runtime/particle-execution-context.js';
 import {Id, IdGenerator} from '../runtime/id.js';
 import {workerPool} from '../runtime/worker-pool.js';
 
-const WORKER_PATH = `https://$build/worker.js`;
+const WORKER_PATH = `https://$worker/worker.js`;
 
 export const pecIndustry = (loader): PecFactory => {
   // worker paths are relative to worker location, remap urls from there to here

--- a/src/runtime/env.ts
+++ b/src/runtime/env.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright (c) 2020 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Loader} from './loader.js';
+
+export class Env {
+  static loader: Loader;
+  /**
+   * Call `init` to establish a default loader environment.
+   */
+  static init(root?: string, urls?: {}) {
+    this.loader = new Loader({...this.mapFromRootPath(root), ...urls});
+  }
+  static mapFromRootPath(root: string) {
+    // TODO(sjmiles): the map below is commonly-used, but it's not generic enough to live here.
+    // Shells that use this default should be provide it to `init` themselves.
+    return {
+      // important: path to `worker.js`
+      'https://$worker/': `${root}/shells/lib/worker/dist/`,
+      // TODO(sjmiles): for backward compat
+      'https://$build/': `${root}/shells/lib/worker/dist/`,
+      // these are optional (?)
+      'https://$arcs/': `${root}/`,
+      'https://$shells': `${root}/shells`,
+      'https://$particles/': {
+        root,
+        path: '/particles/',
+        buildDir: '/bazel-bin',
+        buildOutputRegex: /\.wasm$/.source
+      }
+    };
+
+  }
+}

--- a/src/runtime/env.ts
+++ b/src/runtime/env.ts
@@ -24,8 +24,6 @@ export class Env {
     return {
       // important: path to `worker.js`
       'https://$worker/': `${root}/shells/lib/worker/dist/`,
-      // TODO(sjmiles): for backward compat
-      'https://$build/': `${root}/shells/lib/worker/dist/`,
       // these are optional (?)
       'https://$arcs/': `${root}/`,
       'https://$shells': `${root}/shells`,

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -868,9 +868,9 @@ ${e.message}
     }
 
     // TODO: loader should not be optional.
-    if (particleItem.implFile && loader) {
+    if (particleItem.implFile /*&& loader*/) {
       if (!Loader.isJvmClasspath(particleItem.implFile)) {
-        particleItem.implFile = loader.join(manifest.fileName, particleItem.implFile);
+        particleItem.implFile = (loader || Loader).join(manifest.fileName, particleItem.implFile);
       }
     }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -34,7 +34,6 @@ import {RamDiskStorageDriverProvider} from './storage/drivers/ramdisk.js';
 import {SimpleVolatileMemoryProvider, VolatileMemoryProvider, VolatileStorageKey, VolatileStorageKeyFactory} from './storage/drivers/volatile.js';
 import {StorageEndpointManager} from './storage/storage-manager.js';
 import {DirectStorageEndpointManager} from './storage/direct-storage-endpoint-manager.js';
-import {Env} from './env.js';
 
 const {warn} = logsFactory('Runtime', 'orange');
 
@@ -61,9 +60,9 @@ export type RuntimeArcOptions = Readonly<{
   modality?: Modality;
 }>;
 
-let staticMemoryProvider;
 
-// TODO(sjmiles): weird layering here due to dancing around global state
+// TODO(sjmiles): weird layering here due to dancing around global state (working on it)
+let staticMemoryProvider;
 const initDrivers = () => {
   VolatileStorageKey.register();
   staticMemoryProvider = new SimpleVolatileMemoryProvider();
@@ -93,25 +92,6 @@ export class Runtime {
       initDrivers();
     }
   }
-
-  /**
-   * Call `init` to establish a default Runtime environment (capturing the return value is optional).
-   * Systems can use `Runtime.getRuntime()` to access this environment instead of plumbing `runtime`
-   * arguments through numerous functions.
-   * Some static methods on this class automatically use the default environment.
-   */
-  // static init(root?: string, urls?: {}): Runtime {
-  //   const map = {...Runtime.mapFromRootPath(root), ...urls};
-  //   const loader = new Loader(map);
-  //   const pecFactory = pecIndustry(loader);
-  //   const runtime = new Runtime({
-  //     loader,
-  //     composerClass: SlotComposer,
-  //     pecFactory,
-  //     memoryProvider: staticMemoryProvider
-  //   });
-  //   return runtime;
-  // }
 
   static mapFromRootPath(root: string) {
     // TODO(sjmiles): this is a commonly-used map, but it's not generic enough to live here.

--- a/src/runtime/storage/drivers/driver-factory.ts
+++ b/src/runtime/storage/drivers/driver-factory.ts
@@ -9,9 +9,7 @@
  */
 
 import {StorageKey} from '../storage-key.js';
-import {StorageKeyParser} from '../storage-key-parser.js';
 import {Exists, Driver} from './driver.js';
-import {CapabilitiesResolver} from '../../capabilities-resolver.js';
 
 export interface StorageDriverProvider {
   // information on the StorageDriver and characteristics
@@ -21,11 +19,6 @@ export interface StorageDriverProvider {
 }
 
 export class DriverFactory {
-  static clearRegistrationsForTesting() {
-    this.providers = new Set();
-    StorageKeyParser.reset();
-    CapabilitiesResolver.reset();
-  }
   static providers: Set<StorageDriverProvider> = new Set();
   static async driverInstance<Data>(storageKey: StorageKey, exists: Exists) {
     for (const provider of this.providers) {

--- a/src/runtime/storage/drivers/firebase.ts
+++ b/src/runtime/storage/drivers/firebase.ts
@@ -255,7 +255,7 @@ export class FirebaseStorageKeyFactory extends StorageKeyFactory {
 // If you want to test using the firebase driver you have three options.
 // (1) for (_slow_) manual testing, call FirebaseStorageDriverProvider.register()
 // somewhere at the beginning of your test; if you want to be hermetic,
-// call DriverFactory.clearRegistrationsForTesting() at the end.
+// call Runtime.resetDrivers() at the end.
 // (2) to use a mock firebase implementation and directly test the driver,
 // construct your driver using
 // FakeFirebaseStorageDriverProvider.newDriverForTesting(key, exists);
@@ -263,4 +263,4 @@ export class FirebaseStorageKeyFactory extends StorageKeyFactory {
 // (3) you can also register the FakeFirebaseStorageDriverProvider with
 // the DriverFactory by calling FakeFirebaseStorageDriverProvider.register();
 // again your storageKey databaseURLs must be test-url and don't forget
-// to clean up with DriverFactory.clearRegistrationsForTesting().
+// to clean up with Runtime.resetDrivers().

--- a/src/runtime/storage/tests/active-store-test.ts
+++ b/src/runtime/storage/tests/active-store-test.ts
@@ -21,6 +21,7 @@ import {noAwait} from '../../../utils/lib-utils.js';
 import {StoreInfo} from '../store-info.js';
 import {ActiveStore} from '../active-store.js';
 import {DirectStorageEndpointManager} from '../direct-storage-endpoint-manager.js';
+import {Runtime} from '../../runtime.js';
 
 let testKey: StorageKey;
 
@@ -33,11 +34,11 @@ describe('Store', async () => {
 
   beforeEach(() => {
     testKey = new MockStorageKey();
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   after(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it(`will throw an exception if an appropriate driver can't be found`, async () => {

--- a/src/runtime/storage/tests/direct-store-muxer-test.ts
+++ b/src/runtime/storage/tests/direct-store-muxer-test.ts
@@ -21,7 +21,7 @@ import {DirectStore} from '../direct-store.js';
 import {StoreInfo} from '../store-info.js';
 import {StorageEndpointManager} from '../storage-manager.js';
 import {DirectStorageEndpointManager} from '../direct-storage-endpoint-manager.js';
-
+import {Runtime} from '../../runtime.js';
 
 /* eslint-disable no-async-promise-executor */
 
@@ -33,7 +33,7 @@ let storageManager: StorageEndpointManager;
 
 describe('Direct Store Muxer', async () => {
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
     DriverFactory.register(new MockStorageDriverProvider());
     storageManager = new DirectStorageEndpointManager();
   });

--- a/src/runtime/storage/tests/firebase-store-integration-test.ts
+++ b/src/runtime/storage/tests/firebase-store-integration-test.ts
@@ -29,13 +29,13 @@ async function createStore(storageKey: StorageKey, exists: Exists): Promise<Acti
 describe('Firebase + Store Integration', async () => {
   let runtime;
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
     runtime = new Runtime();
     MockFirebaseStorageDriverProvider.register(runtime.getCacheService());
   });
 
   after(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('will store a sequence of model and operation updates as models', async () => {

--- a/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
@@ -10,7 +10,7 @@
 
 import {assert} from '../../../platform/chai-web.js';
 import {ProxyMessageType, ProxyMessage} from '../store-interface.js';
-import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
+import {RamDiskStorageKey} from '../drivers/ramdisk.js';
 import {Exists} from '../drivers/driver.js';
 import {Runtime} from '../../runtime.js';
 import {DirectStoreMuxer} from '../direct-store-muxer.js';
@@ -40,8 +40,6 @@ describe('RamDisk + Direct Store Muxer Integration', async () => {
     `);
     const simpleSchema = manifest.schemas.Simple;
 
-    const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const type = new MuxType(new EntityType(simpleSchema));
     const storeInfo = new StoreInfo<MuxType<EntityType>>({

--- a/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-direct-store-muxer-integration-test.ts
@@ -9,9 +9,8 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
-import {StorageMode, ProxyMessageType, ProxyMessage} from '../store-interface.js';
+import {ProxyMessageType, ProxyMessage} from '../store-interface.js';
 import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
-import {DriverFactory} from '../drivers/driver-factory.js';
 import {Exists} from '../drivers/driver.js';
 import {Runtime} from '../../runtime.js';
 import {DirectStoreMuxer} from '../direct-store-muxer.js';
@@ -31,7 +30,7 @@ function assertHasModel(message: ProxyMessage<CRDTMuxEntity>, model: CRDTEntity<
 
 describe('RamDisk + Direct Store Muxer Integration', async () => {
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('will allow storage of a number of objects', async () => {
@@ -42,7 +41,7 @@ describe('RamDisk + Direct Store Muxer Integration', async () => {
     const simpleSchema = manifest.schemas.Simple;
 
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const type = new MuxType(new EntityType(simpleSchema));
     const storeInfo = new StoreInfo<MuxType<EntityType>>({

--- a/src/runtime/storage/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-store-integration-test.ts
@@ -11,7 +11,7 @@
 import {assert} from '../../../platform/chai-web.js';
 import {ProxyMessageType} from '../store-interface.js';
 import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../../crdt/lib-crdt.js';
-import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
+import {RamDiskStorageKey} from '../drivers/ramdisk.js';
 import {Exists} from '../drivers/driver.js';
 import {Runtime} from '../../runtime.js';
 import {CountType} from '../../../types/lib-types.js';
@@ -33,7 +33,6 @@ describe('RamDisk + Store Integration', async () => {
 
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const activeStore = await createStore(storageKey, Exists.ShouldCreate);
 
@@ -55,7 +54,6 @@ describe('RamDisk + Store Integration', async () => {
 
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);
     const activeStore2 = await createStore(storageKey, Exists.ShouldExist);
@@ -93,7 +91,6 @@ describe('RamDisk + Store Integration', async () => {
   it('will store operation updates from multiple sources with some timing delays', async () => {
     // store1.onProxyMessage, DELAY, DELAY, DELAY, store1.onProxyMessage, store2.onProxyMessage, DELAY, DELAY, DELAY, store2.onProxyMessage, DELAY, DELAY, DELAY, DELAY, DELAY
     const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);
     const activeStore2 = await createStore(storageKey, Exists.ShouldExist);

--- a/src/runtime/storage/tests/ramdisk-store-integration-test.ts
+++ b/src/runtime/storage/tests/ramdisk-store-integration-test.ts
@@ -12,7 +12,6 @@ import {assert} from '../../../platform/chai-web.js';
 import {ProxyMessageType} from '../store-interface.js';
 import {CRDTCountTypeRecord, CRDTCount, CountOpTypes} from '../../../crdt/lib-crdt.js';
 import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
-import {DriverFactory} from '../drivers/driver-factory.js';
 import {Exists} from '../drivers/driver.js';
 import {Runtime} from '../../runtime.js';
 import {CountType} from '../../../types/lib-types.js';
@@ -29,12 +28,12 @@ async function createStore(storageKey: StorageKey, exists: Exists): Promise<Acti
 describe('RamDisk + Store Integration', async () => {
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('will store a sequence of model and operation updates as models', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const activeStore = await createStore(storageKey, Exists.ShouldCreate);
 
@@ -56,7 +55,7 @@ describe('RamDisk + Store Integration', async () => {
 
   it('will store operation updates from multiple sources', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);
     const activeStore2 = await createStore(storageKey, Exists.ShouldExist);
@@ -94,7 +93,7 @@ describe('RamDisk + Store Integration', async () => {
   it('will store operation updates from multiple sources with some timing delays', async () => {
     // store1.onProxyMessage, DELAY, DELAY, DELAY, store1.onProxyMessage, store2.onProxyMessage, DELAY, DELAY, DELAY, store2.onProxyMessage, DELAY, DELAY, DELAY, DELAY, DELAY
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new RamDiskStorageKey('unique');
     const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);
     const activeStore2 = await createStore(storageKey, Exists.ShouldExist);

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -28,8 +28,6 @@ describe('ReferenceModeStore Integration', async () => {
   });
 
   it('will store and retrieve entities through referenceModeStores (separate stores)', async () => {
-    const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
@@ -64,8 +62,6 @@ describe('ReferenceModeStore Integration', async () => {
   });
 
   it('will store and retrieve entities through referenceModeStores (shared stores)', async () => {
-    const runtime = new Runtime();
-   //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
     const arc = new Runtime().newArc('testArc');
 
@@ -101,8 +97,6 @@ describe('ReferenceModeStore Integration', async () => {
   });
 
   it('will store and retrieve entities through referenceModeStores (shared proxies)', async () => {
-    const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
     const arc = new Runtime().newArc('testArc');
 
@@ -139,8 +133,6 @@ describe('ReferenceModeStore Integration', async () => {
   });
 
   it('will send an ordered list from one handle to another (separate store)', async () => {
-    const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
 
     const type = new EntityType(new Schema(['AnEntity'], {
@@ -177,8 +169,6 @@ describe('ReferenceModeStore Integration', async () => {
   });
 
   it('will send an ordered list from one handle to another (shared store)', async () => {
-    const runtime = new Runtime();
-    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
     const arc = new Runtime().newArc('testArc');
 

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -9,8 +9,7 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
-import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
-import {DriverFactory} from '../drivers/driver-factory.js';
+import {RamDiskStorageKey} from '../drivers/ramdisk.js';
 import {Runtime} from '../../runtime.js';
 import {EntityType, Schema} from '../../../types/lib-types.js';
 import {ReferenceModeStorageKey} from '../reference-mode-storage-key.js';
@@ -25,12 +24,12 @@ import {StoreInfo} from '../store-info.js';
 describe('ReferenceModeStore Integration', async () => {
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('will store and retrieve entities through referenceModeStores (separate stores)', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
@@ -66,7 +65,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will store and retrieve entities through referenceModeStores (shared stores)', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+   //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
     const arc = new Runtime().newArc('testArc');
 
@@ -103,7 +102,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will store and retrieve entities through referenceModeStores (shared proxies)', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
     const arc = new Runtime().newArc('testArc');
 
@@ -141,7 +140,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will send an ordered list from one handle to another (separate store)', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
 
     const type = new EntityType(new Schema(['AnEntity'], {
@@ -179,7 +178,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will send an ordered list from one handle to another (shared store)', async () => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
+    //RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
     const arc = new Runtime().newArc('testArc');
 

--- a/src/runtime/storage/tests/reference-mode-store-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-test.ts
@@ -9,6 +9,7 @@
  */
 
 import {assert} from '../../../platform/chai-web.js';
+import {Runtime} from '../../runtime.js';
 import {ProxyMessageType} from '../store-interface.js';
 import {DriverFactory} from '../drivers/driver-factory.js';
 import {Exists} from '../drivers/driver.js';
@@ -90,12 +91,12 @@ describe('Reference Mode Store', async () => {
     testKey = new ReferenceModeStorageKey(new MockHierarchicalStorageKey(), new MockHierarchicalStorageKey());
     storeInfo = new StoreInfo({
         storageKey: testKey, type: collectionType, exists: Exists.ShouldCreate, id: 'base-store-id'});
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
     storageManager = new DirectStorageEndpointManager();
   });
 
   after(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it(`will throw an exception if an appropriate driver can't be found`, async () => {

--- a/src/runtime/storage/tests/storage-key-test.ts
+++ b/src/runtime/storage/tests/storage-key-test.ts
@@ -14,7 +14,6 @@ import {VolatileStorageKey} from '../drivers/volatile.js';
 import {FirebaseStorageKey, FirebaseStorageDriverProvider} from '../drivers/firebase.js';
 import {RamDiskStorageKey, RamDiskStorageDriverProvider} from '../drivers/ramdisk.js';
 import {ReferenceModeStorageKey} from '../reference-mode-storage-key.js';
-import {DriverFactory} from '../drivers/driver-factory.js';
 import {Runtime} from '../../runtime.js';
 import {mockFirebaseStorageKeyOptions} from '../testing/mock-firebase.js';
 
@@ -22,12 +21,11 @@ describe('StorageKey', () => {
 
   beforeEach(() => {
     const runtime = new Runtime();
-    RamDiskStorageDriverProvider.register(runtime.getMemoryProvider());
     FirebaseStorageDriverProvider.register(runtime.getCacheService(), mockFirebaseStorageKeyOptions);
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('can round-trip VolatileStorageKey', () => {

--- a/src/runtime/storage/tests/store-sequence-test.ts
+++ b/src/runtime/storage/tests/store-sequence-test.ts
@@ -62,7 +62,7 @@ describe('Store Sequence', async () => {
   it('services a model request and applies 2 models', async () => {
     const sequenceTest = new SequenceTest<ActiveStore<CRDTCountTypeRecord>>();
     sequenceTest.setTestConstructor(async () => {
-      DriverFactory.clearRegistrationsForTesting();
+      Runtime.resetDrivers();
       DriverFactory.register(new MockStorageDriverProvider());
 
       return createStore(testKey, Exists.ShouldCreate);
@@ -127,7 +127,7 @@ describe('Store Sequence', async () => {
 
     const sequenceTest = new SequenceTest<ActiveStore<CRDTCountTypeRecord>>();
     sequenceTest.setTestConstructor(async () => {
-      DriverFactory.clearRegistrationsForTesting();
+      Runtime.resetDrivers();
       DriverFactory.register(new MockStorageDriverProvider());
 
       return createStore(testKey, Exists.ShouldCreate);
@@ -178,7 +178,7 @@ describe('Store Sequence', async () => {
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
       const arc = runtime.newArc('arc', null);
-      DriverFactory.clearRegistrationsForTesting();
+      Runtime.resetDrivers();
       VolatileStorageDriverProvider.register(arc);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);
@@ -228,7 +228,7 @@ describe('Store Sequence', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
-      DriverFactory.clearRegistrationsForTesting();
+      Runtime.resetDrivers();
       MockFirebaseStorageDriverProvider.register(runtime.getCacheService());
       const storageKey = new FirebaseStorageKey('test', 'test.domain', 'testKey', 'foo');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);
@@ -278,7 +278,7 @@ describe('Store Sequence', async () => {
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
       const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, ''));
-      DriverFactory.clearRegistrationsForTesting();
+      Runtime.resetDrivers();
       VolatileStorageDriverProvider.register(arc);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -294,7 +294,7 @@ describe('Arc', () => {
     assert.isNull(await dHandle.fetch());
   });
 
-  it('FOOBL instantiates recipes only if fate is correct', async () => {
+  it('instantiates recipes only if fate is correct', async () => {
     const loader = new Loader(null, {
       './a.js': `
         defineParticle(({Particle}) => class Noop extends Particle {});

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -205,7 +205,11 @@ describe('Arc', () => {
   });
 
   it('idle can safely be called multiple times ', async () => {
+<<<<<<< HEAD
     const runtime = new Runtime();
+=======
+    const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
+>>>>>>> dfbd89714... surgically remove static (global) runtime object
     const arc = runtime.newArc('test');
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -205,11 +205,7 @@ describe('Arc', () => {
   });
 
   it('idle can safely be called multiple times ', async () => {
-<<<<<<< HEAD
     const runtime = new Runtime();
-=======
-    const runtime = /*Runtime.newForNodeTesting()*/new Runtime();
->>>>>>> dfbd89714... surgically remove static (global) runtime object
     const arc = runtime.newArc('test');
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);

--- a/src/runtime/tests/artifacts/Products/Interests.recipes
+++ b/src/runtime/tests/artifacts/Products/Interests.recipes
@@ -11,7 +11,7 @@ import 'Product.schema'
 
 particle Interests in 'source/Interests.js'
   list: reads [Product]
-  person: reads Person
+  person: reads Person {}
   postamble: consumes? Slot
   description `find out about ${person.name}'s interests`
 

--- a/src/runtime/tests/artifacts/Products/Manufacturer.recipes
+++ b/src/runtime/tests/artifacts/Products/Manufacturer.recipes
@@ -11,7 +11,7 @@ import '../Common/Multiplexer.manifest'
 import 'Product.schema'
 
 particle ManufacturerInfo in 'source/ManufacturerInfo.js'
-  product: reads Product
+  product: reads Product {}
   annotation: consumes Slot
   description `check manufacturer information`
 

--- a/src/runtime/tests/artifacts/Products/ShowProducts.recipes
+++ b/src/runtime/tests/artifacts/Products/ShowProducts.recipes
@@ -10,7 +10,7 @@ import '../Common/List.manifest'
 import 'Product.schema'
 
 particle ShowProduct in 'source/ShowProduct.js'
-  product: reads Product {name, category, seller, price, shipDays}
+  product: reads Product 
   item: consumes Slot
 
 recipe MuxedProductItem &muxProduct

--- a/src/runtime/tests/artifacts/Products/ShowProducts.recipes
+++ b/src/runtime/tests/artifacts/Products/ShowProducts.recipes
@@ -10,7 +10,7 @@ import '../Common/List.manifest'
 import 'Product.schema'
 
 particle ShowProduct in 'source/ShowProduct.js'
-  product: reads Product 
+  product: reads Product {name, category, seller, price, shipDays}
   item: consumes Slot
 
 recipe MuxedProductItem &muxProduct

--- a/src/runtime/tests/artifacts/Products/ShowProducts.recipes
+++ b/src/runtime/tests/artifacts/Products/ShowProducts.recipes
@@ -10,7 +10,7 @@ import '../Common/List.manifest'
 import 'Product.schema'
 
 particle ShowProduct in 'source/ShowProduct.js'
-  product: reads Product
+  product: reads Product 
   item: consumes Slot
 
 recipe MuxedProductItem &muxProduct

--- a/src/runtime/tests/capabilities-resolver-test.ts
+++ b/src/runtime/tests/capabilities-resolver-test.ts
@@ -19,15 +19,14 @@ import {CapabilitiesResolver} from '../capabilities-resolver.js';
 import {ArcId} from '../id.js';
 import {Capabilities, Persistence, Ttl, Shareable, DeletePropagation} from '../capabilities.js';
 import {assertThrowsAsync} from '../../testing/test-util.js';
-import {DriverFactory} from '../storage/drivers/driver-factory.js';
+import {Runtime} from '../runtime.js';
 import {Manifest} from '../manifest.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 
 describe('Capabilities Resolver New', () => {
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
-
 
   type StorageKeyType = typeof VolatileStorageKey|typeof RamDiskStorageKey|typeof DatabaseStorageKey;
   function verifyReferenceModeStorageKey(key: StorageKey, expectedType: StorageKeyType) {
@@ -52,94 +51,65 @@ describe('Capabilities Resolver New', () => {
   it('fails creating keys with no factories', Flags.withDefaultReferenceMode(async () => {
     const resolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
     // Verify storage keys for none of the capabilities cannot be created.
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        unspecified, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        inMemory, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        inMemoryWithTtls, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        onDisk, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        onDiskWithTtl, entityType, handleId));
+    await assertThrowsAsync(async () => resolver.createStorageKey(unspecified, entityType, handleId));
+    await assertThrowsAsync(async () => resolver.createStorageKey(inMemory, entityType, handleId));
+    await assertThrowsAsync(async () => resolver.createStorageKey(inMemoryWithTtls, entityType, handleId));
+    await assertThrowsAsync(async () => resolver.createStorageKey(onDisk, entityType, handleId));
+    await assertThrowsAsync(async () => resolver.createStorageKey(onDiskWithTtl, entityType, handleId));
   }));
 
   it('creates volatile keys', Flags.withDefaultReferenceMode(async () => {
     // Register volatile storage key factory.
     // Verify only volatile (in-memory, no ttl) storage key can be created.
-    VolatileStorageKey.register();
+    //VolatileStorageKey.register();
     const resolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        unspecified, entityType, handleId), VolatileStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        inMemory, entityType, handleId), VolatileStorageKey);
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        inMemoryWithTtls, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        onDisk, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        onDiskWithTtl, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        inMemoryWithDeleteProp, entityType, handleId));
+    const createKey = resolver.createStorageKey.bind(resolver);
+    verifyReferenceModeStorageKey(await createKey(unspecified, entityType, handleId), VolatileStorageKey);
+    verifyReferenceModeStorageKey(await createKey(inMemory, entityType, handleId), VolatileStorageKey);
+    await assertThrowsAsync(async () => createKey(inMemoryWithTtls, entityType, handleId));
+    await assertThrowsAsync(async () => createKey(onDisk, entityType, handleId));
+    await assertThrowsAsync(async () => createKey(onDiskWithTtl, entityType, handleId));
+    await assertThrowsAsync(async () => createKey(inMemoryWithDeleteProp, entityType, handleId));
   }));
 
   it('creates keys with db only factories', Flags.withDefaultReferenceMode(async () => {
+    Runtime.resetDrivers(true);
     DatabaseStorageKey.register();
     const resolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        unspecified, entityType, handleId), MemoryDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        inMemory, entityType, handleId), MemoryDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        inMemoryWithTtls, entityType, handleId), MemoryDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        inMemoryWithDeleteProp, entityType, handleId), MemoryDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        onDisk, entityType, handleId), PersistentDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        onDiskWithTtl, entityType, handleId), PersistentDatabaseStorageKey);
+    const createKey = resolver.createStorageKey.bind(resolver);
+    verifyReferenceModeStorageKey(await createKey(unspecified, entityType, handleId), MemoryDatabaseStorageKey);
+    verifyReferenceModeStorageKey(await createKey(inMemory, entityType, handleId), MemoryDatabaseStorageKey);
+    verifyReferenceModeStorageKey(await createKey(inMemoryWithTtls, entityType, handleId), MemoryDatabaseStorageKey);
+    verifyReferenceModeStorageKey(await createKey(inMemoryWithDeleteProp, entityType, handleId), MemoryDatabaseStorageKey);
+    verifyReferenceModeStorageKey(await createKey(onDisk, entityType, handleId), PersistentDatabaseStorageKey);
+    verifyReferenceModeStorageKey(await createKey(onDiskWithTtl, entityType, handleId), PersistentDatabaseStorageKey);
   }));
 
   it('creates keys with volatile and db factories', Flags.withDefaultReferenceMode(async () => {
     // Register database storage key factories. Verify all storage keys created as expected.
-    VolatileStorageKey.register();
-    RamDiskStorageDriverProvider.register(new TestVolatileMemoryProvider());
+    Runtime.resetDrivers();
     DatabaseStorageKey.register();
     const resolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test')});
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        unspecified, entityType, handleId), VolatileStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        Capabilities.create([new Shareable(false)]), entityType, handleId), VolatileStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        Capabilities.create([new Shareable(true)]), entityType, handleId), RamDiskStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        inMemory, entityType, handleId), VolatileStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        inMemoryWithTtls, entityType, handleId), MemoryDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        onDisk, entityType, handleId), PersistentDatabaseStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-        onDiskWithTtl, entityType, handleId), PersistentDatabaseStorageKey);
+    const verify = async (a, b, c, d) => verifyReferenceModeStorageKey(await resolver.createStorageKey(a, b, c), d);
+    await verify(unspecified, entityType, handleId, VolatileStorageKey);
+    await verify(Capabilities.create([new Shareable(false)]), entityType, handleId, VolatileStorageKey);
+    await verify(Capabilities.create([new Shareable(true)]), entityType, handleId, RamDiskStorageKey);
+    await verify(inMemory, entityType, handleId, VolatileStorageKey);
+    await verify(inMemoryWithTtls, entityType, handleId, MemoryDatabaseStorageKey);
+    await verify(onDisk, entityType, handleId, PersistentDatabaseStorageKey);
+    await verify(onDiskWithTtl, entityType, handleId, PersistentDatabaseStorageKey);
   }));
 
   it('creates keys with custom factory', Flags.withDefaultReferenceMode(async () => {
-    // Register volatile factory, pass in-memory database in constructor.
-    VolatileStorageKey.register();
     const resolver = new CapabilitiesResolver({arcId: ArcId.newForTest('test'), factories: [new MemoryDatabaseStorageKeyFactory()]});
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-      unspecified, entityType, handleId), VolatileStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-      inMemory, entityType, handleId), VolatileStorageKey);
-    verifyReferenceModeStorageKey(await resolver.createStorageKey(
-      inMemoryWithTtls, entityType, handleId), MemoryDatabaseStorageKey);
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        onDisk, entityType, handleId));
-    await assertThrowsAsync(async () => resolver.createStorageKey(
-        onDiskWithTtl, entityType, handleId));
+    verifyReferenceModeStorageKey(await resolver.createStorageKey(unspecified, entityType, handleId), VolatileStorageKey);
+    verifyReferenceModeStorageKey(await resolver.createStorageKey(inMemory, entityType, handleId), VolatileStorageKey);
+    verifyReferenceModeStorageKey(await resolver.createStorageKey(inMemoryWithTtls, entityType, handleId), MemoryDatabaseStorageKey);
+    await assertThrowsAsync(async () => resolver.createStorageKey(onDisk, entityType, handleId));
+    await assertThrowsAsync(async () => resolver.createStorageKey(onDiskWithTtl, entityType, handleId));
   }));
 
   it('creates keys for recipe with volatile and db factories', Flags.withDefaultReferenceMode(async () => {
-    VolatileStorageKey.register();
     DatabaseStorageKey.register();
     const manifestStr = `
         recipe

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -47,25 +47,20 @@ function verifyPrimitiveType(field, type) {
 
 describe('manifest', async () => {
 
-  let memoryProvider;
+  let runtime;
   let storageManager;
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
-    memoryProvider = new TestVolatileMemoryProvider();
+    Runtime.resetDrivers();
+    runtime = new Runtime();
     storageManager = new DirectStorageEndpointManager();
-    RamDiskStorageDriverProvider.register(memoryProvider);
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
-  const parseManifest = async (content: string, options: ManifestParseOptions = {memoryProvider}): Promise<Manifest> => {
-    return Manifest.parse(content, options);
-  };
-
   it('can parse a manifest containing a recipe', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema S
         t: Text
 
@@ -113,7 +108,7 @@ describe('manifest', async () => {
     const type = manifest.recipes[0].handleConnections[0].type;
     assert.strictEqual('one-s', type.toPrettyString());
     assert.strictEqual('many-ses', type.collectionOf().toPrettyString());
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('can parse a manifest containing a particle specification', async () => {
     const schemaStr = `
@@ -121,7 +116,7 @@ schema Product
 schema Person
     `;
     const particleStr0 =
-`particle TestParticle in 'testParticle.js'
+`particle TestParticle in './testParticle.js'
   list: reads [Product {}]
   person: writes Person {}
   modality dom
@@ -137,9 +132,9 @@ schema Person
     list \`my special list\``;
 
     const particleStr1 =
-`particle NoArgsParticle in 'noArgsParticle.js'
+`particle NoArgsParticle in './noArgsParticle.js'
   modality dom`;
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
 ${schemaStr}
 ${particleStr0}
 ${particleStr1}
@@ -150,7 +145,7 @@ ${particleStr1}
       assert.strictEqual(particleStr1, manifest.particles[1].toString());
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('SLANDLES can parse a manifest containing a particle specification', async () => {
     const schemaStr = `
@@ -158,7 +153,7 @@ schema Product
 schema Person
     `;
     const particleStr0 =
-`particle TestParticle in 'testParticle.js'
+`particle TestParticle in './testParticle.js'
   list: reads [Product {}]
   person: writes Person {}
   root: \`consumes Slot {formFactor:big} #master #main
@@ -174,9 +169,9 @@ schema Person
     list \`my special list\``;
 
     const particleStr1 =
-`particle NoArgsParticle in 'noArgsParticle.js'
+`particle NoArgsParticle in './noArgsParticle.js'
   modality dom`;
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
 ${schemaStr}
 ${particleStr0}
 ${particleStr1}
@@ -187,11 +182,11 @@ ${particleStr1}
       assert.strictEqual(particleStr1, manifest.particles[1].toString());
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('can parse a manifest containing a particle with an argument list', async () => {
-    const manifest = await parseManifest(`
-    particle TestParticle in 'a.js'
+    const manifest = await runtime.parse(`
+    particle TestParticle in './a.js'
       list: reads [Product {}]
       person: writes Person {}
       thing: consumes
@@ -201,8 +196,8 @@ ${particleStr1}
     assert.lengthOf(manifest.particles[0].handleConnections, 2);
   });
   it('SLANDLES can parse a manifest containing a particle with an argument list', async () => {
-    const manifest = await parseManifest(`
-    particle TestParticle in 'a.js'
+    const manifest = await runtime.parse(`
+    particle TestParticle in './a.js'
       list: reads [Product {}]
       person: writes Person {}
       thing: \`consumes Slot
@@ -212,8 +207,8 @@ ${particleStr1}
     assert.lengthOf(manifest.particles[0].handleConnections, 4);
   });
   it('can parse a manifest with dependent handles', async () => {
-    const manifest = await parseManifest(`
-    particle TestParticle in 'a.js'
+    const manifest = await runtime.parse(`
+    particle TestParticle in './a.js'
       input: reads [Product {}]
         output: writes [Product {}]
       thing: consumes
@@ -223,8 +218,8 @@ ${particleStr1}
     assert.lengthOf(manifest.particles[0].handleConnections, 2);
   });
   it('SLANDLES can parse a manifest with dependent handles', async () => {
-    const manifest = await parseManifest(`
-    particle TestParticle in 'a.js'
+    const manifest = await runtime.parse(`
+    particle TestParticle in './a.js'
       input: reads [Product {}]
         output: writes [Product {}]
       thing: \`consumes Slot
@@ -234,58 +229,58 @@ ${particleStr1}
     assert.lengthOf(manifest.particles[0].handleConnections, 4);
   });
   it('can round-trip particles with dependent handles', async () => {
-    const manifestString = `particle TestParticle in 'a.js'
+    const manifestString = `particle TestParticle in './a.js'
   input: reads [Product {}]
     output: writes [Product {}]
   modality dom
   thing: consumes Slot
     otherThing: provides? Slot`;
 
-    const manifest = await parseManifest(manifestString);
+    const manifest = await runtime.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     assert.strictEqual(manifestString, manifest.particles[0].toString());
   });
   it('SLANDLES can round-trip particles with dependent handles', async () => {
-    const manifestString = `particle TestParticle in 'a.js'
+    const manifestString = `particle TestParticle in './a.js'
   input: reads [Product {}]
     output: writes [Product {}]
   thing: \`consumes? Slot
     otherThing: \`provides? Slot
   modality dom`;
 
-    const manifest = await parseManifest(manifestString);
+    const manifest = await runtime.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     assert.strictEqual(manifestString, manifest.particles[0].toString());
   });
   it('can parse a manifest containing a schema', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Bar
         value: Text`);
     const verify = (manifest: Manifest) => verifyPrimitiveType(manifest.schemas.Bar.fields.value, 'Text');
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('can parse a manifest containing an extended schema', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
         value: Text
       schema Bar extends Foo`);
     const verify = (manifest: Manifest) => verifyPrimitiveType(manifest.schemas.Bar.fields.value, 'Text');
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('can parse a manifest containing an inline schema', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
         value: Text
       particle Fooer
         foo: reads Foo {value}`);
     const verify = (manifest: Manifest) => verifyPrimitiveType(manifest.schemas.Foo.fields.value, 'Text');
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('can parse a manifest containing an inline schema with line breaks and a trailing comma', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle Fooer
         foo: reads Foo {
           // Comments can go here
@@ -300,7 +295,7 @@ ${particleStr1}
       verifyPrimitiveType(connectionEntity.fields.other, 'Number');
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('two manifests with stores with the same filename, store name and data have the same ids', async () => {
     const manifestText = `
@@ -315,10 +310,8 @@ ${particleStr1}
         "locations": {}
       }
     `;
-    const manifestA = await parseManifest(manifestText, {fileName: 'the.manifest', memoryProvider});
-
-    const manifestB = await parseManifest(manifestText, {fileName: 'the.manifest', memoryProvider});
-
+    const manifestA = await runtime.parse(manifestText, {fileName: 'test.arcs'});
+    const manifestB = await runtime.parse(manifestText, {fileName: 'test.arcs'});
     assert.strictEqual(manifestA.stores[0].id.toString(), manifestB.stores[0].id.toString());
   });
   it('two manifests with stores with the same filename and store name but different data have different ids', async () => {
@@ -334,14 +327,12 @@ ${particleStr1}
         "locations": {}
       }
     `;
-    const manifestA = await parseManifest(manifestText(12345), {fileName: 'the.manifest', memoryProvider});
-
-    const manifestB = await parseManifest(manifestText(67890), {fileName: 'the.manifest', memoryProvider});
-
+    const manifestA = await runtime.parse(manifestText(12345));
+    const manifestB = await runtime.parse(manifestText(67890));
     assert.notStrictEqual(manifestA.stores[0].id.toString(), manifestB.stores[0].id.toString());
   });
   it('can parse a recipe with a synthetic join handle', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       recipe
         people: map #folks
         other: map #products
@@ -362,11 +353,11 @@ ${particleStr1}
       assert.include(pairs.joinedHandles, places);
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('fails to parse a recipe with an invalid synthetic join handle', async () => {
     try {
-      await parseManifest(`
+      await runtime.parse(`
         recipe
           people: map #folks
           things: map #products
@@ -377,7 +368,7 @@ ${particleStr1}
     }
   });
   it('can resolve a recipe with a synthetic join handle', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle JoinReader
         data: reads [(
           Person {name: Text},
@@ -403,7 +394,7 @@ ${particleStr1}
     assert.isTrue(recipe.isResolved());
   });
   it('can resolve a recipe with a synthetic join handle and multiple readers', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle PeopleReader
         people: reads [Person {age: Number, name: Text}]
       particle PlaceReader
@@ -444,7 +435,7 @@ ${particleStr1}
     assert.isTrue(recipe.isResolved());
   });
   it('does not allow writing to a synthetic join handle', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle JoinReader
         data: writes [(
           Person {name: Text},
@@ -463,7 +454,7 @@ ${particleStr1}
     assert.sameMembers(errors, [`Invalid fate 'join' for handle 'pairs: join (people, places)'; it is used for 'writes' JoinReader::data connection`]);
   });
   it('supports recipes with constraints', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema S
       particle A
         a: reads S
@@ -483,10 +474,10 @@ ${particleStr1}
       assert.strictEqual(constraint.to.connection, 'b');
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('supports recipes with constraints that reference handles', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle A
         a: writes S {}
 
@@ -503,10 +494,10 @@ ${particleStr1}
       assert.strictEqual(constraint.to.handle.localName, 'localThing');
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('supports recipes with local names', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema S
       particle P1
         x: writes S
@@ -521,11 +512,11 @@ ${particleStr1}
           x: writes thingHandle
         P2
           x: writes thingHandle`);
-    const deserializedManifest = (await parseManifest(manifest.toString()));
+    const deserializedManifest = (await runtime.parse(manifest.toString()));
   });
   // TODO: move these tests to new-recipe tests.
   it('can normalize simple recipes', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema S
       particle P1
         x: writes S
@@ -550,10 +541,10 @@ ${particleStr1}
     assert.deepEqual(recipe1.toString(), recipe2.toString());
     assert.strictEqual(await recipe1.digest(), await recipe2.digest());
 
-    const deserializedManifest = await parseManifest(manifest.toString());
+    const deserializedManifest = await runtime.parse(manifest.toString());
   });
   it('can normalize recipes with interdependent ordering of handles and particles', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema S
       particle P1
         x: writes S
@@ -579,33 +570,33 @@ ${particleStr1}
     assert.deepEqual(recipe1.toString(), recipe2.toString());
   });
   it('can resolve recipe particles defined in the same manifest', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Something
       schema Someother
-      particle Thing in 'thing.js'
+      particle Thing in './thing.js'
         someThings: reads [Something]
         someOthers: writes [Someother]
       recipe
         Thing`);
     const verify = (manifest: Manifest) => assert(manifest.recipes[0].particles[0].spec);
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('treats a failed import as non-fatal', async () => { // TODO(cypher1): Review this.
     const loader = new Loader(null, {
       './a': `import 'b'`,
       './b': `lol what is this`,
     });
-    const cc = await ConCap.capture(() => Manifest.load('./a', loader, {memoryProvider}));
+    const cc = await ConCap.capture(() => runtime.parseFile('./a', {loader}));
     assert.lengthOf(cc.warn, 2);
     assert.match(cc.warn[0][0], /Parse error in '\.\/b' line 1/);
     assert.match(cc.warn[1][0], /Error importing '\.\/b'/);
   });
   it('throws an error when a particle has invalid description', async () => {
     try {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         schema Foo
-        particle Thing in 'thing.js'
+        particle Thing in './thing.js'
           foo: reads Foo
           description \`Does thing\`
             bar \`my-bar\``);
@@ -616,20 +607,20 @@ ${particleStr1}
   });
   it('can load a manifest via a loader', async () => {
     const registry: Dictionary<Promise<Manifest>> = {};
-
     const loader = new Loader(null, {
-      '*': 'recipe'});
-    const manifest = await Manifest.load('some-path', loader, {registry, memoryProvider});
+      '*': 'recipe'
+    });
+    const manifest = await runtime.parseFile('some-path', {loader, registry});
     assert(manifest.recipes[0]);
     assert.strictEqual(manifest, await registry['some-path']);
   });
   it('can load a manifest with imports', async () => {
     const registry: Dictionary<Promise<Manifest>> = {};
     const loader = new Loader(null, {
-      './a': `import 'b'`,
+      './a': `import './b'`,
       './b': `recipe`,
     });
-    const manifest = await Manifest.load('./a', loader, {registry, memoryProvider});
+    const manifest = await runtime.parseFile('./a', {loader, registry});
     assert.strictEqual(await registry['./a'], manifest);
     assert.strictEqual(manifest.imports[0], await registry['./b']);
   });
@@ -642,10 +633,10 @@ ${particleStr1}
           ParticleB`,
       './b': `
         schema Thing
-        particle ParticleB in 'b.js'
+        particle ParticleB in './b.js'
           thing: reads Thing`
     });
-    const manifest = await Manifest.load('./a', loader, {registry, memoryProvider});
+    const manifest = await runtime.parseFile('./a', {loader, registry});
     const particleLit = (await registry['./b']).findParticleByName('ParticleB').toLiteral();
     deleteFieldRecursively(particleLit, 'location');
     assert.deepEqual(
@@ -663,7 +654,7 @@ ${particleStr1}
             value: Text`
     });
     const registry = {};
-    const manifest = await Manifest.load('./a', loader, {registry, memoryProvider});
+    const manifest = await runtime.parseFile('./a', {loader, registry});
     verifyPrimitiveType(manifest.schemas.Bar.fields.value, 'Text');
   });
   it('can find all imported recipes', async () => {
@@ -677,11 +668,11 @@ ${particleStr1}
           recipe`,
       './c': `recipe`,
     });
-    const manifest = await Manifest.load('./a', loader, {memoryProvider});
+    const manifest = await runtime.parseFile('./a', {loader});
     assert.lengthOf(manifest.allRecipes, 3);
   });
   it('can parse a schema with union typing', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
         u: (Text or URL)
         test: Text
@@ -697,14 +688,14 @@ ${particleStr1}
       verifyPrimitiveType(opt.t.getFieldTypes()[2], 'Boolean');
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('generates helpful type errors in recipes', async () => {
-    const manifest = await parseManifest(`
-      particle P in 'a.js'
+    const manifest = await runtime.parse(`
+      particle P in './a.js'
         outV: writes * {name: Text, age: Number}
 
-      particle Q in 'a.js'
+      particle Q in './a.js'
         inV: reads * {first_name: Text, age: Number}
 
       recipe
@@ -721,10 +712,10 @@ ${particleStr1}
       assert.sameMembers(errors, [`Type validations failed for handle 'val: create': could not guarantee variable ~ meets read requirements * {first_name: Text, age: Number} with write guarantees * {name: Text, age: Number}`], 'expected type error');
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('parses meta namespace section', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       meta
         name: 'Awesome Arc'
         namespace: com.some.namespace
@@ -734,11 +725,11 @@ ${particleStr1}
     assert.equal(manifest.meta.namespace, 'com.some.namespace');
   });
   it('parses and type checks a recipe with nested schemas', async () => {
-    const manifest = await parseManifest(`
-      particle P in 'a.js'
+    const manifest = await runtime.parse(`
+      particle P in './a.js'
         writer: writes * {inner: inline {x: Text, y: List<Number>}, z: Text}
 
-      particle Q in 'b.js'
+      particle Q in './b.js'
         reader: reads * {inner: inline {y: List<Number>}, z: Text}
 
       recipe
@@ -753,7 +744,7 @@ ${particleStr1}
   });
   describe('refinement types', async () => {
     it('can construct manifest containing schema with refinement types', Flags.withFieldRefinementsAllowed(async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         schema Foo
           num: Number [num < 5]`);
       const verify = (manifest: Manifest) => {
@@ -766,17 +757,17 @@ ${particleStr1}
         assert.strictEqual(binaryExpression.operator.op, '<');
       };
       verify(manifest);
-      verify(await parseManifest(manifest.toString()));
+      verify(await runtime.parse(manifest.toString()));
     }));
     it('can construct manifest with particles using already defined schema (with refinements)', Flags.withFieldRefinementsAllowed(async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
       schema Person
         name: Text
         id: Text
         age: Number [age > 0]
       schema Ordered
         index: Number [index >= 0]
-      particle OrderPeople in 'OrderPeople.js'
+      particle OrderPeople in './OrderPeople.js'
         orderedPeople: writes [Ordered Person {name, id, index}]`);
       const verify = (manifest: Manifest) => {
         const entity = manifest.particles[0].handleConnectionMap.get('orderedPeople').type['collectionType'];
@@ -797,7 +788,7 @@ ${particleStr1}
       verify(manifest);
     }));
     it('can construct manifest with particles using already defined schema (with refinements and double quotes)', Flags.withFieldRefinementsAllowed(async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
       schema Person
         name: Text
         id: Text
@@ -825,7 +816,7 @@ ${particleStr1}
       verify(manifest);
     }));
     it('can construct manifest containing a particle with refinement types', Flags.withFieldRefinementsAllowed(async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
       particle Foo
         input: reads Something {value: Number [value > 0], price: Number [price > 0]} [value > 10 and price < 2]`);
       const verify = (manifest: Manifest) => {
@@ -847,7 +838,7 @@ ${particleStr1}
         assert.strictEqual(ref.expression.rightExpr.rightExpr.value, 2);
       };
       verify(manifest);
-      verify(await parseManifest(manifest.toString()));
+      verify(await runtime.parse(manifest.toString()));
     }));
 
     describe('refinement type checking', async () => {
@@ -864,7 +855,7 @@ ${particleStr1}
 
       it('checks refinement expressions with out of scope variables', Flags.withFieldRefinementsAllowed(async () => {
         assertThrowsAsync(async () => {
-          await parseManifest(`
+          await runtime.parse(`
             particle Writer
               output: writes Something {num: Number [ foo > 5 ] }
             particle Reader
@@ -879,7 +870,7 @@ ${particleStr1}
       }));
       it('checks refinement expressions with out of scope field names', Flags.withFieldRefinementsAllowed(async () => {
         assertThrowsAsync(async () => {
-          await parseManifest(`
+          await runtime.parse(`
             particle Writer
               output: writes Something {num: Number [ other_num > 5 ], other_num: Number }
             particle Reader
@@ -893,7 +884,7 @@ ${particleStr1}
         }, 'Unresolved field name \'other_num\' in the refinement expression.');
       }));
       it('checks refinement expressions', Flags.withFieldRefinementsAllowed(async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Writer
             output: writes Something {num: Number [ num > 5 ] }
           particle Reader
@@ -907,7 +898,7 @@ ${particleStr1}
         verify(manifest, true, []);
       }));
       it('checks for unsafe refinement expressions', Flags.withFieldRefinementsAllowed(async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle BadWriter
             output: writes Something {num: Number [ num > 3 ] }
           particle Reader
@@ -922,7 +913,7 @@ ${particleStr1}
         verify(manifest, false, [refinementError]);
       }));
       it('ignores impossible refinement expressions', Flags.withFlags({fieldRefinementsAllowed: true, warnOnUnsafeRefinement: true}, async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number [ (num < 3) and (num > 3) ] }
           particle Reader
@@ -938,7 +929,7 @@ ${particleStr1}
       }));
 
       it('ignores dynamic query refinement expressions on fields', Flags.withFlags({fieldRefinementsAllowed: true, warnOnUnsafeRefinement: true}, async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number [ (num > 3) ] }
           particle Reader
@@ -957,7 +948,7 @@ ${particleStr1}
       }));
 
       it('ignores dynamic query refinement expressions on fields (and warns when wall turned on', Flags.withFlags({fieldRefinementsAllowed: true, warnOnUnsafeRefinement: true}, async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number [ (num > 3) ] }
           particle Reader
@@ -976,7 +967,7 @@ ${particleStr1}
       }));
 
       it('ignores dynamic query refinement expressions', Flags.withFlags({warnOnUnsafeRefinement: true}, async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number} [ (num > 3) ]
           particle Reader
@@ -994,7 +985,7 @@ ${particleStr1}
       }));
 
       it('applies refinements', Flags.withFieldRefinementsAllowed(async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number [ (num > 3) ] }
           particle Reader
@@ -1008,7 +999,7 @@ ${particleStr1}
         verify(manifest, false, ['Type validations failed for handle \'data: create\': could not guarantee variable ~ meets read requirements Something {num: Number[(num > 5)]} with write guarantees Something {num: Number[(num > 3)]}']);
       }));
       it('ignores dynamic query refinement expressions and-ed with refinements', Flags.withFlags({fieldRefinementsAllowed: true, warnOnUnsafeRefinement: true}, async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number [ (num > 5) ] }
           particle Reader
@@ -1026,7 +1017,7 @@ ${particleStr1}
         assert.match(cc.warn[1], /Unable to ascertain if .* is at least as specific as .*/);
       }));
       it('ignores refinements or-ed with dynamic query refinement expressions', Flags.withFlags({fieldRefinementsAllowed: true, warnOnUnsafeRefinement: true}, async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number }
           particle Reader
@@ -1045,7 +1036,7 @@ ${particleStr1}
         assert.lengthOf(cc.log, 0);
       }));
       it('catches unsafe schema level refinements', Flags.withFieldRefinementsAllowed(async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number } [num > 0]
           particle Reader
@@ -1059,7 +1050,7 @@ ${particleStr1}
         verify(manifest, false, ['Type validations failed for handle \'data: create\': could not guarantee variable ~ meets read requirements Something {num: Number[(num > 3)]} with write guarantees Something {num: Number[(num > 0)]}']);
       }));
       it('allows safe schema level refinements', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle Impossible
             output: writes Something {num: Number } [num > 5]
           particle Reader
@@ -1077,7 +1068,7 @@ ${particleStr1}
 
   describe('relaxed reads and writes', async () => {
     it('can parse a manifest containing relaxed reads', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         schema Thing
         schema NotAThing
 
@@ -1138,15 +1129,15 @@ recipe SomeRecipe
     foo: writes myFoo
   PC as particle2
     foo: reads someof myFoo`;
-      const manifest = await parseManifest(manifestStr);
+      const manifest = await runtime.parse(manifestStr);
       assert.strictEqual(manifest.toString(), manifestStr, 'round trip failed');
     });
   });
 
   it('can parse a manifest containing a recipe with slots', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Thing
-      particle SomeParticle in 'some-particle.js'
+      particle SomeParticle in './some-particle.js'
         someParam: reads Thing
         mySlot: consumes Slot {formFactor: big}
           otherSlot: provides Slot {handle: someParam}
@@ -1188,12 +1179,12 @@ recipe SomeRecipe
       assert.strictEqual(mySlot.providedSlots['oneMoreSlot'], recipe.particles[0].getSlotConnectionByName('oneMoreSlot').targetSlot);
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('SLANDLES can parse a manifest containing a recipe with slots', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Thing
-      particle SomeParticle in 'some-particle.js'
+      particle SomeParticle in './some-particle.js'
         someParam: reads Thing
         mySlot: \`consumes Slot {formFactor: big}
           otherSlot: \`provides Slot {handle: someParam}
@@ -1230,13 +1221,13 @@ recipe SomeRecipe
       assert.strictEqual(mySlot.connections[0], recipe.particles[0].connections['mySlot']);
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('unnamed consume slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle &work in './some-particle.js'
         slotA: consumes
-      particle SomeParticle1 &rest in 'some-particle.js'
+      particle SomeParticle1 &rest in './some-particle.js'
         slotC: consumes
 
       recipe
@@ -1250,10 +1241,10 @@ recipe SomeRecipe
     assert.isEmpty(recipe.slots);
   });
   it('unnamed consume set slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle &work in './some-particle.js'
         slotA: consumes [Slot]
-      particle SomeParticle1 &rest in 'some-particle.js'
+      particle SomeParticle1 &rest in './some-particle.js'
         slotC: consumes [Slot]
 
       recipe
@@ -1267,10 +1258,10 @@ recipe SomeRecipe
     assert.isEmpty(recipe.slots);
   });
   it('unnamed consume set slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle &work in './some-particle.js'
         slotA: consumes [Slot]
-      particle SomeParticle1 &rest in 'some-particle.js'
+      particle SomeParticle1 &rest in './some-particle.js'
         slotC: consumes [Slot]
 
       recipe
@@ -1284,10 +1275,10 @@ recipe SomeRecipe
     assert.isEmpty(recipe.slots);
   });
   it('SLANDLES unnamed consume slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle &work in './some-particle.js'
         slotA: \`consumes Slot
-      particle SomeParticle1 &rest in 'some-particle.js'
+      particle SomeParticle1 &rest in './some-particle.js'
         slotC: \`consumes Slot
 
       recipe
@@ -1301,10 +1292,10 @@ recipe SomeRecipe
     assert.isEmpty(recipe.handles);
   });
   it('SLANDLES unnamed consume set slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle &work in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle SomeParticle1 &rest in 'some-particle.js'
+      particle SomeParticle1 &rest in './some-particle.js'
         slotC: \`consumes [Slot]
 
       recipe
@@ -1318,10 +1309,10 @@ recipe SomeRecipe
     assert.isEmpty(recipe.handles);
   });
   it('SLANDLES unnamed consume set slots', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle &work in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle &work in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle SomeParticle1 &rest in 'some-particle.js'
+      particle SomeParticle1 &rest in './some-particle.js'
         slotC: \`consumes [Slot]
 
       recipe
@@ -1336,8 +1327,8 @@ recipe SomeRecipe
   });
   it('resolves in context with multiple consumed slots', async () => {
     const parseRecipe = async (arg: {label: string, isRequiredSlotA: boolean, isRequiredSlotB: boolean, expectedIsResolved: boolean}) => {
-      const recipe = (await parseManifest(`
-        particle SomeParticle in 'some-particle.js'
+      const recipe = (await runtime.parse(`
+        particle SomeParticle in './some-particle.js'
           slotA: consumes${arg.isRequiredSlotA ? '' : '?'} Slot
           slotB: consumes${arg.isRequiredSlotB ? '' : '?'} Slot
 
@@ -1357,8 +1348,8 @@ recipe SomeRecipe
   });
   it('SLANDLES resolves in context with multiple consumed slots', async () => {
     const parseRecipe = async (arg: {label: string, isRequiredSlotA: boolean, isRequiredSlotB: boolean, expectedIsResolved: boolean}) => {
-      const recipe = (await parseManifest(`
-        particle SomeParticle in 'some-particle.js'
+      const recipe = (await runtime.parse(`
+        particle SomeParticle in './some-particle.js'
           slotA: \`consumes${arg.isRequiredSlotA ? '' : '?'} Slot
           slotB: \`consumes${arg.isRequiredSlotB ? '' : '?'} Slot
 
@@ -1378,8 +1369,8 @@ recipe SomeRecipe
   });
   it('SLANDLES resolves & consumes in context with multiple set slots', async () => {
     const parseRecipe = async (arg: {label: string, isRequiredSlotA: boolean, isRequiredSlotB: boolean, expectedIsResolved: boolean}) => {
-      const recipe = (await parseManifest(`
-        particle SomeParticle in 'some-particle.js'
+      const recipe = (await runtime.parse(`
+        particle SomeParticle in './some-particle.js'
           slotA: \`consumes${arg.isRequiredSlotA ? '' : '?'} [Slot]
           slotB: \`consumes${arg.isRequiredSlotB ? '' : '?'} [Slot]
 
@@ -1399,12 +1390,12 @@ recipe SomeRecipe
   });
 
   it('SLANDLES resolves with dependent slandles', async () => {
-    const manifest = await parseManifest(`
-      particle Parent in 'parent.js'
+    const manifest = await runtime.parse(`
+      particle Parent in './parent.js'
         root: \`consumes Slot
           mySlot: \`provides Slot
 
-      particle Child in 'child.js'
+      particle Child in './child.js'
         childSlot: \`consumes Slot
 
       recipe SlandleRenderSlotsRecipe
@@ -1424,12 +1415,12 @@ recipe SomeRecipe
   });
 
   it('SLANDLES doesn\'t resolve mismatching dependencies dependent slandles', async () => {
-    const manifest = await parseManifest(`
-      particle Parent in 'parent.js'
+    const manifest = await runtime.parse(`
+      particle Parent in './parent.js'
         root: \`consumes Slot
           mySlot: \`provides Slot
 
-      particle Child in 'child.js'
+      particle Child in './child.js'
         childSlot: \`consumes Slot
 
       recipe SlandleRenderSlotsRecipe
@@ -1448,8 +1439,8 @@ recipe SomeRecipe
   });
 
   it('recipe slots with tags', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle in './some-particle.js'
         slotA: consumes #aaa
           slotB: provides #bbb
       recipe
@@ -1481,8 +1472,8 @@ recipe SomeRecipe
     assert.lengthOf(Object.keys(slotConn.providedSlots), 1);
   });
   it('SLANDLES recipe slots with tags', async () => {
-    const manifest = await parseManifest(`
-      particle SomeParticle in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle SomeParticle in './some-particle.js'
         slotA: \`consumes Slot #aaa
           slotB: \`provides Slot #bbb
       recipe
@@ -1512,10 +1503,10 @@ recipe SomeRecipe
     assert.deepEqual(['aa', 'hello'], slotConn.tags);
   });
   it('recipe slots with different names', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: consumes
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: consumes
           slotB2: provides
       recipe
@@ -1536,10 +1527,10 @@ recipe SomeRecipe
     assert.isTrue(recipe.isResolved());
   });
   it('SLANDLES recipe slots with different names', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes Slot
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes Slot
           slotB2: \`provides Slot
       recipe
@@ -1563,10 +1554,10 @@ recipe SomeRecipe
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
   it('SLANDLES recipe set slots with different names (passing a single slot to a set slot)', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes Slot
           slotB2: \`provides Slot
       recipe
@@ -1587,10 +1578,10 @@ recipe SomeRecipe
     assert.isFalse(recipe.normalize(), 'does not normalize');
   });
   it('SLANDLES recipe set slots with different names (passing a slot as a set slot)', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes Slot
           slotB2: \`provides [Slot]
       recipe
@@ -1614,10 +1605,10 @@ recipe SomeRecipe
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
   it('SLANDLES recipe set slots with different names (passing set slots)', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes [Slot]
           slotB2: \`provides [Slot]
       recipe
@@ -1641,10 +1632,10 @@ recipe SomeRecipe
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
   it('SLANDLES recipe set slots with different names (passing a single slot to a set slot)', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes Slot
           slotB2: \`provides Slot
       recipe
@@ -1665,10 +1656,10 @@ recipe SomeRecipe
     assert.isFalse(recipe.normalize(), 'does not normalize');
   });
   it('SLANDLES recipe set slots with different names (passing a slot as a set slot)', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes Slot
           slotB2: \`provides [Slot]
       recipe
@@ -1692,10 +1683,10 @@ recipe SomeRecipe
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
   it('SLANDLES recipe set slots with different names (passing set slots)', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA: \`consumes [Slot]
-      particle ParticleB in 'some-particle.js'
+      particle ParticleB in './some-particle.js'
         slotB1: \`consumes [Slot]
           slotB2: \`provides [Slot]
       recipe
@@ -1719,8 +1710,8 @@ recipe SomeRecipe
     assert.isTrue(recipe.isResolved(options), `Expected recipe to be resolved.\n\t ${JSON.stringify([...options.errors])}`);
   });
   it('recipe provided slot with no local name', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA1: consumes
           slotA2: provides
       recipe
@@ -1738,8 +1729,8 @@ recipe SomeRecipe
     assert.isFalse(recipe.isResolved());
   });
   it('SLANDLES recipe provided slot with no local name', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA1: \`consumes Slot
           slotA2: \`provides Slot
       recipe
@@ -1768,8 +1759,8 @@ recipe SomeRecipe
     assert.isFalse(recipe.isResolved());
   });
   it('SLANDLES recipe provided set slots with no local name', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA1: \`consumes [Slot]
           slotA2: \`provides [Slot]
       recipe
@@ -1798,8 +1789,8 @@ recipe SomeRecipe
     assert.isFalse(recipe.isResolved());
   });
   it('SLANDLES recipe provided set slots with no local name', async () => {
-    const manifest = await parseManifest(`
-      particle ParticleA in 'some-particle.js'
+    const manifest = await runtime.parse(`
+      particle ParticleA in './some-particle.js'
         slotA1: \`consumes [Slot]
           slotA2: \`provides [Slot]
       recipe
@@ -1828,11 +1819,11 @@ recipe SomeRecipe
     assert.isFalse(recipe.isResolved());
   });
   it('incomplete aliasing', async () => {
-    const recipe = (await parseManifest(`
-      particle P1 in 'some-particle.js'
+    const recipe = (await runtime.parse(`
+      particle P1 in './some-particle.js'
         slotA: consumes
           slotB: provides
-      particle P2 in 'some-particle.js'
+      particle P2 in './some-particle.js'
         slotB: consumes
       recipe
         P1
@@ -1856,11 +1847,11 @@ recipe SomeRecipe
     assert.strictEqual(slotB.sourceConnection, slotConnA);
   });
   it('SLANDLES incomplete aliasing', async () => {
-    const recipe = (await parseManifest(`
-      particle P1 in 'some-particle.js'
+    const recipe = (await runtime.parse(`
+      particle P1 in './some-particle.js'
         slotA: \`consumes Slot
           slotB: \`provides Slot
-      particle P2 in 'some-particle.js'
+      particle P2 in './some-particle.js'
         slotB: \`consumes Slot
       recipe
         P1
@@ -1888,11 +1879,11 @@ recipe SomeRecipe
     assert.include(directions, '`consumes');
   });
   it('parses local slots with IDs', async () => {
-    const recipe = (await parseManifest(`
-      particle P1 in 'some-particle.js'
+    const recipe = (await runtime.parse(`
+      particle P1 in './some-particle.js'
         slotA: consumes
           slotB: provides
-      particle P2 in 'some-particle.js'
+      particle P2 in './some-particle.js'
         slotB: consumes
       recipe
         slot0: slot 'rootslot-0'
@@ -1907,11 +1898,11 @@ recipe SomeRecipe
     assert.lengthOf(recipe.slots, 2);
   });
   it('SLANDLES parses local slots with IDs', async () => {
-    const recipe = (await parseManifest(`
-      particle P1 in 'some-particle.js'
+    const recipe = (await runtime.parse(`
+      particle P1 in './some-particle.js'
         slotA: \`consumes Slot
           slotB: \`provides Slot
-      particle P2 in 'some-particle.js'
+      particle P2 in './some-particle.js'
         slotB: \`consumes Slot
       recipe
         slot0: \`slot 'rootslot-0'
@@ -1942,7 +1933,7 @@ recipe SomeRecipe
       }
     }();
 
-    await Manifest.load('./somewhere/a', loader, {registry, memoryProvider});
+    await runtime.parseFile('./somewhere/a', {loader, registry});
     assert(registry['./somewhere/a path/b']);
   });
   it('parses all particles manifests', async () => {
@@ -1985,7 +1976,7 @@ recipe SomeRecipe
     const manifestSource = `
         schema Thing
           someProp: Text
-        store Store0 of [Thing] in 'entities.json'`;
+        store Store0 of [Thing] in './entities.json'`;
     const entitySource = JSON.stringify(
       {root: {values:
         {
@@ -1997,7 +1988,7 @@ recipe SomeRecipe
       './the.manifest': manifestSource,
       './entities.json': entitySource
     });
-    const manifest = await Manifest.load('./the.manifest', loader, {memoryProvider});
+    const manifest = await runtime.parseFile('./the.manifest', {loader});
     const storageStub = manifest.findStoreByName('Store0') as StoreInfo<CollectionEntityType>;
     assert(storageStub);
     const handle = await handleForStoreInfo(storageStub, {...manifest, storageManager});
@@ -2013,20 +2004,19 @@ recipe SomeRecipe
         rawData: {someProp: 'someValue2'},
       }
     ]);
-    DriverFactory.clearRegistrationsForTesting();
   });
   it('throws an error when a store has invalid json', async () => {
     try {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
       schema Thing
       resource EntityList
         start
         this is not json?
 
-      store Store0 of [Thing] in EntityList`);
+      store Store0 of [Thing] in EntityList`, {fileName: 'foo.arcs'});
       assert(false);
     } catch (e) {
-      assert.deepEqual(e.message, `Post-parse processing error caused by <no filename> line 7.
+      assert.deepEqual(e.message, `Post-parse processing error caused by 'foo.arcs' line 7.
 Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         store Store0 of [Thing] in EntityList
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^`);
@@ -2035,7 +2025,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
   it('loads entities from a resource section', async () => {
     const now = new Date().getTime();
     const later = new Date(now + 1000).getTime();
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Thing
         someProp: Text
 
@@ -2053,7 +2043,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         }
 
       store Store0 of [Thing] in EntityList
-    `, {fileName: 'the.manifest', memoryProvider});
+    `);
     const storeInfo = manifest.findStoreByName('Store0') as StoreInfo<CollectionEntityType>;
     assert(storeInfo);
     const handle = await handleForStoreInfo(storeInfo, {...manifest, storageManager});
@@ -2070,16 +2060,15 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
         rawData: {someProp: 'someValue2'},
       }
     ]);
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('loads inline entities with primitive and reference fields', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       store X of [{n: Number, t: Text, u: URL, f: Boolean, b: Bytes, r: &{z: Text}}] with {
         {n: 0, t: '', u: '', f: false, b: ||, r: <'i1', 'reference-mode://{volatile://!1:test/backing@}{volatile://!2:test/container@}'>},
         {n: 4.5, t: 'abc', u: 'site', f: true, b: |5a, 7, d|, r: <'i2', 'reference-mode://{volatile://!3:test/backing2@}{volatile://!4:test/container2@}'>},
       }
-    `, {fileName: 'the.manifest', memoryProvider});
+    `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
     const handle = await handleForStoreInfo(store, {...manifest, storageManager});
     const entities = (await handle.toList()).map(Entity.serialize);
@@ -2095,11 +2084,10 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       n: 4.5, t: 'abc', u: 'site', f: true, b: new Uint8Array([0x5a, 0x07, 0x0d]),
       r: {id: 'i2', entityStorageKey: 'reference-mode://{volatile://!3:test/backing2@}{volatile://!4:test/container2@}', creationTimestamp: null, expirationTimestamp: null}
     });
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('loads inline entities with collection fields', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       store X of [{
         n: [Number], t: [Text], u: [URL], f: [Boolean], b: [Bytes], r: [&{z: Text}]
       }] with {
@@ -2113,7 +2101,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
             r: [<'i1', 'reference-mode://{volatile://!1:test/backing@}{volatile://!2:test/container@}'>],
         }
       }
-    `, {fileName: 'the.manifest', memoryProvider});
+    `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
     const handle = await handleForStoreInfo(store, {...manifest, storageManager});
     const entities = (await handle.toList()).map(Entity.serialize);
@@ -2132,11 +2120,10 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       b: [new Uint8Array([0x17, 0xb0]), new Uint8Array()],
       r: [{id: 'i1', entityStorageKey: 'reference-mode://{volatile://!1:test/backing@}{volatile://!2:test/container@}', creationTimestamp: null, expirationTimestamp: null}],
     });
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('loads inline entities with tuple fields', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       store X of [{
         a: (Number, Number, Bytes, URL),
         b: (Boolean, Text)
@@ -2150,7 +2137,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
           b: (true, 'xyz'),
         },
       }
-    `, {fileName: 'the.manifest', memoryProvider});
+    `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
     const handle = await handleForStoreInfo(store, {...manifest, storageManager});
     const entities = (await handle.toList()).map(Entity.serialize);
@@ -2166,18 +2153,17 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       a: [6.5, -2, new Uint8Array([0x5e, 0x06]), 'link'],
       b: [true, 'xyz'],
     });
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('loads inline entities with union fields', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       store X of [{u: (Text or Number or Boolean or Bytes)}] with {
         {u: 'str'},
         {u: 52},
         {u: true},
         {u: |1e, e7|},
       }
-    `, {fileName: 'the.manifest', memoryProvider});
+    `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
     const handle = await handleForStoreInfo(store, {...manifest, storageManager});
     const entities = (await handle.toList()).map(e => Entity.serialize(e).rawData);
@@ -2188,12 +2174,11 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       {u: true},
       {u: new Uint8Array([0x1e, 0xe7])},
     ]);
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('throws an error when inline entities do not match the store schema', async () => {
     const check = async (manifestStr, msg) => {
-      const manifest = await parseManifest(manifestStr, {fileName: 'the.manifest', memoryProvider});
+      const manifest = await runtime.parse(manifestStr);
       const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
       const handle = await handleForStoreInfo(store, {...manifest, storageManager});
       await assertThrowsAsync(async () => handle.toList(), msg);
@@ -2216,14 +2201,12 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
 
     // Incorrect field name
     await check(`store X of [{a: Text}] with { {b: 'abc'} }`, `Can't set field b; not in schema`);
-
-    DriverFactory.clearRegistrationsForTesting();
   });
 
   it('resolves store names to ids', async () => {
     const manifestSource = `
         schema Thing
-        store Store0 of [Thing] in 'entities.json'
+        store Store0 of [Thing] in './entities.json'
         recipe
           myStore: map Store0`;
     const entitySource = JSON.stringify({root: {}, locations: {}});
@@ -2231,27 +2214,25 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       './the.manifest': manifestSource,
       './entities.json': entitySource,
     });
-    const manifest = await Manifest.load('./the.manifest', loader, {memoryProvider});
+    const manifest = await runtime.parseFile('./the.manifest', {loader});
     const recipe = manifest.recipes[0];
     assert.deepEqual(recipe.toString(), `recipe\n  myStore: map '!manifest:./the.manifest:store0:${await digest(entitySource)}'`);
   });
 
   it('has prettyish syntax errors', async () => {
     try {
-      await parseManifest('recipe ?', {fileName: 'bad-file', memoryProvider});
+      await runtime.parse('recipe ?', {fileName: 'bad-file'});
       assert(false);
     } catch (e) {
-      assert.deepEqual(e.message, `Parse error in 'bad-file' line 1.
-Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found.
-  recipe ?
-         ^`);
+      const expected = 'Parse error in \'bad-file\' line 1.\nExpected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found.\n  recipe ?\n         ^';
+      assert.deepEqual(e.message, expected);
     }
   });
 
   it('errors when the manifest connects a particle incorrectly', async () => {
     const manifest = `
         schema Thing
-        particle TestParticle in 'tp.js'
+        particle TestParticle in './tp.js'
           iny: reads Thing
           outy: writes Thing
           inouty: reads writes Thing
@@ -2262,7 +2243,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
             outy: writes x
             inouty: writes x`;
     try {
-      await parseManifest(manifest);
+      await runtime.parse(manifest);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /'writes' not compatible with 'reads' param of 'TestParticle'/);
@@ -2272,7 +2253,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
   it('errors when the manifest references a missing particle param', async () => {
     const manifest = `
         schema Thing
-        particle TestParticle in 'tp.js'
+        particle TestParticle in './tp.js'
           a: reads Thing
         recipe
           x: create
@@ -2280,7 +2261,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
             a: reads x
             b: reads x`;
     try {
-      await parseManifest(manifest);
+      await runtime.parse(manifest);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /param 'b' is not defined by 'TestParticle'/);
@@ -2289,13 +2270,13 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
 
   it('errors when the manifest references a missing consumed slot', async () => {
     const manifest = `
-        particle TestParticle in 'tp.js'
+        particle TestParticle in './tp.js'
           root: consumes
         recipe
           TestParticle
             other: consumes`;
     try {
-      await parseManifest(manifest);
+      await runtime.parse(manifest);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /Consumed slot 'other' is not defined by 'TestParticle'/);
@@ -2303,13 +2284,13 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
   });
   it('SLANDLES errors when the manifest references a missing consumed slot', async () => {
     const manifest = `
-        particle TestParticle in 'tp.js'
+        particle TestParticle in './tp.js'
           root: \`consumes Slot
         recipe
           TestParticle
             other: \`consumes`;
     try {
-      await parseManifest(manifest);
+      await runtime.parse(manifest);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /param 'other' is not defined by 'TestParticle'/);
@@ -2318,7 +2299,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
 
   it('errors when the manifest references a missing provided slot', async () => {
     const manifest = `
-        particle TestParticle in 'tp.js'
+        particle TestParticle in './tp.js'
           root: consumes Slot
             action: provides Slot
         recipe
@@ -2326,7 +2307,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
             root: consumes
               noAction: provides`;
     try {
-      await parseManifest(manifest);
+      await runtime.parse(manifest);
       assert.fail('did not throw');
     } catch (e) {
       assert.match(e.message, /Provided slot 'noAction' is not defined by 'TestParticle'/);
@@ -2334,7 +2315,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
   });
   it('SLANDLES errors when the manifest references a missing provided slot', async () => {
     const manifest = `
-        particle TestParticle in 'tp.js'
+        particle TestParticle in './tp.js'
           root: \`consumes Slot
             action: \`provides Slot
         recipe
@@ -2342,7 +2323,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
             root: \`consumes
             noAction: \`provides`;
     try {
-      await parseManifest(manifest);
+      await runtime.parse(manifest);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /param 'noAction' is not defined by 'TestParticle'/);
@@ -2355,7 +2336,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
         recipe
           NoParticle.paramA: writes OtherParticle.paramB`;
     try {
-      await parseManifest(manifestFrom);
+      await runtime.parse(manifestFrom);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /could not find particle 'NoParticle'/);
@@ -2367,7 +2348,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
         recipe
           ParticleA.paramA: writes OtherParticle.paramB`;
     try {
-      await parseManifest(manifestTo);
+      await runtime.parse(manifestTo);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /could not find particle 'OtherParticle'/);
@@ -2379,7 +2360,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
         recipe
           ParticleA.paramA: writes ParticleB.paramB`;
     try {
-      await parseManifest(manifestFromParam);
+      await runtime.parse(manifestFromParam);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /'paramA' is not defined by 'ParticleA'/);
@@ -2393,7 +2374,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
         recipe
           ParticleA.paramA: writes ParticleB.paramB`;
     try {
-      await parseManifest(manifestToParam);
+      await runtime.parse(manifestToParam);
       assert.fail();
     } catch (e) {
       assert.match(e.message, /'paramB' is not defined by 'ParticleB'/);
@@ -2405,7 +2386,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
     const manifestSource = `
       recipe
         search \`Hello dear world\``;
-    let recipe = (await parseManifest(manifestSource)).recipes[0];
+    let recipe = (await runtime.parse(manifestSource)).recipes[0];
     assert.isNotNull(recipe.search);
     let search = checkNotNull(recipe.search);
     assert.strictEqual('Hello dear world', search.phrase);
@@ -2421,7 +2402,7 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
   search \`Hello dear world\`
     tokens \`dear\` \`hello\` \`world\` // unresolved search tokens`);
 
-    recipe = (await parseManifest(manifestSource)).recipes[0];
+    recipe = (await runtime.parse(manifestSource)).recipes[0];
     // resolve some tokens.
     search = checkNotNull(recipe.search);
     search.resolveToken('hello');
@@ -2449,9 +2430,9 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
   });
 
   it('merge recipes with search strings', async () => {
-    const recipe1 = (await parseManifest(`recipe
+    const recipe1 = (await runtime.parse(`recipe
   search \`Hello world\``)).recipes[0];
-    const recipe2 = (await parseManifest(`recipe
+    const recipe2 = (await runtime.parse(`recipe
   search \`good morning\`
     tokens \`morning\` // \`good\``)).recipes[0];
 
@@ -2465,10 +2446,10 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
     const loader = new Loader(null, {
       '*': '{"root": {}, "locations": {}}'
     });
-    const parseOptions = {loader, memoryProvider};
-    const manifest = await parseManifest(`
+    const parseOptions = {loader};
+    const manifest = await runtime.parse(`
   schema Product
-  store ClairesWishlist of [Product] #wishlist in 'wishlist.json'
+  store ClairesWishlist of [Product] #wishlist in './wishlist.json'
     description \`Claire's wishlist\``, parseOptions);
     const verify = (manifest: Manifest) => {
       assert.lengthOf(manifest.stores, 1);
@@ -2476,11 +2457,11 @@ Expected a verb (e.g. &Verb) or an uppercase identifier (e.g. Foo) but "?" found
     };
     verify(manifest);
     assert.strictEqual(manifest.stores[0].toManifestString(),
-                 (await parseManifest(manifest.stores[0].toManifestString(), parseOptions)).toString());
-    verify(await parseManifest(manifest.toString(), parseOptions));
+                 (await runtime.parse(manifest.stores[0].toManifestString(), parseOptions)).toString());
+    verify(await runtime.parse(manifest.toString(), parseOptions));
   });
   it('can parse a manifest containing resources', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
 resource SomeName
   start
   {'foo': 'bar'}
@@ -2489,7 +2470,7 @@ resource SomeName
     assert.deepEqual(manifest.resources['SomeName'], `{'foo': 'bar'}\nhello\n`);
   });
   it('can parse a manifest containing incomplete interfaces', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
       interface FullInterface
         foo: reads Foo
@@ -2518,7 +2499,7 @@ resource SomeName
     assert(manifest.findInterfaceByName('FullInterface'));
   });
   it('can parse a manifest containing interfaces', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
       interface Bar
         foo: reads Foo
@@ -2532,7 +2513,7 @@ resource SomeName
     assert(manifest.recipes[0].normalize());
   });
   it('can parse a manifest containing a warning', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
         value: Text
       particle Particle
@@ -2541,7 +2522,7 @@ resource SomeName
     assert.lengthOf(manifest.allParticles, 1);
   });
   it('can parse interfaces using new-style body syntax', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
       interface Bar
         foo: reads Foo
@@ -2556,9 +2537,9 @@ resource SomeName
     assert(manifest.recipes[0].normalize());
   });
   it('can resolve optional handles', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Something
-      particle Thing in 'thing.js'
+      particle Thing in './thing.js'
         inThing: reads [Something]
         maybeOutThings: writes? [Something]
       recipe
@@ -2574,10 +2555,10 @@ resource SomeName
       assert.isTrue(recipe.isResolved());
     };
     verify(manifest);
-    verify(await parseManifest(manifest.toString()));
+    verify(await runtime.parse(manifest.toString()));
   });
   it('can resolve an immediate handle specified by a particle target', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema S
       interface HostedInterface
         foo: reads S
@@ -2597,7 +2578,7 @@ resource SomeName
     assert(recipe.isResolved());
   });
   it('can resolve a particle with an inline schema', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle P
         foo: reads * {value: Text}
       recipe
@@ -2610,7 +2591,7 @@ resource SomeName
     assert(recipe.isResolved());
   });
   it('can resolve a particle with a schema reference', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
         far: Text
       particle P
@@ -2634,7 +2615,7 @@ resource SomeName
   modality dom`);
   });
   it('can resolve a particle with an inline schema reference', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
       particle P
         bar: reads Bar {foo: &Foo {far: Text}}
@@ -2657,7 +2638,7 @@ resource SomeName
   modality dom`);
   });
   it('can resolve a particle with a collection of schema references', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Foo
         far: Text
       particle P
@@ -2681,7 +2662,7 @@ resource SomeName
   modality dom`);
   });
   it('can resolve a particle with a collection of inline schema references', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle P
         bar: reads Bar {foo: [&Foo {far: Text}]}
       recipe
@@ -2703,7 +2684,7 @@ resource SomeName
   modality dom`);
   });
   it('can resolve inline schemas against out of line schemas', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema T
         value: Text
       particle P
@@ -2723,7 +2704,7 @@ resource SomeName
     assert(validRecipe.isResolved());
   });
   it('can resolve handle types from inline schemas', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle P
         foo: reads * {value: Text}
       particle P2
@@ -2771,7 +2752,7 @@ resource SomeName
   });
 
   it('can infer field types of inline schemas from external schemas', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Thing
         value: Text
       particle P
@@ -2792,7 +2773,7 @@ resource SomeName
   });
 
   it('supports inline schemas with multiple names', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Thing1
         value1: Text
       schema Thing2
@@ -2821,7 +2802,7 @@ resource SomeName
     FirebaseStorageDriverProvider.register(
         new Runtime().getCacheService(),
         mockFirebaseStorageKeyOptions);
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Bar
         value: Text
 
@@ -2839,12 +2820,11 @@ resource SomeName
     assert.isTrue(validRecipe.normalize());
     assert.isTrue(validRecipe.isResolved());
     assert.strictEqual(manifest.stores[0].toManifestString(),
-                 (await parseManifest(manifest.stores[0].toManifestString())).toString());
-    DriverFactory.clearRegistrationsForTesting();
+                 (await runtime.parse(manifest.stores[0].toManifestString())).toString());
   });
 
   it('can process a schema alias', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       alias schema This That as SchemaAlias
       alias schema * extends SchemaAlias as Extended
     `);
@@ -2853,12 +2833,12 @@ resource SomeName
   });
 
   it('expands schema aliases', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       alias schema Name1 as Thing1
         field1: Text
       alias schema Name2 as Thing2
         field2: Text
-      particle P in 'p.js'
+      particle P in './p.js'
         param: reads Thing1 Thing2 Name3 {field1: Text, field3: Text}
     `);
     const paramSchema = checkNotNull(manifest.findParticleByName('P').inputs[0].type.getEntitySchema());
@@ -2868,12 +2848,12 @@ resource SomeName
 
   it('fails when expanding conflicting schema aliases', async () => {
     try {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         alias schema Name1 as Thing1
           field1: Text
         alias schema Name2 as Thing2
           field1: Number
-        particle P in 'p.js'
+        particle P in './p.js'
           param: reads Thing1 Thing2 {}
       `);
       assert.fail();
@@ -2884,10 +2864,10 @@ resource SomeName
 
   it('fails when inline schema specifies a field type that does not match alias expansion', async () => {
     try {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         alias schema Name1 as Thing1
           field1: Text
-        particle P in 'p.js'
+        particle P in './p.js'
           param: reads Thing1 {field1: Number}
       `);
       assert.fail();
@@ -2898,7 +2878,7 @@ resource SomeName
 
   it('can relate inline schemas to generic connections', async () => {
     const data = '{"root": {}, "locations": {}}';
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Thing
         value: Text
         num: Number
@@ -2926,7 +2906,7 @@ resource SomeName
   });
 
   it('can parse a recipe with slot constraints on verbs', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       recipe
         &verb
           consumeSlot: consumes
@@ -2944,7 +2924,7 @@ resource SomeName
   });
 
   it('SLANDLES can parse a recipe with slot constraints on verbs', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       recipe
         provideSlot: \`slot
         &verb
@@ -2965,11 +2945,11 @@ resource SomeName
   });
 
   it('can parse particle arguments with tags', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       schema Dog
       schema Sled
       schema DogSled
-      particle DogSledMaker in 'thing.js'
+      particle DogSledMaker in './thing.js'
         leader: reads Dog #leader
         team: reads [Dog]
         sled: reads Sled #dogsled
@@ -2994,7 +2974,7 @@ resource SomeName
   });
 
   it('can parse a particle with tuples', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle P
         foo: reads [(
           &Bar {photo: URL},
@@ -3013,32 +2993,32 @@ resource SomeName
   });
 
   it('can round-trip particles with tags', async () => {
-    const manifestString = `particle TestParticle in 'a.js'
+    const manifestString = `particle TestParticle in './a.js'
   input: reads [Product {}]
     output: writes [Product {}]
   modality dom
   thing: consumes Slot #main #tagname
     otherThing: provides Slot #testtag`;
 
-    const manifest = await parseManifest(manifestString);
+    const manifest = await runtime.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     assert.strictEqual(manifestString, manifest.particles[0].toString());
   });
 
   it('SLANDLES can round-trip particles with tags', async () => {
-    const manifestString = `particle TestParticle in 'a.js'
+    const manifestString = `particle TestParticle in './a.js'
   input: reads [Product {}]
     output: writes [Product {}]
   thing: \`consumes Slot {formFactor:big} #main #tagname
     otherThing: \`provides Slot {handle:thingy} #testtag
   modality dom`;
 
-    const manifest = await parseManifest(manifestString);
+    const manifest = await runtime.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     assert.strictEqual(manifestString, manifest.particles[0].toString());
   });
   it('SLANDLES can round-trip particles with fields', async () => {
-    const manifestString = `particle TestParticle in 'a.js'
+    const manifestString = `particle TestParticle in './a.js'
   input: reads [Product {}]
     output: writes [Product {}]
   thingy: reads ~a
@@ -3046,13 +3026,13 @@ resource SomeName
     otherThing: \`provides Slot {handle:thingy} #testtag
   modality dom`;
 
-    const manifest = await parseManifest(manifestString);
+    const manifest = await runtime.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     assert.strictEqual(manifestString, manifest.particles[0].toString());
   });
 
   it('can parse recipes with an implicit create handle', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle A
         a: writes S {}
       particle B
@@ -3070,7 +3050,7 @@ resource SomeName
   });
 
   it('can parse recipes with a require section', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle P1
         a: writes S {}
         root: consumes
@@ -3097,7 +3077,7 @@ resource SomeName
   });
 
   it('recipe resolution checks the require sections', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
 
       particle A
         input: reads S {}
@@ -3116,7 +3096,7 @@ resource SomeName
 
   describe('trust claims and checks', () => {
     it('supports multiple claim statements', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           output1: writes T {}
           output2: writes T {}
@@ -3138,7 +3118,7 @@ resource SomeName
     });
 
     it('supports field-level claim statements', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           output1: writes T {aaa: Text, bbb: Number}
           output2: writes T {ccc: Text, ddd: &Foo {eee: Number}}
@@ -3177,7 +3157,7 @@ resource SomeName
     });
 
     it('supports field-level claim statements involving collections', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           output1: writes [T {aaa: Text, bbb: [Number]}]
           output2: writes [T {ccc: [&Foo {ddd: [Number]}]}]
@@ -3211,19 +3191,19 @@ resource SomeName
     });
 
     it('rejects invalid fields in field-level claims', async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           output: writes T {foo: Text}
           claim output.bar is something
       `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           output: writes T {foo: &Bar {bar: Number}}
           claim output.foo.baz is something
       `), `Schema 'Bar {bar: Number}' does not contain field 'baz'.`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           output: writes [T {foo: [&Bar {bar: Number}]}]
           claim output.foo.bar.baz is something
@@ -3231,7 +3211,7 @@ resource SomeName
     });
 
     it('supports claim statement with multiple tags', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           output1: writes T {}
           claim output1 is property1 and is property2
@@ -3247,7 +3227,7 @@ resource SomeName
     });
 
     it('supports "is not" tag claims', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           output1: writes T {}
           output2: writes T {}
@@ -3265,7 +3245,7 @@ resource SomeName
      });
 
     it('supports "derives from" claims with multiple parents', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {}
           input2: reads T {}
@@ -3283,7 +3263,7 @@ resource SomeName
     });
 
     it('supports field-level "derives from" claims', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads T {foo: Text}
           output: writes T {bar: Text}
@@ -3304,7 +3284,7 @@ resource SomeName
     });
 
     it('rejects invalid fields in field-level "derives from" claims', async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: writes T {foo: Text}
           output: writes T {foo: Text}
@@ -3313,7 +3293,7 @@ resource SomeName
     });
 
     it('supports mixed claims with multiple tags, not tags, and "derives from"', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {}
           input2: reads T {}
@@ -3339,7 +3319,7 @@ resource SomeName
     });
 
     it('supports multiple check statements', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {}
           input2: reads T {}
@@ -3365,7 +3345,7 @@ resource SomeName
     });
 
     it('supports checks and claims with labels starting with "not"', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {}
           input2: reads T {}
@@ -3398,7 +3378,7 @@ resource SomeName
     });
 
     it('supports field-level check statements', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {aaa: Text, bbb: Number}
           input2: reads T {ccc: Text, ddd: &Foo {eee: Number}}
@@ -3441,19 +3421,19 @@ resource SomeName
     });
 
     it('rejects invalid fields in field-level checks', async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads T {foo: Text}
           check input.bar is something
       `), `Schema 'T {foo: Text}' does not contain field 'bar'.`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads T {foo: &Bar {bar: Number}}
           check input.foo.baz is something
       `), `Schema 'Bar {bar: Number}' does not contain field 'baz'.`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads [T {foo: [&Bar {bar: Number}]}]
           check input.foo.bar.baz is something
@@ -3461,7 +3441,7 @@ resource SomeName
     });
 
     it(`supports 'is from store' checks`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {}
           input2: reads T {}
@@ -3485,7 +3465,7 @@ resource SomeName
     });
 
     it(`supports 'is from output' checks`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input1: reads T {}
           input2: reads T {}
@@ -3510,7 +3490,7 @@ resource SomeName
     });
 
     it('supports checks on provided slots', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           root: consumes
             mySlot: provides
@@ -3530,7 +3510,7 @@ resource SomeName
     });
 
     it(`supports checks with the 'or' operation`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads T {}
           check input is property1 or is not property2 or is property3
@@ -3551,7 +3531,7 @@ resource SomeName
     });
 
     it(`supports checks with the 'and' operation`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads T {}
           check input is property1 and is not property2 and is property3
@@ -3572,7 +3552,7 @@ resource SomeName
     });
 
     it(`supports arbitrary nesting of 'and' and 'or' operations and conditions`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads T {}
           check input (is property1 and ((is not property2))) or ((is property2) or is not property3)
@@ -3600,7 +3580,7 @@ resource SomeName
     });
 
     it(`supports checks with the implication operator`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads T {}
           check input (is property1 => is property2)
@@ -3622,7 +3602,7 @@ resource SomeName
     });
 
     it(`supports checks with complex nesting of implications`, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads T {}
           check input ((is property1 and is not property2) => (is property3 => (is not property4 or is property5))) or is property6
@@ -3657,7 +3637,7 @@ resource SomeName
     });
 
     it('supports field-level checks and claims with type variables', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle A
           input: reads [~a with {foo: Number}]
           output: writes [~a]
@@ -3679,7 +3659,7 @@ resource SomeName
     });
 
     it('parses max type variables into the appropriate data structure', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle Foo
           data: reads ~a with {age: Number, *}
 
@@ -3709,7 +3689,7 @@ resource SomeName
     });
 
     it('supports field-level checks and claims with resolved type variables', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle OrderIngestion in '.OrderIngestion'
           data: writes [Product {sku: Text, name: Text, price: Number}]
 
@@ -3759,19 +3739,19 @@ resource SomeName
     });
 
     it('rejects unknown fields in type variables', async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads ~a
           check input.foo is trusted
       `), `Type variable ~a does not contain field 'foo'`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           output: writes ~a
           claim output.foo is trusted
       `), `Type variable ~a does not contain field 'foo'`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads ~a
           output: writes Result {foo: Text}
@@ -3780,26 +3760,26 @@ resource SomeName
     });
 
     it('fails to parse concrete types with inline schema field of `*`', async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
           particle Foo
             data: reads {*}
-      `), `\
-Post-parse processing error caused by <no filename> line 3.
+      `, {fileName: 'test.arcs'}), `\
+Post-parse processing error caused by 'test.arcs' line 3.
 Only type variables may have '*' fields.
               data: reads {*}
                           ^^^`);
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
           particle Foo
             data: reads {name: Text, *}
-      `), `\
-Post-parse processing error caused by <no filename> line 3.
+      `, {fileName: 'test.arcs'}), `\
+Post-parse processing error caused by 'test.arcs' line 3.
 Only type variables may have '*' fields.
               data: reads {name: Text, *}
                           ^^^^^^^^^^^^^^^`);
     });
 
     it('warns about using multiple `*` in a single variable constraint', async () => {
-      const cc = await ConCap.capture(() => parseManifest(`
+      const cc = await ConCap.capture(() => runtime.parse(`
           particle Foo
             data: reads ~a with {*, *}
       `));
@@ -3810,7 +3790,7 @@ Only type variables may have '*' fields.
     });
 
     it('supports field-level checks and claims with max type variables', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         particle SkuRedactor in '.SkuRedactor'
           input: reads [~a with {sku: Text, *}]
           output: writes [~a]
@@ -3831,7 +3811,7 @@ Only type variables may have '*' fields.
     it('data stores can make claims', async () => {
       const data = '{"root": {}, "locations": {}}';
 
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         store NobId of NobIdStore {nobId: Text} in NobIdJson
           claim is property1 and is property2
         resource NobIdJson
@@ -3852,7 +3832,7 @@ Only type variables may have '*' fields.
     it('data stores can make field-level claims', async () => {
       const data = '{"root": {}, "locations": {}}';
 
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         store NobId of NobIdStore {nobId: Text, someRef: [&Foo {foo: [Text]}]} in NobIdJson
           claim field nobId is property1 and is property2
           claim field someRef.foo is property3
@@ -3880,7 +3860,7 @@ Only type variables may have '*' fields.
     it('rejects invalid fields in field-level claims on stores', async () => {
       const data = '{"root": {}, "locations": {}}';
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         store NobId of NobIdStore {nobId: Text} in NobIdJson
           claim field foo is property1 and is property2
         resource NobIdJson
@@ -3888,7 +3868,7 @@ Only type variables may have '*' fields.
           ${data}
       `), `Schema 'NobIdStore {nobId: Text}' does not contain field 'foo'.`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         store NobId of NobIdStore {nobId: Text, someRef: [&Foo {foo: [Text]}]} in NobIdJson
           claim field someRef.bar is property1 and is property2
         resource NobIdJson
@@ -3898,7 +3878,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow mixing 'and' and 'or' operations without nesting`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads T {}
           check input is property1 or is property2 and is property3
@@ -3906,7 +3886,7 @@ Only type variables may have '*' fields.
     });
 
     it('SLANDLES can round-trip particles with checks and claims', async () => {
-      const manifestString = `particle TestParticle in 'a.js'
+      const manifestString = `particle TestParticle in './a.js'
   input1: reads T {}
   input2: reads T {}
   input3: reads T {}
@@ -3934,11 +3914,11 @@ Only type variables may have '*' fields.
   check childSlot is not somewhatTrusted
   modality dom`;
 
-      const manifest = await parseManifest(manifestString);
+      const manifest = await runtime.parse(manifestString);
       assert.strictEqual(manifest.toString(), manifestString);
     });
     it('can round-trip particles with checks and claims', async () => {
-      const manifestString = `particle TestParticle in 'a.js'
+      const manifestString = `particle TestParticle in './a.js'
   input1: reads T {}
   input2: reads T {}
   input3: reads T {}
@@ -3966,18 +3946,18 @@ Only type variables may have '*' fields.
   parentSlot: consumes Slot
     childSlot: provides Slot`;
 
-      const manifest = await parseManifest(manifestString);
+      const manifest = await runtime.parse(manifestString);
       assert.strictEqual(manifest.toString(), manifestString);
    });
 
     it('fails for unknown handle names', async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           output: writes T {}
           claim oops is trusted
       `), `Can't make a claim on unknown handle oops`);
 
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           input: reads T {}
           check oops is trusted
@@ -3985,7 +3965,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow claims on inputs`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           foo: reads T {}
           claim foo is trusted
@@ -3993,7 +3973,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on outputs`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           foo: writes T {}
           check foo is trusted
@@ -4001,7 +3981,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different claims for the same handle`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           foo: writes T {}
           claim foo is trusted
@@ -4010,7 +3990,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different claims for the same field`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           foo: writes T {bar: Text}
           claim foo.bar is trusted
@@ -4019,7 +3999,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different checks for the same handle`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           foo: reads T {}
           check foo is trusted
@@ -4028,7 +4008,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple different checks for the same field`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           foo: reads T {bar: Text}
           check foo.bar is trusted
@@ -4037,7 +4017,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on consumed slots`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           someOtherSlot: consumes
             mySlot: provides
@@ -4046,7 +4026,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on unknown slots`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           someOtherSlot: consumes
             mySlot: provides
@@ -4055,7 +4035,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow multiple provided slots with the same name`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           firstSlot: consumes
             mySlot: provides
@@ -4065,7 +4045,7 @@ Only type variables may have '*' fields.
     });
 
     it(`doesn't allow checks on fields in slots`, async () => {
-      await assertThrowsAsync(async () => parseManifest(`
+      await assertThrowsAsync(async () => runtime.parse(`
         particle A
           someOtherSlot: consumes
             mySlot: provides
@@ -4077,12 +4057,12 @@ Only type variables may have '*' fields.
   describe('all schemas', () => {
     describe('handles manifests with no schemas', () => {
       it('handles an empty manifest', async () => {
-        const emptyManifest = await parseManifest(``);
+        const emptyManifest = await runtime.parse(``);
         const emptyResult = emptyManifest.allSchemas;
         assert.isEmpty(emptyResult);
       });
       it('handles a non-empty manifest', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           particle A
           recipe Foo
             A
@@ -4093,7 +4073,7 @@ Only type variables may have '*' fields.
     });
     describe('handles manifests with simple schemas', () => {
       it('handles a schema with no fields', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           schema Foo
           particle Bar
             recipe Food
@@ -4107,7 +4087,7 @@ Only type variables may have '*' fields.
 
       });
       it('handles a schema with fields', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
         schema Foo
           a: Text
           b: Number
@@ -4125,7 +4105,7 @@ Only type variables may have '*' fields.
         assert.deepEqual(result[0].names, ['Foo']);
       });
       it('handles schemas with no fields', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           schema Foo
           schema Boo
           schema Roo
@@ -4140,7 +4120,7 @@ Only type variables may have '*' fields.
         assert.isEmpty(result[2].fields);
       });
       it('handles multiple schemas with fields', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
         schema Foo
           a: Text
         schema Boo
@@ -4181,7 +4161,7 @@ Only type variables may have '*' fields.
         assert.isDefined(result[3].fields.f);
       });
       it('handles out of order schemas declarations', async () => {
-        const manifest = await parseManifest(`
+        const manifest = await runtime.parse(`
           schema Baz
             t: Text
           schema Foo
@@ -4226,7 +4206,7 @@ Only type variables may have '*' fields.
           './a': manifestStr,
           './b': jsonStr,
         });
-        const manifest = await Manifest.load('./a', loader, {memoryProvider});
+        const manifest = await runtime.parseFile('./a', {loader});
         const result = manifest.allSchemas;
         assert.lengthOf(result, 1);
         assert.lengthOf(result[0].names, 1);
@@ -4300,7 +4280,7 @@ Only type variables may have '*' fields.
           './a': manifestStr,
           './b': jsonStr,
         });
-        const manifest = await Manifest.load('./a', loader, {memoryProvider});
+        const manifest = await runtime.parseFile('./a', {loader});
         const result = manifest.allSchemas;
         assert.equal(result.length, 2);
 
@@ -4320,7 +4300,7 @@ Only type variables may have '*' fields.
       });
     });
     it('handles out of order schemas declarations', async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         schema Baz
           t: Text
         schema Foo
@@ -4339,7 +4319,7 @@ Only type variables may have '*' fields.
     });
     it('catches unsupported recursive schemas declarations', Flags.withFlags({recursiveSchemasAllowed: false}, async () => {
       assertThrowsAsync(async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         schema Baz
           t: Text
           bar: &Bar
@@ -4360,7 +4340,7 @@ Only type variables may have '*' fields.
       });
     }));
     it('handles recursive schemas declarations', Flags.withFlags({recursiveSchemasAllowed: true}, async () => {
-      const manifest = await parseManifest(`
+      const manifest = await runtime.parse(`
         schema Baz
           t: Text
           bar: &Bar
@@ -4381,7 +4361,7 @@ Only type variables may have '*' fields.
     }));
 });
   it('warns about using external schemas', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
 schema Thing
   value: Text
 
@@ -4397,7 +4377,7 @@ particle A
   input: reads [Product {}]
   modality dom`;
 
-    const manifest = await parseManifest(manifestString);
+    const manifest = await runtime.parse(manifestString);
     assert.lengthOf(manifest.particles, 1);
     const particle = manifest.particles[0];
     assert.isTrue(particle.external);
@@ -4405,14 +4385,14 @@ particle A
     assert.strictEqual(manifestString, particle.toString());
   });
   it('parses JVM class path', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       particle Particle in 'com.wow.Particle'
     `);
 
     assert.equal(manifest.particles[0].implFile, 'com.wow.Particle');
   });
   it('derives JVM class path from namespace', async () => {
-    const manifest = await parseManifest(`
+    const manifest = await runtime.parse(`
       meta
         namespace: com.wow
       particle Particle in '.Particle'
@@ -4425,7 +4405,7 @@ particle A
     ]);
   });
   it('derives JVM implFile from namespace across imports', async () => {
-    const manifest = await Manifest.load('/c.arcs', new Loader(null, {
+    const staticFiles = {
       '/a.arcs': `
         meta
           namespace: com.wow
@@ -4441,11 +4421,10 @@ particle A
           namespace: com.abc
         import './a.arcs'
         import './b.arcs'
-
         particle Boom in '.Boom'
-      `,
-    }));
-
+      `
+    };
+    const manifest = await runtime.parseFile('/c.arcs', {loader: new Loader(null, staticFiles)});
     assert.sameMembers(manifest.allParticles.map(p => p.implFile), [
       'com.abc.Boom',
       'com.wow.Wow',
@@ -4455,11 +4434,9 @@ particle A
 });
 
 describe('Manifest storage migration', () => {
-  let memoryProvider;
-  beforeEach(() => { memoryProvider = new TestVolatileMemoryProvider(); });
 
   it('inflates into RamDisk', async () => {
-    const manifest = await Manifest.parse(`
+    const manifest = await new Runtime().parse(`
 store NobId of NobIdStore {nobId: Text} in NobIdJson
 resource NobIdJson
   start
@@ -4472,7 +4449,7 @@ resource NobIdJson
     },
     "locations": {}
   }
-`, {memoryProvider});
+`);
     assert.lengthOf(manifest.stores, 1);
     const store = manifest.stores[0];
 
@@ -4484,17 +4461,15 @@ resource NobIdJson
   });
 });
 describe('annotations', async () => {
-  let memoryProvider;
   const loader = new Loader(null, {
     '*': '{"root": {}, "locations": {}}'
   });
+  const runtime = new Runtime();
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
-    memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
+    Runtime.resetDrivers();
   });
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   it('parses annotations', async () => {
@@ -4527,7 +4502,8 @@ recipe One
 recipe Two
 @goodForAll
 recipe Three`;
-    const manifest = await Manifest.parse(manifestStr);
+    const runtime = new Runtime({loader});
+    const manifest = await runtime.parse(manifestStr);
     assert.equal(Object.keys(manifest.annotations).length, 4);
     assert.sameMembers(Object.keys(manifest.annotations), ['noParam', 'oneParam', 'multiParam', 'goodForAll']);
     const noParam = manifest.annotations['noParam'];
@@ -4569,7 +4545,7 @@ recipe Three`;
     `), `annotation not found: 'nonexistent'`);
   });
   it('throws when wrong annotation target', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
         annotation noParam
           retention: Source
           targets: [Particle]
@@ -4584,24 +4560,24 @@ annotation oneParam(foo: Text)
   retention: Source
   doc: 'doc'`;
   it('throws when wrong annotation param', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
 ${oneParamAnnotation}
 @oneParam(wrong: 'hello')
 recipe
     `), `unexpected annotation param: 'wrong'`);
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: 'hello', wrong: 'world')
 recipe
     `), `unexpected annotation param: 'wrong'`);
   });
   it('throws when annotation param value of incorrect type', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: 5)
 recipe
     `), `expected 'Text' for param 'foo', instead got 5`);
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
 ${oneParamAnnotation}
 @oneParam(foo: false)
 recipe
@@ -4626,7 +4602,7 @@ recipe
 ${oneParamAnnotation}
 @oneParam(foo: 'hello')
 recipe`;
-    const manifest = await Manifest.parse(manifestStr);
+    const manifest = await runtime.parse(manifestStr);
     const recipe = manifest.recipes[0];
     assert.lengthOf(recipe.annotations, 1);
     assert.equal(recipe.annotations[0].name, 'oneParam');
@@ -4640,7 +4616,7 @@ recipe`;
 ${oneParamAnnotation}
 @oneParam
 recipe`;
-    const manifest = await Manifest.parse(manifestStr);
+    const manifest = await runtime.parse(manifestStr);
     const recipe = manifest.recipes[0];
     assert.lengthOf(recipe.annotations, 1);
     assert.equal(recipe.annotations[0].name, 'oneParam');
@@ -4664,7 +4640,7 @@ particle Fooer
   foos4: writes [Foo {value: Text}]
   modality dom
 `;
-    const manifest = await Manifest.parse(manifestStr);
+    const manifest = await runtime.parse(manifestStr);
     const particle = manifest.particles[0];
     assert.lengthOf(particle.handleConnections, 4);
     assert.lengthOf(particle.getConnectionByName('foos1').annotations, 1);
@@ -4678,7 +4654,7 @@ particle Fooer
     assert.equal(manifest.toString(), manifestStr.trim());
   });
   it('fails schema annotations with wrong target', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
       annotation foo(bar: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4698,7 +4674,7 @@ annotation foo(bar: Text, baz: Number)
 schema Foo
   value: Text
     `;
-    const manifest = await Manifest.parse(manifestStr);
+    const manifest = await runtime.parse(manifestStr);
     const schema = manifest.schemas['Foo'];
     assert.lengthOf(schema.annotations, 1);
     assert.isUndefined(schema.annotations[0].params['bar']);
@@ -4717,9 +4693,9 @@ annotation baz(qux: Number)
   doc: 'a'
 @foo(bar: 'hello')
 @baz(qux: 123)
-store Store0 of [Thing {blah: Text}] 'my-things' in 'Things.json'
+store Store0 of [Thing {blah: Text}] 'my-things' in './Things.json'
     `;
-    const manifest = await Manifest.parse(manifestStr, {loader, memoryProvider});
+    const manifest = await runtime.parse(manifestStr, {loader});
     const annotations = manifest.stores[0].annotations;
     assert.lengthOf(annotations, 2);
     assert.equal(annotations.find(a => a.name === 'foo').params['bar'], 'hello');
@@ -4727,7 +4703,7 @@ store Store0 of [Thing {blah: Text}] 'my-things' in 'Things.json'
     assert.equal(manifest.toString(), manifestStr.trim());
   });
   it('parses recipe handle annotations', async () => {
-    const manifest = await Manifest.parse(`
+    const manifest = await runtime.parse(`
 annotation hello(world: Text)
   targets: [Handle, Store]
   retention: Source
@@ -4742,7 +4718,7 @@ recipe
     assert.lengthOf(quzHandle.annotations, 3);
   });
   it('parses annotation with single param and simple value', async () => {
-    const connection = (await Manifest.parse(`
+    const connection = (await runtime.parse(`
       annotation hello(txt: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4758,7 +4734,7 @@ recipe
     assert.equal(connection.getAnnotation('world').params['txt'], 'bye');
   });
   it('fails parsing annotation simple value when multiple params', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
       annotation hello(txt1: Text, txt2: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4767,7 +4743,7 @@ recipe
         foo: reads [* {bar: Text}] @hello('hi')`), `annotation 'hello' has unexpected unnamed param 'hi'`);
   });
   it('fails parsing annotation simple value when wrong type', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
       annotation hello(txt: Text)
         targets: [Handle, HandleConnection]
         retention: Source
@@ -4776,21 +4752,21 @@ recipe
         foo: reads [* {bar: Text}] @hello(5)`), `expected 'Text' for param 'txt', instead got 5`);
   });
   it('fails parsing invalid canonical annotation ttl', async () => {
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
       recipe
         foo: create @persistent @ttl('300')
     `), `Invalid ttl: 300`);
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
       recipe
         foo: create @persistent @ttl(300)
     `), `expected 'Text' for param 'value', instead got 300`);
-    await assertThrowsAsync(async () => Manifest.parse(`
+    await assertThrowsAsync(async () => runtime.parse(`
       recipe
         foo: create @persistent @ttl('day')
     `), `Invalid ttl: day`);
   });
   it('parses canonical annotations', async () => {
-    const manifest = (await Manifest.parse(`
+    const manifest = (await runtime.parse(`
       @arcId('myFavoriteArc')
       recipe
         foo: create @persistent @ttl('3d')
@@ -4834,7 +4810,7 @@ recipe
   });
 
   it('parses @policy annotation', async () => {
-    const manifest = (await Manifest.parse(`
+    const manifest = (await runtime.parse(`
       policy MyPolicy {}
 
       @policy('MyPolicy')
@@ -4853,7 +4829,7 @@ recipe
   });
 
   it('fails when the @policy annotation mentions an unknown policy name', async () => {
-    const manifest = await ConCap.silence(() => Manifest.parse(`
+    const manifest = await ConCap.silence(() => runtime.parse(`
       @policy('ThisPolicyDoesNotExist')
       recipe
         foo: create
@@ -4867,7 +4843,7 @@ recipe
   });
 
   it('fails when the @policy annotation is missing its argument', async () => {
-    assertThrowsAsync(async () => Manifest.parse(`
+    assertThrowsAsync(async () => runtime.parse(`
       @policy
       recipe
         foo: create
@@ -4875,7 +4851,7 @@ recipe
   });
 
   it('supports importing policies from another file', async () => {
-    const loader = new Loader(null, {
+    const staticFiles = {
       '/policy.arcs': `
         policy MyPolicy {}
       `,
@@ -4886,15 +4862,16 @@ recipe
         recipe
           foo: create
       `,
-    });
-    const manifest = await Manifest.load('/recipe.arcs', loader);
+    };
+    const runtime = new Runtime({loader: new Loader(null, staticFiles)});
+    const manifest = await runtime.parseFile('/recipe.arcs');
     const recipe = manifest.recipes[0];
     assert.strictEqual(recipe.policy.name, 'MyPolicy');
   });
 
   describe('isolated, ingress and egress particles', () => {
     it('particles are ingress and egress by default', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         particle P
       `);
       assert.deepEqual(manifest.particles[0].dataflowType, ParticleDataflowType.INGRESS_AND_EGRESS);
@@ -4902,7 +4879,7 @@ recipe
     });
 
     it('egress annotation works', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         @egress
         particle P
       `);
@@ -4911,7 +4888,7 @@ recipe
     });
 
     it('combination of egress and ingress annotations works', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         @egress
         @ingress
         particle P
@@ -4921,7 +4898,7 @@ recipe
     });
 
     it('egress annotation with type works', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         @egress('MyEgressType')
         particle P
       `);
@@ -4930,7 +4907,7 @@ recipe
     });
 
     it('isolated annotation works', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         @isolated
         particle P
       `);
@@ -4939,7 +4916,7 @@ recipe
     });
 
     it('throws if both isolated and egress annotations are applied', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         @egress
         @isolated
         particle P
@@ -4950,7 +4927,7 @@ recipe
     });
 
     it('throws if both isolated and ingress annotations are applied', async () => {
-      const manifest = await Manifest.parse(`
+      const manifest = await runtime.parse(`
         @ingress
         @isolated
         particle P
@@ -5160,7 +5137,7 @@ describe('validateUniqueDefinitions', () => {
         import './b.arcs'
       `,
     });
-    return Manifest.load('/c.arcs', loader, {memoryProvider: new TestVolatileMemoryProvider()});
+    return new Runtime().parseFile('/c.arcs', {loader});
   }
 
   it('rejects duplicate particle names', async () => {
@@ -5256,7 +5233,7 @@ describe('validateUniqueDefinitions', () => {
 describe('expressions', () => {
   it('does not allow mixing implementation and result expressions', async () => {
     try {
-      const manifest = await Manifest.parse(`
+      const manifest = await new Runtime().parse(`
         particle Converter in 'converter.js'
           foo: reads Foo {x: Number}
           bar: writes Bar {y: Number} =
@@ -5270,7 +5247,7 @@ A particle with implementation cannot use result expressions.
     }
   });
   it('saves result expressions on handle connection specs', async () => {
-    const manifest = await Manifest.parse(`
+    const manifest = await new Runtime().parse(`
       particle Converter
         foo: reads Foo {x: Number}
         bar: writes Bar {y: Number} =

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -63,29 +63,31 @@ describe('Runtime', () => {
     const actual = await Runtime.getArcDescription(arc);
     assert.strictEqual(expected, actual);
   });
-  // it('parses a Manifest', async () => {
-  //   const content = `
-  //   schema Greeting
-  //     value: Text
+  it('parses a Manifest', async () => {
+    const content = `
+    schema Greeting
+      value: Text
 
-  //   particle Hello in 'hello.js'
-  //     text: writes Greeting {value}
+    particle Hello in 'hello.js'
+      text: writes Greeting {value}
 
-  //   recipe
-  //     handleA: create *
-  //     Hello
-  //       text: writes handleA`;
-  //   const expected = await Manifest.parse(content);
-  //   const actual = await Runtime.parseManifest(content);
-  //   assertManifestsEqual(actual, expected);
-  // });
-  // it('loads a Manifest', async () => {
-  //   const registry = {};
-  //   const loader = new Loader();
-  //   const expected = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader, registry);
-  //   const actual = await Runtime.loadManifest('./src/runtime/tests/artifacts/test.manifest', loader, registry);
-  //   assertManifestsEqual(actual, expected);
-  // });
+    recipe
+      handleA: create *
+      Hello
+        text: writes handleA`;
+    const fileName = './src/runtime/tests/artifacts/test.manifest';
+    const expected = await Manifest.parse(content, {fileName});
+    const actual = await new Runtime().parse(content, {fileName});
+    assertManifestsEqual(actual, expected);
+  });
+  it('loads a Manifest', async () => {
+    const registry = {};
+    const loader = new Loader();
+    const path = './src/runtime/tests/artifacts/test.manifest';
+    const expected = await Manifest.load(path, loader, {registry});
+    const actual = await new Runtime().parseFile(path, {loader, registry});
+    assertManifestsEqual(actual, expected);
+  });
   it('runs arcs', async () => {
     const runtime = new Runtime();
     assert.equal(runtime.arcById.size, 0);

--- a/src/runtime/tests/test-environment-test.ts
+++ b/src/runtime/tests/test-environment-test.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {registerSystemExceptionHandler, removeSystemExceptionHandler, defaultSystemExceptionHandler} from '../arc-exceptions.js';
-import {DriverFactory} from '../storage/drivers/driver-factory.js';
+import {Runtime} from '../runtime.js';
 
 let exceptions: Error[] = [];
 
@@ -24,5 +24,5 @@ afterEach(function() {
     // Error function not yet included in mocha typescript declarations...
     this.test['error'](exception);
   }
-  DriverFactory.clearRegistrationsForTesting();
+  Runtime.resetDrivers();
 });

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -17,11 +17,10 @@ import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {ActiveCollectionEntityStore, handleForActiveStore} from '../../runtime/storage/storage.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 
 describe('common particles test', () => {
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
   it('resolves after cloning', async () => {
     const memoryProvider = new TestVolatileMemoryProvider();
@@ -76,11 +75,8 @@ describe('common particles test', () => {
 
 
   it('copy handle test', async () => {
-    const loader = new Loader();
-    const memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
-    const context =  await Manifest.load('./src/tests/particles/artifacts/copy-collection-test.recipes', loader, {memoryProvider});
-    const runtime = new Runtime({loader, context, memoryProvider});
+    const runtime = new Runtime();
+    runtime.context = await runtime.parseFile('./src/tests/particles/artifacts/copy-collection-test.recipes');
     const arc = runtime.newArc('demo', storageKeyPrefixForTest());
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);

--- a/src/tests/particles/dataflow-test.ts
+++ b/src/tests/particles/dataflow-test.ts
@@ -8,25 +8,18 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import glob from 'glob';
-import {Loader} from '../../platform/loader.js';
-import {Manifest} from '../../runtime/manifest.js';
-import {analyseDataflow} from '../../dataflow/analysis/analysis.js';
 import {assert} from '../../platform/chai-web.js';
-import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
-import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../runtime/runtime.js';
+import {analyseDataflow} from '../../dataflow/analysis/analysis.js';
 
 // Checks that all of the Dataflow example recipes successfully pass dataflow
 // analysis.
 describe('Dataflow example recipes', () => {
-  const loader = new Loader();
+  const runtime = new Runtime();
   const filenames = glob.sync('particles/Dataflow/*.arcs');
-
   for (const filename of filenames) {
     it(`passes dataflow analysis: ${filename}`, async () => {
-      const memoryProvider = new TestVolatileMemoryProvider();
-      RamDiskStorageDriverProvider.register(memoryProvider);
-      const manifest = await Manifest.load(filename, loader, {memoryProvider});
+      const manifest = await runtime.parseFile(filename);
       for (const recipe of manifest.recipes) {
         recipe.normalize();
         const [_graph, result] = analyseDataflow(recipe, manifest);
@@ -34,5 +27,5 @@ describe('Dataflow example recipes', () => {
       }
     });
   }
-  DriverFactory.clearRegistrationsForTesting();
+  Runtime.resetDrivers();
 });

--- a/src/tests/particles/particles-test.ts
+++ b/src/tests/particles/particles-test.ts
@@ -12,24 +12,19 @@ import {Manifest} from '../../runtime/manifest.js';
 import glob from 'glob';
 import {Loader} from '../../platform/loader.js';
 import {assert} from '../../platform/chai-web.js';
-import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
-import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-memory-provider.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../runtime/runtime.js';
 
 /** Tests that all .schema, .recipe(s) and .manifest files in the particles folder compile successfully. */
 describe('Particle definitions', () => {
-  const loader = new Loader();
+  const runtime = new Runtime();
   const filenames = glob.sync('particles/**/*.arcs');
 
-  let memoryProvider;
   beforeEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
-    memoryProvider = new TestVolatileMemoryProvider();
-    RamDiskStorageDriverProvider.register(memoryProvider);
+    Runtime.resetDrivers();
   });
 
   afterEach(() => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   });
 
   filenames
@@ -39,7 +34,7 @@ describe('Particle definitions', () => {
         return;
       }
       it(`parses successfully: ${filename}`, async () => {
-        const manifest = await Manifest.load(filename, loader, {memoryProvider});
+        const manifest = await runtime.parseFile(filename);
         for (const particle of manifest.particles) {
           if (particle.implFile == null) {
             // It's ok for some particles to not have implementation files (e.g.

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -20,7 +20,6 @@ import {DatabaseStorageKey} from '../runtime/storage/database-storage-key.js';
 import {Handle} from '../runtime/recipe/lib-recipe.js';
 import {digest} from '../platform/digest-web.js';
 import {VolatileStorageKey} from '../runtime/storage/drivers/volatile.js';
-import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
 import {StoreInfo} from '../runtime/storage/store-info.js';
 
 export class AllocatorRecipeResolverError extends Error {

--- a/src/tools/manifest2proto-cli.ts
+++ b/src/tools/manifest2proto-cli.ts
@@ -58,7 +58,7 @@ async function main() {
   try {
     fs.mkdirSync(opts.outdir, {recursive: true});
 
-    const runtime = Runtime.init('../..', PATHS);
+    const runtime = new Runtime({rootPath: '../..', urlMap: PATHS});
     const buffer = await encodeManifestToProto(runtime, opts._[0]);
 
     const outPath = path.join(opts.outdir, opts.outfile);

--- a/src/tools/paths.oss.ts
+++ b/src/tools/paths.oss.ts
@@ -7,7 +7,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-// Path mappings to add to `Runtime.init(.)`
+// Path mappings to add to `new Runtime({urlMap})`
 //
 // This constant is overridden in Google internal repo to allow absolute imports
 // in manifest files.

--- a/src/tools/recipe2plan-cli.ts
+++ b/src/tools/recipe2plan-cli.ts
@@ -70,7 +70,7 @@ const outFormat = (() => {
 
 void Flags.withDefaultReferenceMode(async () => {
   try {
-    const runtime = Runtime.init('../..', PATHS);
+    const runtime = new Runtime({rootPath: '../..', urlMap: PATHS});
     fs.mkdirSync(opts.outdir, {recursive: true});
 
     const manifest = await runtime.parseFile(opts._[0]);

--- a/src/tools/schema2base.ts
+++ b/src/tools/schema2base.ts
@@ -16,7 +16,7 @@ import {SchemaGraph, SchemaNode} from './schema2graph.js';
 import {ParticleSpec} from '../runtime/arcs-types/particle-spec.js';
 import {PATHS} from './paths.oss.js';
 
-const runtime = Runtime.init('../..', PATHS);
+const runtime = new Runtime({rootPath: '../..', urlMap: PATHS});
 
 export interface EntityGenerator {
   generate(): string;

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -18,7 +18,7 @@ import {
 } from '../allocator-recipe-resolver.js';
 import {assertThrowsAsync} from '../../testing/test-util.js';
 import {Flags} from '../../runtime/flags.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../runtime/runtime.js';
 import {VolatileStorageKey} from '../../runtime/storage/drivers/volatile.js';
 import {PersistentDatabaseStorageKey} from '../../runtime/storage/database-storage-key.js';
 import {CreatableStorageKey} from '../../runtime/storage/creatable-storage-key.js';
@@ -27,7 +27,7 @@ import {TestVolatileMemoryProvider} from '../../runtime/testing/test-volatile-me
 const randomSalt = 'random_salt';
 
 describe('allocator recipe resolver', () => {
-  afterEach(() => DriverFactory.clearRegistrationsForTesting());
+  afterEach(() => Runtime.resetDrivers());
   it('detects long running arc', async () => {
     const manifest = (await Manifest.parse(`
         recipe Zero
@@ -370,7 +370,6 @@ describe('allocator recipe resolver', () => {
       );
   });
   it('fails to resolve when user maps to a volatile create handle', Flags.withDefaultReferenceMode(async () => {
-    VolatileStorageKey.register();
     const manifest = await Manifest.parse(`\
   particle Reader
     data: reads Thing {name: Text}
@@ -645,7 +644,7 @@ describe('allocator recipe resolver', () => {
   });
 });
 describe('allocator recipe resolver - ingress restricting', () => {
-  afterEach(() => DriverFactory.clearRegistrationsForTesting());
+  afterEach(() => Runtime.resetDrivers());
   const particleSpec = `
 particle Writer
   thing: writes Thing {a: Text, b: Text, c: Text, d: Text, e: Text}
@@ -741,7 +740,7 @@ particle ReaderB
     const recipes = await resolver.resolve();
     const writingRecipe = recipes.find(recipe => recipe.name === 'WritingRecipe');
     assert.equal(writingRecipe.handles[0].type.resolvedType().toString(), expectedSchema);
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
   };
 
   it('restricts writer fields by one writer-reader recipe', async () => {

--- a/src/tools/tests/codegen-unit-test-base.ts
+++ b/src/tools/tests/codegen-unit-test-base.ts
@@ -11,7 +11,7 @@
 import fs from 'fs';
 import {Manifest} from '../../runtime/manifest.js';
 import {Flags} from '../../runtime/flags.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
+import {Runtime} from '../../runtime/runtime.js';
 
 type Test = {
   name: string;
@@ -95,7 +95,7 @@ export abstract class ManifestCodegenUnitTest extends CodegenUnitTest {
  */
 export async function runCompute(testCase: CodegenUnitTest, test: Test): Promise<string[]> {
   Flags.reset();
-  DriverFactory.clearRegistrationsForTesting();
+  Runtime.resetDrivers();
   const result = await testCase.compute(test.input, test.options, test);
   return Array.isArray(result) ? result : [result];
 }

--- a/src/tools/tests/manifest2proto-test.ts
+++ b/src/tools/tests/manifest2proto-test.ts
@@ -8,18 +8,17 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {assert} from '../../platform/chai-web.js';
+import {fs} from '../../platform/fs-web.js';
 import {encodeManifestToProto, manifestToProtoPayload, typeToProtoPayload} from '../manifest2proto.js';
 import {CountType, EntityType, SingletonType, TupleType, Type, TypeVariable} from '../../types/lib-types.js';
 import {Manifest} from '../../runtime/manifest.js';
-import {fs} from '../../platform/fs-web.js';
-import {ManifestProto, TypeProto} from '../manifest-proto.js';
 import {Loader} from '../../runtime/loader.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {assertThrowsAsync} from '../../testing/test-util.js';
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
+import {ManifestProto, TypeProto} from '../manifest-proto.js';
 
 describe('manifest2proto', () => {
-
   // The tests below construct the JSON representation equivalent to the proto,
   // construct the proto object from the constructed JSON and produce JSON back
   // from the proto object. This ensures that all JSON produced fits the
@@ -1518,8 +1517,9 @@ describe('manifest2proto', () => {
   // This ensures that at least all the constructs used in the .arcs file can be serialized in TS
   // and deserialized in Kotlin to the extent that they are present in the .textproto file.
   it('encodes the Manifest2ProtoTest manifest', async () => {
+    const runtime = new Runtime();
     assert.deepStrictEqual(
-      await encodeManifestToProto(new Runtime(), 'java/arcs/core/data/testdata/Manifest2ProtoTest.arcs'),
+      await encodeManifestToProto(runtime, 'java/arcs/core/data/testdata/Manifest2ProtoTest.arcs'),
       fs.readFileSync('java/arcs/core/data/testdata/Manifest2ProtoTest.binarypb'),
       `The output of manifest2proto for Manifest2ProtoTest.arcs does not match the expectation.\n
 If you want to update the expected output please run:\n

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -19,7 +19,7 @@ import {assertThrowsAsync} from '../../testing/test-util.js';
 const inputManifestPath = 'java/arcs/core/data/testdata/WriterReaderExample.arcs';
 const policiesManifestPath = 'java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs';
 
-const runtime = Runtime.init('../..');
+const runtime = new Runtime({rootPath: '../..'});
 const readManifest = async (manifestPath) => runtime.parseFile(manifestPath);
 
 describe('recipe2plan', () => {

--- a/src/tools/tests/recipe2plan-test.ts
+++ b/src/tools/tests/recipe2plan-test.ts
@@ -14,12 +14,13 @@ import {Flags} from '../../runtime/flags.js';
 import {ManifestProto} from '../manifest-proto.js';
 import {Runtime} from '../../runtime/runtime.js';
 import {Manifest} from '../../runtime/manifest.js';
-import {DriverFactory} from '../../runtime/storage/drivers/driver-factory.js';
 import {assertThrowsAsync} from '../../testing/test-util.js';
 
 const inputManifestPath = 'java/arcs/core/data/testdata/WriterReaderExample.arcs';
 const policiesManifestPath = 'java/arcs/core/data/testdata/WriterReaderPoliciesExample.arcs';
-const readManifest = async (manifestPath) => Runtime.parseFile(manifestPath);
+
+const runtime = Runtime.init('../..');
+const readManifest = async (manifestPath) => runtime.parseFile(manifestPath);
 
 describe('recipe2plan', () => {
   it('generates Kotlin plans from recipes in a manifest', Flags.withDefaultReferenceMode(async () => {
@@ -460,7 +461,7 @@ policy PolicyBarBr2Br3 {
   const assertSuccess = async (recipeStr) => verifyRecipeIngress(recipeStr, true);
   const assertFailure = async (recipeStr) => verifyRecipeIngress(recipeStr, false);
   const verifyRecipeIngress = async (recipeStr: string, expectedSuccess: boolean) => {
-    DriverFactory.clearRegistrationsForTesting();
+    Runtime.resetDrivers();
     const recipesManifest = await Manifest.parse(`
 ${manifestMetaAndParticleSpecs}
 ${recipeStr}


### PR DESCRIPTION
I started working on Step 3 awhile ago. Any statics I added here are likely slated for elimination there. The first commit is called _serious degloballing_, which is lol to me. 

I believe I'm going to need some help with some of the Storage stack, wrt plumbing through runtime scope. Fair warning. 👍 
