### PR TITLE
Disable import ordering in ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,3 +21,5 @@ trim_trailing_whitespace = false
 continuation_indent_size = 2
 insert_file_newline = true
 max_line_length = 100
+disabled_rules=import-ordering
+


### PR DESCRIPTION
Due to the Copybara process, the correct import order is not always the
same in both repos, so this lint check is proving to be very annoying.