### PR TITLE
Ensure that sigh watch doesn't rebuild due to compilation output

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -884,7 +884,7 @@ async function watch(args: string[]): Promise<boolean> {
 
   const command = options._.shift() || 'webpack';
   const watcher = chokidar.watch(options.dir, {
-    ignored: new RegExp(`(node_modules|build/|.git|user-test/|test-output/|${eslintCache}|bundle-cli.js|wasm/|bazel-.*/)`),
+    ignored: new RegExp(`(node_modules|build/|.git|user-test/|test-output/|${eslintCache}|bundle-cli.js|wasm/|dist/|bazel-.*/)`),
     persistent: true
   });
   let timeout = null;


### PR DESCRIPTION
It looks like there's a set of new build output folder under './shells.*/dist/'. I think it might be good for those to be under a build or dist folder but for now have added folders ending in 'dist' to the regex for files for `sigh watch` to ignore.

This fixes constant rebuilding from `sigh watch`