### PR TITLE
Move schema field kind to manifest types

### DIFF
--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -634,7 +634,9 @@ export enum SchemaFieldKind {
   Nested = 'schema-nested',
   Inline = 'schema-inline',
   InlineField = 'schema-inline-field',
-  TypeName = 'type-name' // same as inline.
+  // TypeName is considered a 'partial' of Inline (the type checker will convert to Inline when the
+  // fields are found during annotation of the AST with type info).
+  TypeName = 'type-name'
 }
 
 export type SchemaType = SchemaReferenceType|SchemaCollectionType|

--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -623,16 +623,30 @@ export interface SchemaField extends BaseNode {
   name: string;
 }
 
+export enum SchemaFieldKind {
+  Primitive = 'schema-primitive',
+  KotlinPrimitive = 'kotlin-primitive',
+  Collection = 'schema-collection',
+  Reference = 'schema-reference',
+  OrderedList = 'schema-ordered-list',
+  Union = 'schema-union',
+  Tuple = 'schema-tuple',
+  Nested = 'schema-nested',
+  Inline = 'schema-inline',
+  InlineField = 'schema-inline-field',
+  TypeName = 'type-name' // same as inline.
+}
+
 export type SchemaType = SchemaReferenceType|SchemaCollectionType|
     SchemaPrimitiveType|KotlinPrimitiveType|SchemaUnionType|SchemaTupleType|TypeName|SchemaInline|SchemaOrderedListType|NestedSchema|KotlinPrimitiveType;
 
 export interface SchemaPrimitiveType extends BaseNodeWithRefinement {
-  kind: 'schema-primitive';
+  kind: SchemaFieldKind.Primitive;
   type: SchemaPrimitiveTypeValue;
 }
 
 export interface KotlinPrimitiveType extends BaseNodeWithRefinement {
-  kind: 'kotlin-primitive';
+  kind: SchemaFieldKind.KotlinPrimitive;
   type: KotlinPrimitiveTypeValue;
 }
 
@@ -860,7 +874,7 @@ interface PaxelFunction {
 // represents function(args) => number paxel functions
 function makePaxelNumericFunction(name: PaxelFunctionName, arity: number, type: SchemaPrimitiveTypeValue) {
   return makePaxelFunction(name, arity, {
-    kind: 'schema-primitive', type, location: INTERNAL_PAXEL_LOCATION
+    kind: SchemaFieldKind.Primitive, type, location: INTERNAL_PAXEL_LOCATION
   });
 }
 

--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -651,27 +651,27 @@ export interface KotlinPrimitiveType extends BaseNodeWithRefinement {
 }
 
 export interface SchemaCollectionType extends BaseNodeWithRefinement {
-  kind: 'schema-collection';
+  kind: SchemaFieldKind.Collection;
   schema: SchemaType;
 }
 
 export interface SchemaOrderedListType extends BaseNodeWithRefinement {
-  kind: 'schema-ordered-list';
+  kind: SchemaFieldKind.OrderedList;
   schema: SchemaType;
 }
 
 export interface SchemaReferenceType extends BaseNodeWithRefinement {
-  kind: 'schema-reference';
+  kind: SchemaFieldKind.Reference;
   schema: SchemaType;
 }
 
 export interface SchemaUnionType extends BaseNodeWithRefinement {
-  kind: 'schema-union';
+  kind: SchemaFieldKind.Union;
   types: SchemaType[];
 }
 
 export interface SchemaTupleType extends BaseNodeWithRefinement {
-  kind: 'schema-tuple';
+  kind: SchemaFieldKind.Tuple;
   types: SchemaType[];
 }
 
@@ -888,7 +888,7 @@ const INTERNAL_PAXEL_LOCATION: SourceLocation = {
 // Represents function(sequence<type>, ...) => sequence<type> paxel functions
 function makePaxelCollectionTypeFunction(name: PaxelFunctionName, arity: number) {
   return makePaxelFunction(name, arity, {
-    kind: 'schema-collection',
+    kind: SchemaFieldKind.Collection,
     schema: {
       kind: 'type-name',
       name: '*', // * denotes a passthrough type, the input type is the same as the output type

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1584,7 +1584,7 @@ SchemaInline
   = names:((upperIdent / '*') whiteSpace?)* openBrace fields:(SchemaInlineField commaOrNewline?)* closeBrace
   {
     return toAstNode<AstNode.SchemaInline>({
-      kind: 'schema-inline',
+      kind: AstNode.SchemaFieldKind.Inline,
       names: optional(names, names => names.map(name => name[0]).filter(name => name !== '*'), ['*']),
       fields: optional(fields, fields => fields.map(x => x[0]), [])
     });
@@ -1597,7 +1597,7 @@ SchemaInlineField
       type = optional(type, ty => ty[2], null);
     }
     return toAstNode<AstNode.SchemaInlineField>({
-      kind: 'schema-inline-field',
+      kind: AstNode.SchemaFieldKind.InlineField,
       name,
       type
     });
@@ -1605,7 +1605,7 @@ SchemaInlineField
   / '*'
   {
     return toAstNode<AstNode.SchemaInlineField>({
-      kind: 'schema-inline-field',
+      kind: AstNode.SchemaFieldKind.InlineField,
       name: '*',
       type: null,
     });
@@ -1695,7 +1695,7 @@ SchemaType
 SchemaCollectionType = '[' whiteSpace? schema:SchemaType whiteSpace? ']'
   {
     return toAstNode<AstNode.SchemaCollectionType>({
-      kind: 'schema-collection',
+      kind: AstNode.SchemaFieldKind.Collection,
       schema,
       refinement: null
     });
@@ -1704,7 +1704,7 @@ SchemaCollectionType = '[' whiteSpace? schema:SchemaType whiteSpace? ']'
 SchemaOrderedListType = 'List<' whiteSpace? schema:(SchemaType) whiteSpace? '>'
   {
     return toAstNode<AstNode.SchemaOrderedListType>({
-      kind: 'schema-ordered-list',
+      kind: AstNode.SchemaFieldKind.OrderedList,
       schema
     });
   }
@@ -1712,7 +1712,7 @@ SchemaOrderedListType = 'List<' whiteSpace? schema:(SchemaType) whiteSpace? '>'
 SchemaReferenceType = '&' whiteSpace? schema:(SchemaInline / TypeName)
   {
     return toAstNode<AstNode.SchemaReferenceType>({
-      kind: 'schema-reference',
+      kind: AstNode.SchemaFieldKind.Reference,
       schema
     });
   }
@@ -1721,7 +1721,7 @@ SchemaPrimitiveType
   = type:('Text' / 'URL' / 'Number' / 'BigInt' / 'Boolean' / 'Bytes' / 'Instant')
   {
     return toAstNode<AstNode.SchemaPrimitiveType>({
-      kind: 'schema-primitive',
+      kind: AstNode.SchemaFieldKind.Primitive,
       type,
       refinement: null,
       annotations: [],
@@ -1731,7 +1731,7 @@ SchemaPrimitiveType
 NestedSchemaType = 'inline' whiteSpace? schema:(SchemaInline / TypeName)
   {
     return toAstNode<AstNode.NestedSchema>({
-      kind: 'schema-nested',
+      kind: AstNode.SchemaFieldKind.Nested,
       schema
     });
   }
@@ -1840,7 +1840,7 @@ KotlinPrimitiveType
   = type:('Byte' / 'Short' / 'Int' / 'Long' / 'Char' / 'Float' / 'Double')
   {
     return toAstNode<AstNode.KotlinPrimitiveType>({
-      kind: 'kotlin-primitive',
+      kind: AstNode.SchemaFieldKind.KotlinPrimitive,
       type,
       refinement: null
     });
@@ -1853,7 +1853,7 @@ SchemaUnionType
     for (const type of rest) {
       types.push(type[3]);
     }
-    return toAstNode<AstNode.SchemaUnionType>({kind: 'schema-union', types, refinement: null, annotations: []});
+    return toAstNode<AstNode.SchemaUnionType>({kind: AstNode.SchemaFieldKind.Union, types, refinement: null, annotations: []});
   }
 
 SchemaTupleType
@@ -1863,7 +1863,7 @@ SchemaTupleType
     for (const type of rest) {
       types.push(type[3]);
     }
-    return toAstNode<AstNode.SchemaTupleType>({kind: 'schema-tuple', types, refinement: null, annotations: []});
+    return toAstNode<AstNode.SchemaTupleType>({kind: AstNode.SchemaFieldKind.Tuple, types, refinement: null, annotations: []});
   }
 
 Refinement

--- a/src/types/internal/schema-field.ts
+++ b/src/types/internal/schema-field.ts
@@ -12,20 +12,7 @@ import {assert} from '../../platform/assert-web.js';
 import {Refinement} from './refiner.js';
 import {EntityType, ReferenceType, Type} from './type.js';
 import {AnnotationRef} from '../../runtime/arcs-types/annotation.js';
-import {SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue, BinaryExpressionNode} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
-
-export enum Kind {
-  Primitive = 'schema-primitive',
-  KotlinPrimitive = 'kotlin-primitive',
-  Collection = 'schema-collection',
-  Reference = 'schema-reference',
-  OrderedList = 'schema-ordered-list',
-  Union = 'schema-union',
-  Tuple = 'schema-tuple',
-  Nested = 'schema-nested',
-  Inline = 'schema-inline',
-  TypeName = 'type-name' // same as inline.
-}
+import {SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue, BinaryExpressionNode, SchemaFieldKind as Kind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
 // tslint:disable-next-line: no-any
 type SchemaFieldMethod  = (field: {}) => FieldType;

--- a/src/types/internal/schema-from-literal.ts
+++ b/src/types/internal/schema-from-literal.ts
@@ -11,7 +11,8 @@
 import {Schema} from './schema.js';
 import {Type, EntityType} from './type.js';
 import {Refinement} from './refiner.js';
-import {FieldType, Kind as SchemaFieldKind} from './schema-field.js';
+import {FieldType} from './schema-field.js';
+import {SchemaFieldKind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
 function fromLiteral(data = {fields: {}, names: [], description: {}, refinement: null}) {
   const fields = {};

--- a/src/types/tests/schema-test.ts
+++ b/src/types/tests/schema-test.ts
@@ -23,7 +23,6 @@ import {Entity} from '../../runtime/entity.js';
 import {ConCap} from '../../testing/test-util.js';
 import {Flags} from '../../runtime/flags.js';
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
-import {SchemaFieldKind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
 function getSchemaFromManifest(manifest: Manifest, handleName: string, particleIndex: number = 0): Schema {
   return manifest.particles[particleIndex].handleConnectionMap.get(handleName).type.getEntitySchema();

--- a/src/types/tests/schema-test.ts
+++ b/src/types/tests/schema-test.ts
@@ -23,6 +23,7 @@ import {Entity} from '../../runtime/entity.js';
 import {ConCap} from '../../testing/test-util.js';
 import {Flags} from '../../runtime/flags.js';
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
+import {SchemaFieldKind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
 function getSchemaFromManifest(manifest: Manifest, handleName: string, particleIndex: number = 0): Schema {
   return manifest.particles[particleIndex].handleConnectionMap.get(handleName).type.getEntitySchema();


### PR DESCRIPTION
This should make it easier to enforce kind naming correctness (I've seen a few small bugs where a kind is used via string instead of the enum variant and the type checking sometimes promotes enums rather than giving a type error if the string doesn't exist in the enum.