### PR TITLE
Reducing the number of bazel workers to 16.

### DIFF
--- a/tools/gcb.bazelrc
+++ b/tools/gcb.bazelrc
@@ -1,6 +1,6 @@
 build --strategy=KotlinCompile=worker
 build --remote_cache=https://storage.googleapis.com/arcs-github-gcb-bazel-cache --google_default_credentials
-build --verbose_failures --spawn_strategy=sandboxed --jobs=32 --local_ram_resources=HOST_RAM*.45
+build --verbose_failures --spawn_strategy=sandboxed --jobs=16 --local_ram_resources=HOST_RAM*.45
 build --nostamp --noshow_progress --show_result 0
-test --spawn_strategy=sandboxed --nocache_test_results --test_output=errors --jobs=32 --local_ram_resources=HOST_RAM*.45
+test --spawn_strategy=sandboxed --nocache_test_results --test_output=errors --jobs=16 --local_ram_resources=HOST_RAM*.45
 test --nostamp --noshow_progress --show_result 0


### PR DESCRIPTION
GCB flakes every now and then for the following reasons:
 - The `Socket Closed` error, which is typically caused by OOMs when running bazel.
 - Timeouts in some tests, which is probably caused by starved tests due to resource contention.

This PR reduces the number of simultaneous workers to 16. Hopefully, this should reduce the flakiness in GCB.

Some context: https://github.com/tensorflow/models/issues/3647