### PR TITLE
Ignore log files from sigh watch

### DIFF
--- a/tools/sigh.ts
+++ b/tools/sigh.ts
@@ -888,7 +888,7 @@ async function watch(args: string[]): Promise<boolean> {
 
   const command = options._.shift() || 'webpack';
   const watcher = chokidar.watch(options.dir, {
-    ignored: new RegExp(`(node_modules|build/|.git|user-test/|test-output/|${eslintCache}|bundle-cli.js|wasm/|dist/|bazel-.*/)`),
+    ignored: new RegExp(`(node_modules|build/|.git|user-test/|test-output/|${eslintCache}|bundle-cli.js|wasm/|dist/|bazel-.*/.log)`),
     persistent: true
   });
   let timeout = null;


### PR DESCRIPTION
Maybe we should do something more clever than having a regex but I'm happy to keep updating it as I find things that aren't expected.