### PR TITLE
ActiveStore no longer implements StorageEndpointCommunicationProvider

### DIFF
--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -65,7 +65,7 @@ export class PlanProducer {
     this.searchStore = searchStore;
     this.inspector = inspector;
     if (this.searchStore) {
-      this.handle = handleForActiveStore(this.searchStore.storeInfo, this.searchStore, this.arc);
+      this.handle = handleForActiveStore(this.searchStore.storeInfo, this.arc);
       this.searchStoreCallbackId = this.searchStore.on(() => this.onSearchChanged());
     }
     this.debug = debug;

--- a/src/planning/plan/planificator.ts
+++ b/src/planning/plan/planificator.ts
@@ -192,7 +192,7 @@ export class Planificator {
   }
 
   async _storeSearch(): Promise<void> {
-    const handle = handleForActiveStore(this.searchStore.storeInfo, this.searchStore, this.arc);
+    const handle = handleForActiveStore(this.searchStore.storeInfo, this.arc);
     const handleValue = await handle.fetch();
     const values = handleValue ? JSON.parse(handleValue.current) : [];
 

--- a/src/planning/plan/planning-result.ts
+++ b/src/planning/plan/planning-result.ts
@@ -52,7 +52,7 @@ export class PlanningResult {
     assert(envOptions.storageManager, `storageManager cannot be null`);
     this.store = store;
     if (this.store) {
-      this.handle = handleForActiveStore(store.storeInfo, store, {...envOptions.context, storageManager: envOptions.storageManager});
+      this.handle = handleForActiveStore(store.storeInfo, {...envOptions.context, storageManager: envOptions.storageManager});
       this.storeCallbackId = this.store.on(() => this.load());
     }
   }

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -164,7 +164,7 @@ describe('plan producer - search', () => {
     }
 
     async setNextSearch(search: string) {
-      const handle = handleForActiveStore(this.searchStore.storeInfo, this.searchStore, this.arc);
+      const handle = handleForActiveStore(this.searchStore.storeInfo, this.arc);
       await handle.setFromData({current: JSON.stringify([{arc: this.arc.id.idTreeAsString(), search}])});
       return this.onSearchChanged();
     }

--- a/src/runtime/particle-execution-context.ts
+++ b/src/runtime/particle-execution-context.ts
@@ -175,12 +175,13 @@ export class ParticleExecutionContext {
     return this.idGenerator.newChildId(this.pecId).toString();
   }
 
-  getStorageEndpointProvider(): StorageCommunicationEndpointProvider<CRDTTypeRecord> {
+  getStorageEndpointProvider(): StorageCommunicationEndpointProvider {
     const pec = this;
     return {
-      getStorageEndpoint(
-          storeInfo: StoreInfo<CRDTTypeRecordToType<CRDTTypeRecord>>,
-          storageProxy: StorageProxy<CRDTTypeRecord> | StorageProxyMuxer<CRDTTypeRecord>): StorageCommunicationEndpoint<CRDTTypeRecord> {
+      getStorageEndpoint<T extends Type>(
+          storeInfo: StoreInfo<T>,
+          storageProxy: StorageProxy<TypeToCRDTTypeRecord<T>> | StorageProxyMuxer<TypeToCRDTTypeRecord<T>>
+      ): StorageCommunicationEndpoint<TypeToCRDTTypeRecord<T>> {
         return createStorageEndpoint(storageProxy, pec, pec.apiPort);
       }
     };

--- a/src/runtime/storage/active-store.ts
+++ b/src/runtime/storage/active-store.ts
@@ -15,13 +15,11 @@ import {Exists} from './drivers/driver.js';
 import {StorageKey} from './storage-key.js';
 import {CRDTTypeRecordToType} from './storage.js';
 import {StoreInfo} from './store-info.js';
-import {StoreInterface, StorageCommunicationEndpointProvider, StorageMode, StoreConstructorOptions, ProxyMessageType, ProxyCallback, ProxyMessage} from './store-interface.js';
-import {DirectStorageEndpoint} from './direct-storage-endpoint.js';
+import {StoreInterface, StorageMode, StoreConstructorOptions, ProxyMessageType, ProxyCallback, ProxyMessage} from './store-interface.js';
 
 // A representation of an active store. Subclasses of this class provide specific
 // behaviour as controlled by the provided StorageMode.
-export abstract class ActiveStore<T extends CRDTTypeRecord>
-    implements StoreInterface<T>, StorageCommunicationEndpointProvider<T> {
+export abstract class ActiveStore<T extends CRDTTypeRecord> implements StoreInterface<T> {
   readonly storageKey: StorageKey;
   exists: Exists;
   readonly type: CRDTTypeRecordToType<T>;
@@ -62,10 +60,6 @@ export abstract class ActiveStore<T extends CRDTTypeRecord>
   abstract off(callback: number): void;
   abstract async onProxyMessage(message: ProxyMessage<T>): Promise<void>;
   abstract reportExceptionInHost(exception: PropagatedException): void;
-
-  getStorageEndpoint(storeInfo: StoreInfo<CRDTTypeRecordToType<T>>) {
-    return new DirectStorageEndpoint<T>(this);
-  }
 }
 
 export type StoreConstructor = {

--- a/src/runtime/storage/direct-storage-endpoint-manager.ts
+++ b/src/runtime/storage/direct-storage-endpoint-manager.ts
@@ -10,7 +10,7 @@
 import {assert} from '../../platform/assert-web.js';
 import {CRDTTypeRecord} from '../../crdt//lib-crdt.js';
 import {TypeToCRDTTypeRecord, CRDTTypeRecordToType} from './storage.js';
-import {ProxyMessage} from './store-interface.js';
+import {ProxyMessage, StorageCommunicationEndpointProvider, StorageCommunicationEndpoint} from './store-interface.js';
 import {ActiveStore} from './active-store.js';
 import {Type} from '../../types/lib-types.js';
 import {StoreInfo} from './store-info.js';
@@ -18,9 +18,10 @@ import {StorageKey} from './storage-key.js';
 import {Exists} from './drivers/driver.js';
 import {StorageService} from './storage-service.js';
 import {Consumer} from '../../utils/lib-utils.js';
+import {DirectStorageEndpoint} from './direct-storage-endpoint.js';
 import {StorageEndpointManager} from './storage-manager.js';
 
-export class DirectStorageEndpointManager implements StorageEndpointManager, StorageService {
+export class DirectStorageEndpointManager implements StorageEndpointManager, StorageService, StorageCommunicationEndpointProvider {
   // All the stores, mapped by store ID
   private readonly activeStoresByKey = new Map<StorageKey, ActiveStore<CRDTTypeRecord>>();
 
@@ -56,5 +57,10 @@ export class DirectStorageEndpointManager implements StorageEndpointManager, Sto
 
   async onProxyMessage(storeInfo: StoreInfo<Type>, message: ProxyMessage<CRDTTypeRecord>) {
     return (await this.getActiveStore(storeInfo)).onProxyMessage(message);
+  }
+
+  getStorageEndpoint<T extends Type>(storeInfo: StoreInfo<T>): StorageCommunicationEndpoint<TypeToCRDTTypeRecord<T>> {
+    assert(this.activeStoresByKey.has(storeInfo.storageKey));
+    return new DirectStorageEndpoint(this.activeStoresByKey.get(storeInfo.storageKey) as ActiveStore<TypeToCRDTTypeRecord<T>>);
   }
 }

--- a/src/runtime/storage/direct-storage-endpoint.ts
+++ b/src/runtime/storage/direct-storage-endpoint.ts
@@ -9,7 +9,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {StorageCommunicationEndpoint, ProxyMessage, ProxyCallback, StorageCommunicationEndpointProvider} from './store-interface.js';
+import {StorageCommunicationEndpoint, ProxyMessage, ProxyCallback} from './store-interface.js';
 import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
 import {ActiveStore} from './active-store.js';
 import {ChannelConstructor} from '../channel-constructor.js';

--- a/src/runtime/storage/direct-store-muxer.ts
+++ b/src/runtime/storage/direct-store-muxer.ts
@@ -14,7 +14,7 @@ import {ActiveStore} from './active-store.js';
 import {StorageKey} from './storage-key.js';
 import {DirectStore} from './direct-store.js';
 import {Dictionary, BiMap, noAwait} from '../../utils/lib-utils.js';
-import {StoreConstructorOptions, StorageCommunicationEndpointProvider, StorageMode, ProxyMessageType} from './store-interface.js';
+import {StoreConstructorOptions, StorageMode, ProxyMessageType} from './store-interface.js';
 import {assert} from '../../platform/assert-web.js';
 import {PropagatedException, reportSystemException} from '../arc-exceptions.js';
 import {ChannelConstructor} from '../channel-constructor.js';
@@ -41,7 +41,7 @@ export type StoreRecord<T extends CRDTTypeRecord> = {type: 'record', store: Dire
 /**
  * A store that allows multiple CRDT models to be stored as sub-keys of a single storageKey location.
  */
-export class DirectStoreMuxer<S extends Identified, C extends Identified, T extends CRDTEntityTypeRecord<S, C>> extends ActiveStore<T> implements StorageCommunicationEndpointProvider<T> {
+export class DirectStoreMuxer<S extends Identified, C extends Identified, T extends CRDTEntityTypeRecord<S, C>> extends ActiveStore<T> {
   versionToken: string;
   storageKey: StorageKey;
 

--- a/src/runtime/storage/storage-endpoint.ts
+++ b/src/runtime/storage/storage-endpoint.ts
@@ -22,14 +22,14 @@ import {StoreInfo} from './store-info.js';
 import {CRDTTypeRecordToType} from './storage.js';
 import {Type} from '../../types/lib-types.js';
 
-export function createStorageEndpoint(
-    storageProxy: StorageProxy<CRDTTypeRecord> | StorageProxyMuxer<CRDTTypeRecord>,
+export function createStorageEndpoint<T extends CRDTTypeRecord>(
+    storageProxy: StorageProxy<T> | StorageProxyMuxer<T>,
     channelConstructor: ChannelConstructor,
-    storageFrontend: StorageFrontend): StorageCommunicationEndpoint<CRDTTypeRecord> {
+    storageFrontend: StorageFrontend): StorageCommunicationEndpoint<T> {
   if (storageProxy instanceof StorageProxy) {
     return new StorageEndpointImpl(storageProxy, channelConstructor, storageFrontend);
   } else if (storageProxy instanceof StorageProxyMuxer) {
-    return new StorageMuxerEndpointImpl(storageProxy, channelConstructor, storageFrontend);
+    return new StorageMuxerEndpointImpl(storageProxy as unknown as StorageProxyMuxer<CRDTTypeRecord>, channelConstructor, storageFrontend);
   } else {
     throw new Error('Invalid Proxy');
   }

--- a/src/runtime/storage/storage-manager.ts
+++ b/src/runtime/storage/storage-manager.ts
@@ -13,13 +13,14 @@ import {ActiveStore} from './active-store.js';
 import {Type} from '../../types/lib-types.js';
 import {StoreInfo} from './store-info.js';
 import {StorageService} from './storage-service.js';
+import {StorageCommunicationEndpointProvider} from './store-interface.js';
 
 /**
  * A StorageEndpointManager returns ActiveStores for the given StoreInfo.
  */
 // TODO(b/163702684): Refactor to return StorageCommunicationEndpoint instead and replace
 // StorageEndpointManager with StorageCommunicationEndpointProvider everywhere.
-export interface StorageEndpointManager {
+export interface StorageEndpointManager extends StorageCommunicationEndpointProvider {
   storageService: StorageService;
   getActiveStore<T extends Type>(storeInfo: StoreInfo<T>): Promise<ActiveStore<TypeToCRDTTypeRecord<T>>>;
 }

--- a/src/runtime/storage/store-interface.ts
+++ b/src/runtime/storage/store-interface.ts
@@ -19,6 +19,7 @@ import {ChannelConstructor} from '../channel-constructor.js';
 import {StorageProxyMuxer} from './storage-proxy-muxer.js';
 import {CRDTTypeRecordToType, TypeToCRDTTypeRecord} from './storage.js';
 import {StoreInfo} from './store-info.js';
+import {Type} from '../../types/lib-types.js';
 
 /**
  * This file exists to break a circular dependency between Store and the ActiveStore implementations.
@@ -60,6 +61,9 @@ export interface StorageCommunicationEndpoint<T extends CRDTTypeRecord> {
   getChannelConstructor: Producer<ChannelConstructor>;
 }
 
-export interface StorageCommunicationEndpointProvider<T extends CRDTTypeRecord> {
-  getStorageEndpoint(storeInfo: StoreInfo<CRDTTypeRecordToType<T>>, storageProxy?: StorageProxy<T> | StorageProxyMuxer<T>): StorageCommunicationEndpoint<T>;
+export interface StorageCommunicationEndpointProvider {
+  getStorageEndpoint<T extends Type>(
+    storeInfo: StoreInfo<T>,
+    storageProxy?: StorageProxy<TypeToCRDTTypeRecord<T>> | StorageProxyMuxer<TypeToCRDTTypeRecord<T>>
+  ): StorageCommunicationEndpoint<TypeToCRDTTypeRecord<T>>;
 }

--- a/src/runtime/storage/tests/handle-test.ts
+++ b/src/runtime/storage/tests/handle-test.ts
@@ -16,7 +16,7 @@ import {CollectionType, EntityType, SingletonType, Type, ReferenceType, Schema, 
 import {CollectionHandle, SingletonHandle, EntityHandle} from '../handle.js';
 import {StorageProxy} from '../storage-proxy.js';
 import {ProxyMessageType} from '../store-interface.js';
-import {MockParticle, MockStore} from '../testing/test-storage.js';
+import {MockParticle, MockStoreInfo, MockStore, MockStorageCommunicationProvider} from '../testing/test-storage.js';
 import {Manifest} from '../../manifest.js';
 import {EntityClass, Entity, SerializedEntity} from '../../entity.js';
 import {SYMBOL_INTERNALS} from '../../symbols.js';
@@ -25,16 +25,13 @@ import {Reference} from '../../reference.js';
 import {VersionMap, CollectionOperation, CollectionOpTypes, CRDTCollectionTypeRecord,
         CRDTCollection, CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes, CRDTSingleton,
         CRDTEntityTypeRecord, Identified, CRDTEntity, EntityOpTypes} from '../../../crdt/lib-crdt.js';
-import {StoreInfo} from '../store-info.js';
-
 
 async function getCollectionHandle(primitiveType: EntityType, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<CollectionHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const mockStore = new MockStore<CRDTEntityCollection>(new CollectionType(primitiveType));
   const handle = new CollectionHandle(
       'me',
-      new StorageProxy('id', mockStore.storeInfo, mockStore),
+      new StorageProxy('id', new MockStoreInfo(new CollectionType(primitiveType)), new MockStorageCommunicationProvider()),
       IdGenerator.newSession(),
       fakeParticle,
       canRead,
@@ -51,10 +48,9 @@ async function getCollectionHandle(primitiveType: EntityType, particle?: MockPar
 async function getSingletonHandle(primitiveType: EntityType, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<SingletonHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const mockStore = new MockStore<CRDTEntitySingleton>(new SingletonType(primitiveType));
   const handle = new SingletonHandle(
       'me',
-      new StorageProxy('id', mockStore.storeInfo, mockStore),
+      new StorageProxy('id', new MockStoreInfo(new SingletonType(primitiveType)), new MockStorageCommunicationProvider()),
       IdGenerator.newSession(),
       fakeParticle,
       canRead,
@@ -71,8 +67,7 @@ async function getSingletonHandle(primitiveType: EntityType, particle?: MockPart
 async function getEntityHandle(schema: Schema, muxId: string, particle?: MockParticle, canRead=true, canWrite=true):
     Promise<EntityHandle<Entity>> {
   const fakeParticle: Particle = (particle || new MockParticle()) as unknown as Particle;
-  const mockStore = new MockStore<CRDTMuxEntity>(new MuxType<EntityType>(new EntityType(schema)));
-  const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+  const storageProxy = new StorageProxy('id', new MockStoreInfo(new MuxType<EntityType>(new EntityType(schema))), new MockStorageCommunicationProvider()) as StorageProxy<CRDTMuxEntity>;
   const handle = new EntityHandle<Entity>(
     'me',
     storageProxy,

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -20,6 +20,8 @@ import {StorageProxy} from '../storage-proxy.js';
 import {CollectionHandle} from '../handle.js';
 import {OrderedListField, PrimitiveField} from '../../../types/lib-types.js';
 import {StoreInfo} from '../store-info.js';
+import {CRDTCollectionTypeRecord} from '../../../crdt/internal/crdt-collection.js';
+import {Referenceable} from '../../../crdt/lib-crdt.js';
 
 describe('ReferenceModeStore Integration', async () => {
 
@@ -103,8 +105,9 @@ describe('ReferenceModeStore Integration', async () => {
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
     // Set up a common store and host both handles on top. This will result in one store but two different proxies.
-    const activestore = await arc.getActiveStore(new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'}));
-    const proxy = new StorageProxy('proxy', activestore.storeInfo, activestore);
+    const storeInfo = new StoreInfo({storageKey, type, exists: Exists.MayExist, id: 'store'});
+    const activestore = await arc.storageManager.getActiveStore(storeInfo);
+    const proxy = new StorageProxy('proxy', storeInfo, arc.storageManager) as StorageProxy<CRDTCollectionTypeRecord<Referenceable>>;
     const writeHandle = new CollectionHandle('write-handle', proxy, arc.idGenerator, null, false, true, 'write-handle');
     const particle = new Particle();
     const readHandle = new CollectionHandle('read-handle', proxy, arc.idGenerator, particle, true, false, 'read-handle');

--- a/src/runtime/storage/tests/storage-proxy-test.ts
+++ b/src/runtime/storage/tests/storage-proxy-test.ts
@@ -13,8 +13,9 @@ import {CRDTSingletonTypeRecord, SingletonOperation, SingletonOpTypes} from '../
 import {StorageProxy, NoOpStorageProxy} from '../storage-proxy.js';
 import {ProxyMessageType} from '../store-interface.js';
 import {ActiveStore} from '../active-store.js';
-import {MockHandle, MockStore} from '../testing/test-storage.js';
+import {MockHandle, MockStoreInfo, MockStorageCommunicationProvider} from '../testing/test-storage.js';
 import {EntityType, SingletonType} from '../../../types/lib-types.js';
+import {Type} from '../../../types/lib-types.js';
 
 interface Entity {
   id: string;
@@ -29,8 +30,10 @@ const initialData = {values: {'1': {value: {id: 'e1'}, version: {A: 1}}}, versio
 
 describe('StorageProxy', async () => {
   it('will apply and propagate operation', async () => {
-    const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+    const mockStoreInfo = new MockStoreInfo(singletonEntityType);
+    const provider = new MockStorageCommunicationProvider();
+    const mockStore = provider.addStorageEndpoint(mockStoreInfo, initialData);
+    const storageProxy = new StorageProxy('id', mockStoreInfo, provider) as StorageProxy<CRDTSingletonTypeRecord<Entity>>;
 
     // Register a handle to verify updates are sent back.
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -54,8 +57,9 @@ describe('StorageProxy', async () => {
 
   it('does not notify keepSynced handles if desynced', async () => {
     // Don't pass any data to the MockStore.
-    const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType);
-    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+    const storageProxy = new StorageProxy('id', new MockStoreInfo(singletonEntityType),
+        new MockStorageCommunicationProvider()) as StorageProxy<CRDTSingletonTypeRecord<Entity>>;
+
 
     // Register a keepSynced handle and a !keepSynced one.
     const handle1 = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -79,8 +83,10 @@ describe('StorageProxy', async () => {
   });
 
   it('will sync if desynced before returning the particle view', async () => {
-    const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+    const mockStoreInfo = new MockStoreInfo(singletonEntityType);
+    const provider = new MockStorageCommunicationProvider();
+    const mockStore = provider.addStorageEndpoint(mockStoreInfo, initialData);
+    const storageProxy = new StorageProxy('id', mockStoreInfo, provider) as StorageProxy<CRDTSingletonTypeRecord<Entity>>;
 
     // Register a handle to verify updates are sent back.
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -102,8 +108,10 @@ describe('StorageProxy', async () => {
   });
 
   it('can exchange models with the store', async () => {
-    const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+    const mockStoreInfo = new MockStoreInfo(singletonEntityType);
+    const provider = new MockStorageCommunicationProvider();
+    const mockStore = provider.addStorageEndpoint(mockStoreInfo, initialData);
+    const storageProxy = new StorageProxy('id', mockStoreInfo, provider) as StorageProxy<CRDTSingletonTypeRecord<Entity>>;
 
     // Registering a handle trigger the proxy to connect to the store and fetch the model.
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
@@ -126,8 +134,10 @@ describe('StorageProxy', async () => {
   });
 
   it('propagates exceptions to the store', async () => {
-    const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType, initialData);
-    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+    const mockStoreInfo = new MockStoreInfo(singletonEntityType);
+    const provider = new MockStorageCommunicationProvider();
+    const mockStore = provider.addStorageEndpoint(mockStoreInfo, initialData);
+    const storageProxy = new StorageProxy('id', mockStoreInfo, provider) as StorageProxy<CRDTSingletonTypeRecord<Entity>>;
 
     const handle = new MockHandle<CRDTSingletonTypeRecord<Entity>>(storageProxy);
     handle.onSync = () => {
@@ -144,8 +154,8 @@ describe('StorageProxy', async () => {
 
 describe('NoOpStorageProxy', () => {
   it('overrides all methods in StorageProxy', async () => {
-    const mockStore = new MockStore<CRDTSingletonTypeRecord<Entity>>(singletonEntityType);
-    const storageProxy = new StorageProxy('id', mockStore.storeInfo, mockStore);
+    const storageProxy = new StorageProxy('id', new MockStoreInfo(singletonEntityType),
+        new MockStorageCommunicationProvider());
     const noOpStorageProxy = getNoOpStorageProxy();
 
     const properties = [];

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -91,8 +91,7 @@ describe('common particles test', () => {
     await arc.idle;
 
     const storeInfo = arc.findStoreById(arc.stores[2].id) as StoreInfo<CollectionEntityType>;
-    const endpointProvider = await arc.getActiveStore(storeInfo);
-    const handle = handleForActiveStore(storeInfo, endpointProvider, arc);
+    const handle = handleForActiveStore(storeInfo, arc);
     assert.strictEqual((await handle.toList()).length, 5);
   });
 });


### PR DESCRIPTION
StorageEndpointCommunicationProvider is instead implemented by StorageManager, and isn't typed (step 1 in the doc).