### PR TITLE
Add tests for CrdtEntity.merge()

### DIFF
--- a/javatests/arcs/core/crdt/CrdtSetTest.kt
+++ b/javatests/arcs/core/crdt/CrdtSetTest.kt
@@ -36,6 +36,35 @@ class CrdtSetTest {
     bob = CrdtSet()
   }
 
+  /**
+   * Test for edge case where merging sets with different underlying types.
+   * TODO(b/177036049): this is currently producing unexpected behaviour.
+   * The test should be updated once b/177036049 is resolved.
+   */
+  @Test
+  fun merge_differentTypes() {
+    val charlie: CrdtSet<CrdtEntity.ReferenceImpl> = CrdtSet()
+    val darren: CrdtSet<CrdtEntity.ReferenceImpl> = CrdtSet()
+    val stringEntity = "G'day!".toReferencable()
+    val intEntity = 1.toReferencable()
+
+    val stringAdd = CrdtSet.Operation.Add(
+      "darren",
+      VersionMap("darren" to 1),
+      CrdtEntity.ReferenceImpl(stringEntity.id)
+    )
+    val intAdd = CrdtSet.Operation.Add(
+      "darren",
+      VersionMap("darren" to 1),
+      CrdtEntity.ReferenceImpl(intEntity.id)
+    )
+    charlie.applyOperation(stringAdd)
+    darren.applyOperation(intAdd)
+
+    charlie.merge(darren.data)
+    assertThat(charlie.consumerView).isEmpty()
+  }
+
   @Test
   fun startsEmpty() {
     assertThat(alice.consumerView).isEmpty()


### PR DESCRIPTION
Add tests in line for the test plan of CrdtEntity's merge function. This is the first in a series of PRs around this class. This PR focuses on various combinations of merges and operations along with singletons in a merge.

This PR also includes an added test for CrdtSet to highlight an underlying issue discovered.

Question for @shans: In the `crdtEntity_merge_singletonFieldTypeMismatch` test, we have mismatched field types for the singleton "foo". In this case the "foo" field becomes null after a merge. Is this correct?