### PR TITLE
Add the @Generated tag to generated particle/schema code

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,6 +77,7 @@ maven_install(
         "androidx.test:rules:" + ANDROIDX_TEST_VERSION,
         "androidx.test.uiautomator:uiautomator:" + UI_AUTOMATOR_VERSION,
         "com.google.flogger:flogger:0.4",
+        "javax.annotation:javax.annotation-api:1.3.2",
         "com.google.code.findbugs:jsr305:3.0.2",
         "com.google.flogger:flogger-system-backend:0.4",
         "com.google.dagger:dagger:2.23.1",

--- a/java/arcs/sdk/BUILD
+++ b/java/arcs/sdk/BUILD
@@ -29,11 +29,13 @@ arcs_kt_jvm_library(
         "//java/arcs/core/storage:storage_key",
         "//java/arcs/core/storage/api",
         "//java/arcs/core/util:utils-platform-dependencies",
+        "//third_party/java/jsr250_annotations",
     ],
     deps = [
         "//java/arcs/core/entity",
         "//java/arcs/core/host/api",
         "//java/arcs/core/util:utils-platform-dependencies",
+        "//third_party/java/jsr250_annotations",
         "//third_party/kotlin/kotlinx_coroutines",
     ],
 )

--- a/java/arcs/sdk/js/Generated.kt
+++ b/java/arcs/sdk/js/Generated.kt
@@ -1,0 +1,34 @@
+package arcs.sdk.js
+
+/**
+ * This is an declaration of the JSR250 @Generated annotation for use in automatically
+ * generated code that's generated for a WASM platform.
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class Generated(
+  /**
+   * The value element MUST have the name of the code generator. The
+   * name is the fully qualified name of the code generator.
+   *
+   * @return The name of the code generator
+   */
+  vararg val value: String,
+
+  /**
+   * A place holder for any comments that the code generator may want to
+   * include in the generated code.
+   *
+   * @return Comments that the code generated included
+   */
+  val comment: String = "",
+
+  /**
+   * Date when the source was generated. The date element must follow the ISO
+   * 8601 standard. For example the date element would have the following
+   * value 2017-07-04T12:08:56.235-0700 which represents 2017-07-04 12:08:56
+   * local time in the U.S. Pacific Time time zone.
+   *
+   * @return The date the source was generated
+   */
+  val date: String = ""
+)

--- a/java/arcs/sdk/wasm/Generated.kt
+++ b/java/arcs/sdk/wasm/Generated.kt
@@ -1,0 +1,34 @@
+package arcs.sdk.wasm
+
+/**
+ * This is an declaration of the JSR250 @Generated annotation for use in automatically
+ * generated code that's generated for a WASM platform.
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class Generated(
+  /**
+   * The value element MUST have the name of the code generator. The
+   * name is the fully qualified name of the code generator.
+   *
+   * @return The name of the code generator
+   */
+  vararg val value: String,
+
+  /**
+   * A place holder for any comments that the code generator may want to
+   * include in the generated code.
+   *
+   * @return Comments that the code generated included
+   */
+  val comment: String = "",
+
+  /**
+   * Date when the source was generated. The date element must follow the ISO
+   * 8601 standard. For example the date element would have the following
+   * value 2017-07-04T12:08:56.235-0700 which represents 2017-07-04 12:08:56
+   * local time in the U.S. Pacific Time time zone.
+   *
+   * @return The date the source was generated
+   */
+  val date: String = ""
+)

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -57,6 +57,7 @@ export class Schema2Kotlin extends Schema2Base {
         'import arcs.sdk.ArcsInstant',
         'import arcs.sdk.BigInt',
         'import arcs.sdk.toBigInt',
+        'import javax.annotation.Generated',
       );
     }
     imports.sort();
@@ -182,6 +183,7 @@ ${imports.join('\n')}
     return `
 ${typeAliases.join(`\n`)}
 
+@Generated("src/tools/schema2kotlin.ts")
 abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' : 'arcs.sdk.BaseParticle'}() {
     ${this.opts.wasm ? '' : 'override '}val handles: Handles = Handles(${this.opts.wasm ? 'this' : ''})
 

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -16,6 +16,7 @@ import arcs.sdk.ArcsDuration
 import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt
 import arcs.sdk.toBigInt
+import javax.annotation.Generated
 
 typealias Gold_Data_Ref = AbstractGold.GoldInternal1
 typealias Gold_Alias = AbstractGold.GoldInternal1
@@ -24,6 +25,7 @@ typealias Gold_Collection = AbstractGold.Foo
 typealias Gold_Data = AbstractGold.Gold_Data
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
 
+@Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractGold : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -15,6 +15,7 @@ typealias Gold_Alias = AbstractGold.Gold_Alias
 typealias Gold_Collection = AbstractGold.Foo
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
 
+@Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractGold : WasmParticleImpl() {
     val handles: Handles = Handles(this)
 

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -16,6 +16,7 @@ import arcs.sdk.ArcsDuration
 import arcs.sdk.ArcsInstant
 import arcs.sdk.BigInt
 import arcs.sdk.toBigInt
+import javax.annotation.Generated
 
 typealias KotlinPrimitivesGolden_Data_Ref = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref
 typealias KotlinPrimitivesGolden_Data_Thinglst = AbstractKotlinPrimitivesGolden.Thing
@@ -25,6 +26,7 @@ typealias KotlinPrimitivesGolden_Data_Products = AbstractKotlinPrimitivesGolden.
 typealias KotlinPrimitivesGolden_Data_Detail = AbstractKotlinPrimitivesGolden.Detail
 typealias KotlinPrimitivesGolden_Data = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data
 
+@Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -715,7 +715,7 @@ def arcs_kt_schema(
         deps = arcs_sdk_deps,
         visibility = visibility,
     )
-    outdeps = outdeps + arcs_sdk_deps
+    outdeps += arcs_sdk_deps
 
     if test_harness:
         test_harness_outs = []

--- a/third_party/java/jsr250_annotations/BUILD
+++ b/third_party/java/jsr250_annotations/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+alias(
+    name = "jsr250_annotations",
+    actual = "@maven//:javax_annotation_javax_annotation_api",
+)


### PR DESCRIPTION
This helps with things like preventing static analyzers from raising
warnings for projects that are using Arcs, when the Arcs-generated code
doesn't conform to a standard that the project uses.

An implementation of the @Generated annotation is included for wasm and
js builds as well.

b/176839196