### PR TITLE
Get additional error details from getMaxReadType API

### DIFF
--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -920,10 +920,10 @@ policy MyPolicy {
     const manifestPerson = new EntityType(manifest.schemas['Person']);
     const manifestSensitiveInfo =
       new EntityType(manifest.schemas['SensitiveInfo']);
-    const errors = []
+    const errors = [];
     assert.isNull(
       ingressValidation.getMaxReadType(manifestSensitiveInfo, errors));
-    assert.isTrue(errors.length == 1);
+    assert.isTrue(errors.length === 1);
     assert.deepEqual(errors[0], `Schema 'SensitiveInfo' is not mentioned in policy`);
   });
 });

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -914,4 +914,16 @@ policy MyPolicy {
           /* canReadSubset = */manifestSensitiveInfo)));
   });
 
+  it('returns error details if type has inaccessible schemas', async () => {
+    const manifest = await Manifest.parse(manifestWithMultiplePolicies);
+    const ingressValidation = new IngressValidation(manifest.policies);
+    const manifestPerson = new EntityType(manifest.schemas['Person']);
+    const manifestSensitiveInfo =
+      new EntityType(manifest.schemas['SensitiveInfo']);
+    const errors = []
+    assert.isNull(
+      ingressValidation.getMaxReadType(manifestSensitiveInfo, errors));
+    assert.isTrue(errors.length == 1);
+    assert.deepEqual(errors[0], `Schema 'SensitiveInfo' is not mentioned in policy`);
+  });
 });

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -132,7 +132,7 @@ export class AllocatorRecipeResolver {
             throw new AllocatorRecipeResolverError(
               `No type for handle '${handle.id}'.`);
           }
-          const errors = []
+          const errors = [];
           const maxHandleReadType =
             this.ingressValidation.getMaxReadType(handle.type, errors);
           if (maxHandleReadType == null) {

--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -132,11 +132,12 @@ export class AllocatorRecipeResolver {
             throw new AllocatorRecipeResolverError(
               `No type for handle '${handle.id}'.`);
           }
+          const errors = []
           const maxHandleReadType =
-            this.ingressValidation.getMaxReadType(handle.type);
+            this.ingressValidation.getMaxReadType(handle.type, errors);
           if (maxHandleReadType == null) {
             throw new AllocatorRecipeResolverError(
-              `Unable to find max read type for handle '${handle.id}'.`);
+              `Unable to find max read type for handle '${handle.id}': ${errors}.`);
           }
           allTypes.push(maxHandleReadType);
         });

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -1404,7 +1404,8 @@ recipe ReadingRecipeAD
         expected: 'Thing {a: Text}'
       }),
       AllocatorRecipeResolverError,
-      `Unable to find max read type`
+      `Unable to find max read type for handle 'my-handle-id': `+
+        `Schema 'Sensitive' is not mentioned in policy.`
     );
   });
 


### PR DESCRIPTION
Adds an optional errors array to record the actual errors that happened when `getMaxReadType` returns `null`.