### PR TITLE
Use resolved type to compute max type when type var is resolved.

### DIFF
--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -288,6 +288,14 @@ export class IngressValidation {
       case 'TypeVariable': {
         const typeVar = (type as TypeVariable).variable;
         const canReadSubset = type.canReadSubset;
+        if (type.isResolved()) {
+          const maxReadType = this.getMaxReadType(type.resolvedType(), errors);
+          return (maxReadType == null)
+            ? null
+            : TypeVariable.make(
+              '', maxReadType, null, typeVar.resolveToMaxType);
+        }
+
         // Note that `canReadSubset` captures the constraints induced by the
         // writes to a connection/handle. If `canReadSubset` is null, this
         // type variable represents a connection/handle that was not written

--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -287,7 +287,6 @@ export class IngressValidation {
       }
       case 'TypeVariable': {
         const typeVar = (type as TypeVariable).variable;
-        const canReadSubset = type.canReadSubset;
         if (type.isResolved()) {
           const maxReadType = this.getMaxReadType(type.resolvedType(), errors);
           return (maxReadType == null)
@@ -296,6 +295,7 @@ export class IngressValidation {
               '', maxReadType, null, typeVar.resolveToMaxType);
         }
 
+        const canReadSubset = type.canReadSubset;
         // Note that `canReadSubset` captures the constraints induced by the
         // writes to a connection/handle. If `canReadSubset` is null, this
         // type variable represents a connection/handle that was not written

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -890,7 +890,7 @@ policy MyPolicy {
       'A',
       'foo: inline Foo {a: Text, d: Text}',
       'foo: inline Foo {a: Text, d: Text}');
-    typeVar.maybeEnsureResolved();
+    assert(typeVar.maybeEnsureResolved());
     const expected = await createTypeVarForSchema(
       'A',
       'foo: inline Foo {a: Text, b: Text}',
@@ -935,10 +935,13 @@ policy MyPolicy {
       '',
       /* canWriteSuperset = */manifestSensitiveInfo,
       /* canReadSubset = */manifestSensitiveInfo);
+
+    // Unresolved type variable
+    assert(!typeVar.isResolved());
     assert.isNull(ingressValidation.getMaxReadType(typeVar));
 
     // Resolved Type variable.
-    typeVar.maybeEnsureResolved();
+    assert(typeVar.maybeEnsureResolved());
     assert.isNull(ingressValidation.getMaxReadType(typeVar));
   });
 

--- a/src/runtime/policy/tests/policy-test.ts
+++ b/src/runtime/policy/tests/policy-test.ts
@@ -874,6 +874,31 @@ policy MyPolicy {
       ingressValidation.getMaxReadType(typeVar), expected);
   });
 
+  it('uses resolved type of a typevar to get max read type', async () => {
+    const manifest = await Manifest.parse(`
+      schema A
+        foo: inline Foo {a: Text, b: Text, c: Text, d: Text}
+
+      policy P {
+        from A access {
+          foo {a, b}
+        }
+      }
+    `);
+    const ingressValidation = new IngressValidation(manifest.policies);
+    const typeVar = await createTypeVarForSchema(
+      'A',
+      'foo: inline Foo {a: Text, d: Text}',
+      'foo: inline Foo {a: Text, d: Text}');
+    typeVar.maybeEnsureResolved();
+    const expected = await createTypeVarForSchema(
+      'A',
+      'foo: inline Foo {a: Text, b: Text}',
+      null);
+    assert.deepEqual(
+      ingressValidation.getMaxReadType(typeVar), expected);
+  });
+
   it('returns null for max read type if type has inaccessible schemas', async () => {
     const manifest = await Manifest.parse(manifestWithMultiplePolicies);
     const ingressValidation = new IngressValidation(manifest.policies);
@@ -906,12 +931,15 @@ policy MyPolicy {
         new CollectionType(manifestSensitiveInfo)));
 
     // Type variable.
-    assert.isNull(
-      ingressValidation.getMaxReadType(
-        TypeVariable.make(
-          '',
-          /* canWriteSuperset = */manifestSensitiveInfo,
-          /* canReadSubset = */manifestSensitiveInfo)));
+    const typeVar = TypeVariable.make(
+      '',
+      /* canWriteSuperset = */manifestSensitiveInfo,
+      /* canReadSubset = */manifestSensitiveInfo);
+    assert.isNull(ingressValidation.getMaxReadType(typeVar));
+
+    // Resolved Type variable.
+    typeVar.maybeEnsureResolved();
+    assert.isNull(ingressValidation.getMaxReadType(typeVar));
   });
 
   it('returns error details if type has inaccessible schemas', async () => {


### PR DESCRIPTION
This PR fixes a bug where resolved type variables are not properly taken care of in `getMaxReadType` API.