### PR TITLE
Ensure ingress validation does not allow reads outside of policy.

### DIFF
--- a/src/runtime/policy/ingress-validation.ts
+++ b/src/runtime/policy/ingress-validation.ts
@@ -76,7 +76,10 @@ export class IngressValidation {
         handle.type.resolvedType().getEntitySchema());
       for (const fieldPath of fieldPaths) {
         const fieldCapabilities = this.getFieldCapabilities(fieldPath);
-        assert(fieldCapabilities, `Missing capabilities for ${fieldPath}`);
+        if (fieldCapabilities == null) {
+          return IngressValidationResult.failWith(
+            handle, `Missing capabilities for ${fieldPath}: is it mentioned in policy?`);
+        }
         if (!capabilitiesByField.has(fieldPath)) {
           capabilitiesByField.set(fieldPath, []);
         }

--- a/src/tools/tests/allocator-recipe-resolver-test.ts
+++ b/src/tools/tests/allocator-recipe-resolver-test.ts
@@ -1565,14 +1565,14 @@ recipe ThingWriter
   // In the tests below, `AnotherThing` will have restrictions in the policy and ingress
   // validation should allow it to be read.
   const outsideOfPolicyReads = `
-schema Thing {a: Text, b: Text, c: Text, d: Text}
-schema AnotherThing {w: Text, x: Text, y: Text, z: Text}
+schema Thing {a: Text, b: Text}
+schema AnotherThing {w: Text, x: Text}
 
 particle ThingWriter
   thingOut: writes [Thing]
 particle ThingReader
-  thingIn: reads [Thing {a, b, c}]
-  anotherOut: writes [AnotherThing {w, x, y, z}]
+  thingIn: reads [Thing {a}]
+  anotherOut: writes [AnotherThing {w, x}]
 particle AnotherReader
   anotherIn: reads [AnotherThing]
 
@@ -1592,13 +1592,13 @@ recipe R
   it('does not allow reads if schema is not mentioned in policy', async () => {
     const manifest = await Manifest.parse(outsideOfPolicyReads);
     const policies = await Manifest.parse(`
-schema Thing {a: Text, b: Text, c: Text, d: Text}
-schema AnotherThing {w: Text, x: Text, y: Text, z: Text}
+schema Thing {a: Text, b: Text}
+schema AnotherThing {w: Text, x: Text}
 
 policy Policy {
   @allowedRetention(medium: 'Disk', encryption: false)
   @maxAge('10d')
-  from Thing access { a, b, c }
+  from Thing access { a }
 }`);
     await assertThrowsAsync(
       async () => {
@@ -1614,17 +1614,17 @@ policy Policy {
   it('does not allow reads if field is not mentioned in policy', async () => {
     const manifest = await Manifest.parse(outsideOfPolicyReads);
     const policies = await Manifest.parse(`
-schema Thing {a: Text, b: Text, c: Text, d: Text}
-schema AnotherThing {w: Text, x: Text, y: Text, z: Text}
+schema Thing {a: Text, b: Text}
+schema AnotherThing {w: Text, x: Text}
 
 policy Policy {
   @allowedRetention(medium: 'Disk', encryption: false)
   @maxAge('10d')
-  from Thing access { a, b, c }
+  from Thing access { a }
 
   @allowedRetention(medium: 'Disk', encryption: false)
   @maxAge('10d')
-  from AnotherThing access { w, x, y }
+  from AnotherThing access { w }
 }`);
     await assertThrowsAsync(
       async () => {
@@ -1633,7 +1633,7 @@ policy Policy {
       },
       AllocatorRecipeResolverError,
       `Failed ingress validation for plan R: Validation result: Failure\n`+
-        `     Missing capabilities for AnotherThing.z: is it mentioned in policy?`
+        `     Missing capabilities for AnotherThing.x: is it mentioned in policy?`
     );
   });
 


### PR DESCRIPTION
This PR mainly adds tests to ensure that if there are reads of schemas not mentioned in policy, it is not accidentally persisted. Specifically, this PR has the following changes:
  - Changes an assert into an error.
  - Adds tests to capture the desired behavior.