### PR TITLE
Type annotations (hardening) for Type|TypeLiteral fixes

### DIFF
--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -184,8 +184,10 @@ describe('FindHostedParticle', () => {
     assert.isNotNull(particleSpec['id'], 'particleSpec stored in handle should have an id');
     delete particleSpec['id'];
     await arc.idle;
-    deleteFieldRecursively(manifest.findParticleByName('TestParticle'), 'location');
-    deleteFieldRecursively(particleSpec, 'location');
-    assert.deepEqual(manifest.findParticleByName('TestParticle').toLiteral(), particleSpec.toLiteral());
+    const particleSpecLiteral = particleSpec.toLiteral();
+    const manifestParticleLiteral = manifest.findParticleByName('TestParticle').toLiteral();
+    deleteFieldRecursively(manifestParticleLiteral, 'location');
+    deleteFieldRecursively(particleSpecLiteral, 'location');
+    assert.deepEqual(manifestParticleLiteral, particleSpecLiteral);
   });
 });

--- a/src/runtime/arcs-types/particle-spec.ts
+++ b/src/runtime/arcs-types/particle-spec.ts
@@ -23,7 +23,7 @@ import {resolveFieldPathType} from '../field-path.js';
 
 // TODO: clean up the real vs. literal separation in this file
 
-type SerializedHandleConnectionSpec = {
+export type SerializedHandleConnectionSpec = {
   direction: Direction,
   relaxed: boolean,
   name: string,

--- a/src/runtime/arcs-types/particle-spec.ts
+++ b/src/runtime/arcs-types/particle-spec.ts
@@ -21,13 +21,11 @@ import * as AstNode from '../manifest-ast-types/manifest-ast-nodes.js';
 import {AnnotationRef} from './annotation.js';
 import {resolveFieldPathType} from '../field-path.js';
 
-// TODO: clean up the real vs. literal separation in this file
-
 export type SerializedHandleConnectionSpec = {
   direction: Direction,
   relaxed: boolean,
   name: string,
-  type: Type | TypeLiteral,
+  type: TypeLiteral,
   isOptional: boolean,
   tags?: string[],
   dependentConnections: SerializedHandleConnectionSpec[],

--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -914,8 +914,10 @@ export const PAXEL_FUNCTIONS: PaxelFunction[] = [
   makePaxelCollectionTypeFunction(PaxelFunctionName.First, 1)
 ];
 
-export type PaxelExpressionNode = FromExpressionNode | WhereExpressionNode | LetExpressionNode |
-  SelectExpressionNode | NewExpressionNode | FunctionExpressionNode | RefinementExpressionNode;
+export type PaxelExpressionNode = (FromExpressionNode | WhereExpressionNode | LetExpressionNode |
+  SelectExpressionNode | NewExpressionNode | FunctionExpressionNode | RefinementExpressionNode) & {
+  unparsedPaxelExpression?: string;
+};
 
 export interface ExpressionEntity extends BaseNode {
   kind: 'expression-entity';

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1766,8 +1766,7 @@ ExpressionWithQualifier
 PaxelExpression
   = expr:(NewExpression / ExpressionWithQualifier / RefinementExpression) {
     // Attaches entire expression text to the top level paxel expression node.
-    expr.unparsedPaxelExpression = text();
-    return expr;
+    return toAstNode<AstNode.PaxelExpressionNode>({...expr, unparsedPaxelExpression: text()});
   }
 
 SourceExpression "a scope lookup or a sub-expression,e.g. from p in (paxel expression)"

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -887,6 +887,17 @@ ${e.message}
           warning.key = 'externalSchemas';
           manifest.errors.push(warning);
         }
+        if (model.getEntitySchema()) {
+          // TODO: This should be done as a single pass over all annotation sets.
+          const manifestSchema = manifest.findSchemaByName(model.getEntitySchema().name);
+          const fields = model.getEntitySchema().fields;
+          for (const name of Object.keys(fields)) {
+            // If we have an external schema, annotations were already converted.
+            if (!manifestSchema || !manifestSchema.fields[name]) {
+              fields[name].annotations = Manifest._buildAnnotationRefs(manifest, (fields[name].annotations as unknown) as AstNode.AnnotationRefNode[]);
+            }
+          }
+        }
         const dependentConnections = processArgTypes(arg.dependentConnections);
         const newArg: SerializedHandleConnectionSpec = {
           ...arg,

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -843,7 +843,7 @@ ${e.message}
       annotationItem.allowMultiple, annotationItem.doc);
   }
 
-  private static _processParticle(manifest: Manifest, particleItem, loader?: LoaderBase) {
+  private static _processParticle(manifest: Manifest, particleItem: AstNode.Particle, loader?: LoaderBase) {
     // TODO: we should be producing a new particleSpec, not mutating
     //       particleItem directly.
     // TODO: we should require both of these and update failing tests...

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -88,9 +88,9 @@ describe('particle interface loading', () => {
       verbs: [],
       implFile: 'outer-particle.js',
       args: [
-        {direction: 'hosts', relaxed: false, type: ifaceType, name: 'particle0', dependentConnections: [], isOptional: false, annotations: []},
-        {direction: 'reads', relaxed: false, type: fooType, name: 'input', dependentConnections: [], isOptional: false, annotations: []},
-        {direction: 'writes', relaxed: false, type: barType, name: 'output', dependentConnections: [], isOptional: false, annotations: []}
+        {direction: 'hosts', relaxed: false, type: ifaceType.toLiteral(), name: 'particle0', dependentConnections: [], isOptional: false, annotations: []},
+        {direction: 'reads', relaxed: false, type: fooType.toLiteral(), name: 'input', dependentConnections: [], isOptional: false, annotations: []},
+        {direction: 'writes', relaxed: false, type: barType.toLiteral(), name: 'output', dependentConnections: [], isOptional: false, annotations: []}
       ],
     });
 

--- a/src/types/internal/schema-field.ts
+++ b/src/types/internal/schema-field.ts
@@ -10,12 +10,13 @@
 
 import {assert} from '../../platform/assert-web.js';
 import {Refinement} from './refiner.js';
-import {EntityType, ReferenceType, Type} from './type.js';
+import {EntityType, ReferenceType, Type, TypeLiteral} from './type.js';
 import {AnnotationRef} from '../../runtime/arcs-types/annotation.js';
 import {SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue, BinaryExpressionNode, SchemaFieldKind as Kind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
+export type SchemaFieldLiteralShape  = {kind: Kind, schema?: SchemaFieldLiteralShape, model?: TypeLiteral};
 // tslint:disable-next-line: no-any
-type SchemaFieldMethod  = (field: {}) => FieldType;
+type SchemaFieldMethod  = (field: SchemaFieldLiteralShape) => FieldType;
 
 export abstract class FieldType {
   public refinement: Refinement = null;
@@ -71,7 +72,7 @@ export abstract class FieldType {
     return this.equals(other);
   }
 
-  static create(theField: {}|string): FieldType {
+  static create(theField: SchemaFieldLiteralShape|string): FieldType {
     let newField = null;
     // tslint:disable-next-line: no-any
     const field = theField as any;

--- a/src/types/internal/schema-field.ts
+++ b/src/types/internal/schema-field.ts
@@ -19,7 +19,7 @@ type SchemaFieldMethod  = (field: {}) => FieldType;
 
 export abstract class FieldType {
   public refinement: Refinement = null;
-  public readonly annotations: AnnotationRef[] = [];
+  public annotations: AnnotationRef[] = [];
 
   protected constructor(public readonly kind: Kind) {}
   get isPrimitive(): boolean { return this.kind === Kind.Primitive; }

--- a/src/types/internal/schema-from-literal.ts
+++ b/src/types/internal/schema-from-literal.ts
@@ -11,7 +11,7 @@
 import {Schema} from './schema.js';
 import {Type, EntityType} from './type.js';
 import {Refinement} from './refiner.js';
-import {FieldType} from './schema-field.js';
+import {FieldType, SchemaFieldLiteralShape} from './schema-field.js';
 import {SchemaFieldKind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
 function fromLiteral(data = {fields: {}, names: [], description: {}, refinement: null}) {


### PR DESCRIPTION
Works towards fixing serialization problems in ParticleSpec due to non-specificity of types.

See: b/178046886

Note: Intended to be stacked on https://github.com/PolymerLabs/arcs/pull/6854