### PR TITLE
Type vs type literal (part 3)

### DIFF
--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -756,7 +756,17 @@ export const schemaPrimitiveTypes = [
 
 export type SchemaPrimitiveTypeValue = typeof schemaPrimitiveTypes[number];
 
-export type KotlinPrimitiveTypeValue = 'Byte'|'Short'|'Int'|'Long'|'Char'|'Float'|'Double';
+export const kotlinPrimitiveTypes = [
+  'Byte',
+  'Short',
+  'Int',
+  'Long',
+  'Char',
+  'Float',
+  'Double',
+] as const;
+
+export type KotlinPrimitiveTypeValue = typeof kotlinPrimitiveTypes[number];
 
 export const discreteTypes = [
   'BigInt',

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1716,7 +1716,7 @@ SchemaReferenceType = '&' whiteSpace? schema:(SchemaInline / TypeName)
   }
 
 SchemaPrimitiveType
-  = type:('Text' / 'URL' / 'Number' / 'BigInt' / 'Boolean' / 'Bytes' / 'Instant' / 'Duration')
+  = type:('Text' / 'URL' / 'Object' / 'Number' / 'BigInt' / 'Boolean' / 'Bytes' / 'Instant' / 'Duration')
   {
     return toAstNode<AstNode.SchemaPrimitiveType>({
       kind: AstNode.SchemaFieldKind.Primitive,

--- a/src/types/internal/type.ts
+++ b/src/types/internal/type.ts
@@ -21,6 +21,7 @@ import {Primitive, SourceLocation} from '../../runtime/manifest-ast-types/manife
 import {digest} from '../../platform/digest-web.js';
 import {Consumer} from '../../utils/lib-utils.js';
 import {SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue, SchemaFieldKind as Kind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
+import {Dictionary, Predicate, IndentingStringBuilder} from '../../utils/lib-utils.js';
 
 export interface TypeLiteral extends Literal {
   tag: string;

--- a/src/types/internal/type.ts
+++ b/src/types/internal/type.ts
@@ -1775,22 +1775,6 @@ export abstract class FieldType {
     newField.annotations = field.annotations || [];
     return newField;
   }
-
-  static fromLiteral(field): FieldType {
-  const kind = field.kind;
-  switch (kind) {
-    case SchemaFieldKind.Reference:
-      return FieldType.create({...field, kind, schema: {kind: field.schema.kind, model: Type.fromLiteral(field.schema.model)}});
-    case SchemaFieldKind.Collection:
-    case SchemaFieldKind.OrderedList:
-      return FieldType.create({...field, kind, schema: FieldType.fromLiteral(field.schema)});
-    case SchemaFieldKind.Inline:
-      return FieldType.create({...field, kind, model: EntityType.fromLiteral(field.model)});
-    default:
-      return FieldType.create(field);
-  }
-}
-
 }
 
 export class PrimitiveField extends FieldType {

--- a/src/types/internal/type.ts
+++ b/src/types/internal/type.ts
@@ -9,19 +9,18 @@
  */
 
 import {assert} from '../../platform/assert-web.js';
-import {Refinement, AtLeastAsSpecific} from './refiner.js';
+import {Refinement, AtLeastAsSpecific, RefinementExpressionLiteral} from './refiner.js';
 import {SlotInfo} from './slot-info.js';
 import {AnnotationRef} from '../../runtime/arcs-types/annotation.js';
 import {Direction, SlotDirection} from '../../runtime/arcs-types/enums.js';
 import {ParticleSpec} from '../../runtime/arcs-types/particle-spec.js';
-import {CRDTTypeRecord, CRDTModel, CRDTCount, CRDTCollection, CRDTSingleton, CRDTEntity, SingletonEntityModel, CollectionEntityModel, Referenceable} from '../../crdt/lib-crdt.js';
-import {Dictionary, Predicate, Literal, IndentingStringBuilder} from '../../utils/lib-utils.js';
+import {CRDTTypeRecord, CRDTEntity, CRDTModel, CRDTCount, CRDTCollection, CRDTSingleton, SingletonEntityModel, CollectionEntityModel, Referenceable} from '../../crdt/lib-crdt.js';
 import {Flags} from '../../runtime/flags.js';
-import {mergeMapInto} from '../../utils/lib-utils.js';
+import {Literal, mergeMapInto} from '../../utils/lib-utils.js';
 import {Primitive, SourceLocation} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 import {digest} from '../../platform/digest-web.js';
 import {Consumer} from '../../utils/lib-utils.js';
-import {SchemaFieldKind, SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue, SchemaFieldKind as Kind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
+import {SchemaPrimitiveTypeValue, KotlinPrimitiveTypeValue, SchemaFieldKind as Kind} from '../../runtime/manifest-ast-types/manifest-ast-nodes.js';
 
 export interface TypeLiteral extends Literal {
   tag: string;
@@ -1720,6 +1719,10 @@ export abstract class FieldType {
     return this.equals(other);
   }
 
+  static fromLiteral(field: SchemaFieldLiteralShape|string): FieldType {
+    return FieldType.create(field);
+  }
+
   static create(theField: SchemaFieldLiteralShape|string): FieldType {
     let newField = null;
     // tslint:disable-next-line: no-any
@@ -1745,9 +1748,16 @@ export abstract class FieldType {
           newField = new OrderedListField(FieldType.create(field.schema));
           break;
         case Kind.Inline:
-        case Kind.TypeName:
-          newField = new InlineField(field.model);
+        case Kind.TypeName: {
+          assert(field.model.tag === 'Entity');
+          let model = field.model;
+          if (!(model instanceof EntityType)) {
+            // TODO(b/178046886): remove this when models are always literals.
+            model = Type.fromLiteral(model) as EntityType;
+          }
+          newField = new InlineField(model);
           break;
+        }
         case Kind.Union:
           newField = new UnionField(field.types.map(type => FieldType.create(type)));
           break;
@@ -1984,8 +1994,12 @@ export class InlineField extends FieldType {
 
 // Moved from ./schema.ts
 
-// tslint:disable-next-line: no-any
-type SchemaMethod  = (data?: { fields: {}; names: any[]; description: {}; refinement: {}}) => Schema;
+export type SchemaLiteral = {
+  fields: {[index: string]: SchemaFieldLiteralShape};
+  names: string[];
+  description: {};
+  refinement: {kind: string, expression: RefinementExpressionLiteral};
+};
 
 export class Schema {
   readonly names: string[];
@@ -1997,8 +2011,7 @@ export class Schema {
   hashStr: string = null;
   _annotations: AnnotationRef[];
   location?: SourceLocation = null;
-
-  static fromLiteral(data = {fields: {}, names: [], description: {}, refinement: null}) {
+  static fromLiteral(data: SchemaLiteral = {fields: {}, names: [], description: {}, refinement: null}) {
     const fields = {};
     for (const key of Object.keys(data.fields)) {
       fields[key] = FieldType.fromLiteral(data.fields[key]);
@@ -2013,7 +2026,6 @@ export class Schema {
     }
     return result;
   }
-
 
   static EMPTY = new Schema([], {});
 
@@ -2086,7 +2098,7 @@ export class Schema {
     return schema;
   }
 
-  toLiteral() {
+  toLiteral(): SchemaLiteral {
     const fields = {};
     for (const key of Object.keys(this.fields)) {
       fields[key] = this.fields[key].toLiteral();

--- a/src/types/internal/type.ts
+++ b/src/types/internal/type.ts
@@ -1665,8 +1665,6 @@ export abstract class InterfaceInfo {
 // Moved from ./schema-field.ts
 
 export type SchemaFieldLiteralShape  = {kind: Kind, schema?: SchemaFieldLiteralShape, model?: TypeLiteral};
-// tslint:disable-next-line: no-any
-type SchemaFieldMethod  = (field: SchemaFieldLiteralShape) => FieldType;
 
 export abstract class FieldType {
   public refinement: Refinement = null;


### PR DESCRIPTION
Stacked on #6870 and https://github.com/PolymerLabs/arcs/pull/6876

Changes to make it easier / possible to perform safe construction of Schemas and Schema FieldTypes from ast structures and literals.

* Creates a list of Kotlin Primitive Types to be used for inclusion checking (and bases the type `KotlinPrimitiveTypeValue` on this list so that the two do not need to be maintained separately (as used for `SchemaPrimitiveTypeValue`).
* Add missing parsing support for the `Object` type which we have in documentation and (it seems) support, but didn't support in the parser. Bug found due to type checking else where showing that this case was unreachable.
* Remove unused SchemaFieldMethod type (no longer used as the FieldType.fromLiteral function is no longer in a separate file)
* Add work around to FieldType.create to catch cases where the `model` has been left as a literal instead of being converted to `EntityType` (this occurs because ParticleSpec must contain literals, where other type construction uses 'real' `EntityType` values
* Replace `FieldType.fromLiteral` function that just calls `FieldType.create` in multiple different ways, with a raw call to `FieldType.create`

* Add types to `Schema.fromLiteral` and remove the `SchemaMethod` type (no longer used as fromLiteral is now defined inline, rather than inserted at runtime)
* Add return type to `Schema.toLiteral` to ensure that to/from literal round trip at least at the type level.

* Replace large schema-field-test handwritten Entity definition with a code generated one to ensure that all primitive Types are covered.
* Turn on nullability support in some other tests to allow nullables to be tested in the same way