### PR TITLE
Make ingress validation consider imported policies in the manifest also.

### DIFF
--- a/src/tools/allocator-recipe-resolver.ts
+++ b/src/tools/allocator-recipe-resolver.ts
@@ -45,7 +45,7 @@ export class AllocatorRecipeResolver {
     this.runtime = new Runtime({context});
     DatabaseStorageKey.register(this.runtime);
     this.ingressValidation = policiesManifest
-        ? new IngressValidation(policiesManifest.policies) : null;
+        ? new IngressValidation(policiesManifest.allPolicies) : null;
   }
 
   /**

--- a/src/tools/tests/test-data/AddressPolicy.arcs
+++ b/src/tools/tests/test-data/AddressPolicy.arcs
@@ -1,0 +1,16 @@
+schema Address
+  number: Number
+  street: Text
+  city: Text
+  zip: Number
+  age: Number
+
+
+policy AddressPolicy {
+  @maxAge(age: '2d')
+  @allowedRetention(medium: 'Ram', encryption: false)
+  from Address access {
+    zip
+  }
+}
+

--- a/src/tools/tests/test-data/MainPolicy.arcs
+++ b/src/tools/tests/test-data/MainPolicy.arcs
@@ -1,0 +1,2 @@
+import './PersonPolicy.arcs'
+import './AddressPolicy.arcs'

--- a/src/tools/tests/test-data/PersonPolicy.arcs
+++ b/src/tools/tests/test-data/PersonPolicy.arcs
@@ -1,0 +1,12 @@
+schema Person
+  name: Text
+  age: Number
+
+policy PersonPolicy {
+  @maxAge(age: '2d')
+  @allowedRetention(medium: 'Ram', encryption: false)
+  from Person access {
+    name
+  }
+}
+


### PR DESCRIPTION
Consider a policy file implemented as follows:

```
import 'policy1.arcs'
import 'policy2.arcs'
```

Ingress validation does not take imported policies into account. This PR fixes this issue.