### PR TITLE
Typo fixes in core/allocator.

### DIFF
--- a/java/arcs/core/allocator/Arc.kt
+++ b/java/arcs/core/allocator/Arc.kt
@@ -34,11 +34,12 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  * Represents an instantiated Arc running on one or more [ArcHost]s. An [Arc] can be stopped
  * via [Arc.stop], and best-effort state changes can be listened for via [onArcStateChange].
  *
- * NOTE: that currently [onArcStateChange] listeners are not persistent across service restarts,
- * therefore if an [ArcHost] is running in a [Service], or on another device, and they restart,
+ * NOTE: that currently [onArcStateChange] listeners are not persistent across service restarts.
+ * Therefore, if an [ArcHost] is running in a [Service], or on another device, and they restart,
  * you will not receive updates from those hosts.
  *
- * TODO: add some mechanism to detect host crashes and re-register state change listeners.
+ * TODO(b/181343961): add some mechanism to detect host crashes and re-register state change
+ *  listeners.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class Arc(
@@ -68,11 +69,11 @@ class Arc(
   )
 
   /**
-   *  The current running state of an Arc. This is computed by computing the dominant state
-   *  across all [ArcHost]s in an [Arc], where dominant ordering is defined by the ordering in
-   *  [ArcState], for example, [Error] is greater than [Running], so if one [ArcHost] is in
-   *  state [Error], and another is in state [Running], the overall state of the [Arc]
-   *  is considered to be [Error].
+   * The current running state of an Arc. This is defined by computing the dominant state across
+   * all [ArcHost]s in an [Arc], where dominant ordering is defined by the ordering in [ArcState].
+   * For example, [ArcState.Error] is greater than [ArcState.Running], so if one [ArcHost] is in
+   * state [ArcState.Error], and another is in state [ArcState.Running], the overall state of the
+   * [Arc] is considered to be [ArcState.Error].
    */
   var arcState: ArcState
     get() = arcStateInternal.value
@@ -80,13 +81,13 @@ class Arc(
       arcStateInternal.update { state }
     }
 
-  /** Called whenever the [ArcState] changes to [Running]. */
+  /** Called whenever the [ArcState] changes to [ArcState.Running]. */
   fun onRunning(handler: () -> Unit): Int = onArcStateChangeFiltered(ArcState.Running, handler)
 
-  /** Called whenever the [ArcState] changes to [Stopped]. */
+  /** Called whenever the [ArcState] changes to [ArcState.Stopped]. */
   fun onStopped(handler: () -> Unit): Int = onArcStateChangeFiltered(ArcState.Stopped, handler)
 
-  /** Called whenever the [ArcState] changes to [Error]. */
+  /** Called whenever the [ArcState] changes to [ArcState.Error]. */
   fun onError(handler: () -> Unit): Int = onArcStateChangeFiltered(ArcState.Error, handler)
 
   /**
@@ -95,10 +96,10 @@ class Arc(
    */
   fun removeHandler(handlerId: Int): Unit = callbacks.update { it.withoutCallback(handlerId) }
 
-  /** Wait for the current [Arc] to enter a [Stopped] state. */
+  /** Wait for the current [Arc] to enter a [ArcState.Stopped] state. */
   suspend fun waitForStop() = waitFor(ArcState.Stopped)
 
-  /** Wait for the current [Arc] to enter a [Running] state. */
+  /** Wait for the current [Arc] to enter a [ArcState.Running] state. */
   suspend fun waitForStart() = waitFor(ArcState.Running)
 
   /** Stop the current [Arc]. */

--- a/java/arcs/core/allocator/CollectionHandlePartitionMap.kt
+++ b/java/arcs/core/allocator/CollectionHandlePartitionMap.kt
@@ -72,7 +72,7 @@ class CollectionHandlePartitionMap(
     }
 
     val writes = withContext(collection().dispatcher) {
-      partitions.map { (_, arcHost, particles) ->
+      val entities = partitions.map { (_, arcHost, particles) ->
         val entity = EntityBase("EntityBase", SCHEMA)
         entity.setSingletonValue("arc", arcId.toString())
         entity.setSingletonValue("host", arcHost)
@@ -80,12 +80,13 @@ class CollectionHandlePartitionMap(
           "particles",
           particles.map { it.particleName }.toSet()
         )
-        log.debug { "Writing $entity" }
-        collection().store(entity)
+        log.debug { "Will write $entity" }
+        entity
       }
+      collection().storeAll(entities)
     }
 
-    writes.joinAll()
+    writes.join()
   }
 
   /** Reads associated [Plan.Partition]s with an [ArcId]. */

--- a/java/arcs/core/allocator/CollectionHandlePartitionMap.kt
+++ b/java/arcs/core/allocator/CollectionHandlePartitionMap.kt
@@ -26,8 +26,8 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.withContext
 
 /**
- * An implementation of [Allocator.PartitionSerialization] that stores partition information in an Arcs
- * collection handle, created by the [HandleManager] provided at construction. The handle
+ * An implementation of [Allocator.PartitionSerialization] that stores partition information in an
+ * Arcs collection handle, created by the [HandleManager] provided at construction. The handle
  * will be created the first time any of the publicly exposed methods is called.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -52,7 +52,7 @@ class CollectionHandlePartitionMap(
     handle.awaitReady()
   }
 
-  /** Persists [ArcId] and associated [Plan.Partition]s */
+  /** Persists [ArcId] and associated [Plan.Partition]s. */
   override suspend fun set(partitions: List<Plan.Partition>) {
     val arcId = partitions.arcId()
     check(partitions.all { it.arcId.toArcId() == arcId }) {
@@ -62,7 +62,7 @@ class CollectionHandlePartitionMap(
     log.debug { "writePartitionMap(arcId=${partitions.arcId()})" }
 
     val currentPartitions = readPartitions(arcId)
-    if (!currentPartitions.isEmpty()) {
+    if (currentPartitions.isNotEmpty()) {
       check(
         partitions.size == currentPartitions.size && partitions.containsAll(currentPartitions)
       ) {
@@ -94,7 +94,7 @@ class CollectionHandlePartitionMap(
 
   /**
    * Reads associated [Plan.Partition]s with an [ArcId] and then immediately clears the entries
-   * for that [Arcid].
+   * for that [ArcId].
    */
   override suspend fun readAndClearPartitions(arcId: ArcId): List<Plan.Partition> {
     val entities = entitiesForArc(arcId)
@@ -105,7 +105,7 @@ class CollectionHandlePartitionMap(
     return entities.map { entityToPartition(it) }
   }
 
-  /** Converts a [RawEntity] to a [Plan.Partition] */
+  /** Converts a [RawEntity] to a [Plan.Partition]. */
   private fun entityToPartition(entity: EntityBase): Plan.Partition =
     Plan.Partition(
       entity.getSingletonValue("arc") as String,
@@ -115,7 +115,7 @@ class CollectionHandlePartitionMap(
       }
     )
 
-  /** Looks up [RawEntity]s representing [Plan.Partition]s for a given [ArcId] */
+  /** Looks up [RawEntity]s representing [Plan.Partition]s for a given [ArcId]. */
   private suspend fun entitiesForArc(arcId: ArcId): List<EntityBase> {
     return withContext(collection().dispatcher) {
       collection().fetchAll()
@@ -123,7 +123,7 @@ class CollectionHandlePartitionMap(
   }
 
   companion object {
-    /** Schema for persistent storage of [Plan.Partition] information */
+    /** Schema for persistent storage of [Plan.Partition] information. */
     private val SCHEMA = Schema(
       setOf(SchemaName("partition")),
       SchemaFields(


### PR DESCRIPTION
Fixed minor typos in allocator docs. Implemented a few nits in code, including updating the `CollectionHandlePartitionMap` to use `storeAll` instead of multiple calls to `store`. 