### PR TITLE
ts allocator & arc-host refactoring (step 1)

### DIFF
--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -121,7 +121,7 @@ async function wrappedExecute() {
 
 async function createRecipeArc(recipe, runtime, index) {
   // ask runtime to assemble arc parameter boilerplate (argument is the arc name)
-  const params = runtime.buildArcParams(`arc${index}`);
+  const params = runtime.host.buildArcParams({arcName: `arc${index}`});
   // construct the arc
   const arc = new Arc({...params, extraArcParams});
   // establish a UI Surface

--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -121,9 +121,9 @@ async function wrappedExecute() {
 
 async function createRecipeArc(recipe, runtime, index) {
   // ask runtime to assemble arc parameter boilerplate (argument is the arc name)
-  const params = runtime.host.buildArcParams({arcName: `arc${index}`});
+  // const params = runtime.host.buildArcParams({arcName: `arc${index}`});
   // construct the arc
-  const arc = new Arc({...params, extraArcParams});
+  const arc = runtime.newArc({/*...params*/arcName: `arc${index}`, ...extraArcParams});
   // establish a UI Surface
   const arcPanel = outputPane.addArcPanel(params.id);
   // attach a renderer (SlotObserver and a DOM node) to the composer

--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -131,7 +131,8 @@ async function createRecipeArc(recipe, runtime, index) {
   arcPanel.attachArc(arc);
   arc.arcPanel = arcPanel;
   try {
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    const plan = await runtime.resolveRecipe(arc, recipe);
+    await runtime.allocator.runPlanInArc(arc.id, plan);
   } catch (x) {
     arcPanel.showError('recipe error', x);
     return;

--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -72,8 +72,9 @@ export class ArcHost {
     return serialization;
   }
   async _spawn(storage, id, serialization, portFactories) {
-    return this.runtime.newArc(id, undefined, {
-      serialization,
+    return this.runtime.newArc({
+      arcName: id,
+      serialization, // TODO(mmandlis): support for `serialization` has been lost.
       storage: `${storage}/${id}`,
       portFactories,
       inspectorFactory: devtoolsArcInspectorFactory,

--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -101,7 +101,7 @@ export class ArcHost {
       log(`plan ${plan.toString({showUnresolved: true})} is not resolved.`);
     }
     try {
-      await arc.instantiate(plan);
+      await this.runtime.allocator.runPlanInArc(arc.id, plan);
     } catch (x) {
       error(x);
       //console.error(plan.toString());

--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -72,13 +72,13 @@ export class ArcHost {
     return serialization;
   }
   async _spawn(storage, id, serialization, portFactories) {
-    return this.runtime.newArc({
+    return this.runtime.getArcById(this.runtime.allocator.newArc({
       arcName: id,
       serialization, // TODO(mmandlis): support for `serialization` has been lost.
       storage: `${storage}/${id}`,
       portFactories,
       inspectorFactory: devtoolsArcInspectorFactory,
-    });
+    }));
   }
   async instantiateDefaultRecipe(arc, manifest) {
     log('instantiateDefaultRecipe');

--- a/shells/pipes-shell/source/verbs/event.js
+++ b/shells/pipes-shell/source/verbs/event.js
@@ -11,6 +11,6 @@
 export const event = async ({pid, particleId, eventlet}, runtime) => {
   // TODO(sjmiles): support either key for particleId (for backward compat)
   const id = particleId || pid;
-  const arc = runtime.findArcByParticleId(id);
+  const arc = runtime.host.findArcByParticleId(id);
   arc.peh.slotComposer.sendEvent(id, eventlet);
 };

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -29,14 +29,14 @@ export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
     warn(`found no recipes matching [${recipe}]`);
     return null;
   }
-  const arc = runtime.newArc({
+  const arc = runtime.getArcById(runtime.allocator.newArc({
     arcName: arcId,
     storageKeyPrefix: storageKeyPrefix || defaultStorageKeyPrefix, // TODO(mmandlis): fix this!
     fileName: './serialized.manifest',
     pecFactories: [runtime.pecFactory, portIndustry(bus, pecId)],
     loader: runtime.loader,
     inspectorFactory: devtoolsArcInspectorFactory
-  });
+  }));
   arc.peh.slotComposer.slotObserver = {
     observe: (content, arc) => {
       bus.send({message: 'output', data: content});

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -29,7 +29,9 @@ export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
     warn(`found no recipes matching [${recipe}]`);
     return null;
   }
-  const arc = runtime.newArc(arcId, storageKeyPrefix || defaultStorageKeyPrefix, {
+  const arc = runtime.newArc({
+    arcName: arcId,
+    storageKeyPrefix: storageKeyPrefix || defaultStorageKeyPrefix, // TODO(mmandlis): fix this!
     fileName: './serialized.manifest',
     pecFactories: [runtime.pecFactory, portIndustry(bus, pecId)],
     loader: runtime.loader,

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -44,83 +44,10 @@ export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
     dispose: () => null
   };
   // optionally instantiate recipe
-  if (action && await instantiateRecipe(arc, runtime, action, particles || [])) {
-    log(`successfully instantiated ${recipe} in ${arc.id}`);
+  if (action) {
+    const plan = await runtime.resolveRecipe(arc, action);
+    await runtime.allocator.runPlanInArc(arc.id, plan);
+    log(`successfully instantiated ${plan} in ${arc.id}`);
   }
   return arc;
 };
-
-const instantiateRecipe = async (arc, runtime, recipe, particles) => {
-  // let plan = await runtime.resolveRecipe(arc, recipe);
-  // if (!plan) {
-  //   warn(`failed to resolve recipe ${recipe}`);
-  //   return false;
-  // }
-
-  // Note: Arc `reinstantiate` support was deprecated and removed.
-
-  // if (matchesRecipe(arc.activeRecipe, plan)) {
-  //   log(`recipe ${recipe} is already instantiated in ${arc}`);
-  //   for (const particle of particles) {
-  //     if (!reinstantiateParticle(arc, particle.id, particle.name)) {
-  //       return false;
-  //     }
-  //   }
-  //   return true;
-  // }
-
-  // for (const particle of particles) {
-  //   plan = updateParticleInPlan(plan, particle.id, particle.name, particle.providedSlotId);
-  //   if (!plan) {
-  //     warn(`failed updating particle id '${particle.id}', name ${particle.name} in recipe ${recipe}`);
-  //     return false;
-  //   }
-  // }
-
-  await runtime.allocator.runPlanInArc(arc.id, recipe);
-  return true;
-};
-
-// const reinstantiateParticle = (arc, particleId, particleName) => {
-//   if (particleId) {
-//     const particle = arc.activeRecipe.particles.find(p => p.id === particleId);
-//     if (particle) {
-//       arc.reinstantiateParticle(particle);
-//       return true;
-//     }
-//     warn(`Particle ${particleName} (${particleId} is not found in the active recipe`);
-//   }
-//   return false;
-// };
-
-// const updateParticleInPlan = (plan, particleId, particleName, providedSlotId) => {
-//   if (!!particleId && !!particleName) {
-//     plan = plan.clone();
-//     const particle = plan.particles.find(p => p.name === particleName);
-//     if (!particle) {
-//       warn(`Cannot find particle ${particleName} in plan = ${plan.toString()}.`);
-//       return null;
-//     }
-//     particle.id = particleId;
-//     if (providedSlotId) {
-//       if (particle.getSlotConnections().length !== 1) {
-//         warn(`Unexpected ${particle.getSlotConnections().length} of consumed slots for particle ${particleName}.`);
-//         return;
-//       }
-//       const providedSlots = Object.values(particle.getSlotConnections()[0].providedSlots);
-//       if (providedSlots.length !== 1) {
-//         warn(`Unexpected ${providedSlots.length} of provided slots for particle ${particleName}.`);
-//       }
-//       providedSlots[0].id = providedSlotId;
-//     }
-//     if (!plan.normalize()) {
-//       warn(`cannot normalize after setting id ${particleId} for particle ${particleName}`);
-//       return null;
-//     }
-//     if (!plan.isResolved()) {
-//       warn(`unresolved plan after setting id ${particleId} for particle ${particleName}`);
-//       return null;
-//     }
-//   }
-//   return plan;
-// };

--- a/shells/pipes-shell/source/verbs/stop-arc.js
+++ b/shells/pipes-shell/source/verbs/stop-arc.js
@@ -9,5 +9,5 @@
  */
 
 export const stopArc = async ({arcId}, runtime) => {
-  runtime.stop(arcId);
+  runtime.allocator.stopArc(arcId);
 };

--- a/shells/tests/arcs/ts/runtime/arc-test.ts
+++ b/shells/tests/arcs/ts/runtime/arc-test.ts
@@ -39,7 +39,7 @@ describe('Arc', () => {
 
     `);
 
-    const params = runtime.buildArcParams('test2');
+    const params = runtime.host.buildArcParams({arcName: 'test2'});
     const arc = new Arc(params);
 
     const barType = runtime.context.findTypeByName('Bar') as EntityType;
@@ -135,7 +135,7 @@ describe('Arc', () => {
         A
           root: consumes root
     `);
-    const opts = runtime.buildArcParams('arcid');
+    const opts = runtime.host.buildArcParams({arcName: 'arcid'});
     const arc = new Arc(opts);
 
     const [recipe] = arc.context.recipes;
@@ -160,7 +160,7 @@ describe('Arc', () => {
             foods: foods
         `);
 
-    const opts = runtime.buildArcParams('test');
+    const opts = runtime.host.buildArcParams({arcName: 'test'});
     const arc = new Arc(opts);
     assert.isNotNull(arc);
 

--- a/shells/tests/arcs/ts/runtime/arc-test.ts
+++ b/shells/tests/arcs/ts/runtime/arc-test.ts
@@ -160,8 +160,7 @@ describe('Arc', () => {
             foods: foods
         `);
 
-    const opts = runtime.host.buildArcParams({arcName: 'test'});
-    const arc = new Arc(opts);
+    const arc = runtime.newArc({arcName: 'test'});
     assert.isNotNull(arc);
 
     const favoriteFoodClass = Entity.createEntityClass(runtime.context.findSchemaByName('FavoriteFood'), null);
@@ -177,10 +176,11 @@ describe('Arc', () => {
     const normalized = recipe.normalize(options);
     assert(normalized, 'not normalized ' + options.errors);
     assert(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const serialization = await arc.serialize();
-    const {loader, slotComposer, context, storageService, driverFactory, capabilitiesResolver, storageKeyParser} = opts;
+    const {loader, slotComposer, context, storageService, driverFactory, capabilitiesResolver, storageKeyParser}
+      = runtime.host.buildArcParams({arcName: 'test'});
     const newArc = await Arc.deserialize({serialization, loader, slotComposer, context, fileName: '', storageService, driverFactory, storageKeyParser});
     assert.strictEqual(newArc.stores.length, 1);
     assert.strictEqual(newArc.activeRecipe.toString(), `@active\n${arc.activeRecipe.toString()}`);

--- a/shells/tests/arcs/ts/runtime/arc-test.ts
+++ b/shells/tests/arcs/ts/runtime/arc-test.ts
@@ -56,7 +56,7 @@ describe('Arc', () => {
     const serialization = await arc.serialize();
     runtime.allocator.stopArc(arc.id);
 
-    const newArc = await runtime.allocator.deserialize({serialization, fileName: './manifest.manifest'});
+    const newArc = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: './manifest.manifest'}));
     await newArc.idle;
     store = newArc.findStoreById(store.id) as StoreInfo<CollectionEntityType>;
     const handle = await handleForStoreInfo(store, newArc);
@@ -174,7 +174,7 @@ describe('Arc', () => {
 
     const serialization = await arc.serialize();
     runtime.allocator.stopArc(arc.id);
-    const newArc = await runtime.allocator.deserialize({serialization, fileName: ''});
+    const newArc = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: ''}));
     assert.strictEqual(newArc.stores.length, 1);
     assert.strictEqual(newArc.activeRecipe.toString(), `@active\n${arc.activeRecipe.toString()}`);
     assert.strictEqual(newArc.id.idTreeAsString(), 'test');

--- a/shells/tests/arcs/ts/runtime/arc-test.ts
+++ b/shells/tests/arcs/ts/runtime/arc-test.ts
@@ -55,9 +55,9 @@ describe('Arc', () => {
     await arc.idle;
 
     const serialization = await arc.serialize();
-    arc.dispose();
-    const {loader, context, slotComposer, storageService, driverFactory, storageKeyParser} = opts;
-    const newArc = await Arc.deserialize({serialization, loader, slotComposer, fileName: './manifest.manifest', context, storageService, driverFactory, storageKeyParser});
+    runtime.allocator.stopArc(arc.id);
+
+    const newArc = await runtime.allocator.deserialize({serialization, fileName: './manifest.manifest'});
     await newArc.idle;
     store = newArc.findStoreById(store.id) as StoreInfo<CollectionEntityType>;
     const handle = await handleForStoreInfo(store, newArc);
@@ -174,11 +174,11 @@ describe('Arc', () => {
     await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const serialization = await arc.serialize();
-    const {loader, slotComposer, context, storageService, driverFactory, capabilitiesResolver, storageKeyParser}
-      = runtime.host.buildArcParams({arcName: 'test'});
-    const newArc = await Arc.deserialize({serialization, loader, slotComposer, context, fileName: '', storageService, driverFactory, storageKeyParser});
+    runtime.allocator.stopArc(arc.id);
+    const newArc = await runtime.allocator.deserialize({serialization, fileName: ''});
     assert.strictEqual(newArc.stores.length, 1);
-    assert.strictEqual(newArc.activeRecipe.toString(), `@active\n${arc.activeRecipe.toString()}`);
+    assert.strictEqual(newArc.activeRecipe.toString(),
+                    `@active\n${arc.activeRecipe.toString()}`);
     assert.strictEqual(newArc.id.idTreeAsString(), 'test');
   });
 });

--- a/shells/tests/arcs/ts/runtime/arc-test.ts
+++ b/shells/tests/arcs/ts/runtime/arc-test.ts
@@ -39,8 +39,7 @@ describe('Arc', () => {
 
     `);
 
-    const opts = runtime.host.buildArcParams({arcName: 'test2'});
-    const arc = runtime.newArc({arcId: opts.id});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test2'}));
 
     const barType = runtime.context.findTypeByName('Bar') as EntityType;
     let store = await arc.createStore(barType.collectionOf(), undefined, 'test:1');
@@ -64,7 +63,7 @@ describe('Arc', () => {
     await handle.add(new handle.entityClass({value: 'one'}));
     await newArc.idle;
 
-    // assert.strictEqual(slotComposer.slotsCreated, 1);
+    //assert.strictEqual(slotComposer.slotsCreated, 1);
   });
 
 
@@ -134,7 +133,7 @@ describe('Arc', () => {
         A
           root: consumes root
     `);
-    const arc = runtime.newArc({arcName: 'arcid'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'arcid'}));
     await runtime.allocator.runPlanInArc(arc.id, arc.context.recipes[0]);
   });
 
@@ -155,7 +154,7 @@ describe('Arc', () => {
             foods: foods
         `);
 
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     assert.isNotNull(arc);
 
     const favoriteFoodClass = Entity.createEntityClass(runtime.context.findSchemaByName('FavoriteFood'), null);
@@ -177,8 +176,7 @@ describe('Arc', () => {
     runtime.allocator.stopArc(arc.id);
     const newArc = await runtime.allocator.deserialize({serialization, fileName: ''});
     assert.strictEqual(newArc.stores.length, 1);
-    assert.strictEqual(newArc.activeRecipe.toString(),
-                    `@active\n${arc.activeRecipe.toString()}`);
+    assert.strictEqual(newArc.activeRecipe.toString(), `@active\n${arc.activeRecipe.toString()}`);
     assert.strictEqual(newArc.id.idTreeAsString(), 'test');
   });
 });

--- a/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
@@ -20,7 +20,7 @@ describe('Hot Code Reload for JS Particle', async () => {
       particle A in './A.js'
         root: consumes Slot
 
-      recipe RecipeA
+      recipe
         slot0: slot 'rootslotid-root'
         A
           root: consumes slot0`);
@@ -36,7 +36,9 @@ describe('Hot Code Reload for JS Particle', async () => {
       });`
     });
     const runtime = new Runtime({loader, context});
-    const arc = await runtime.startArc({arcName: 'HotReload', planName: 'RecipeA'});
+    const arcId = await runtime.allocator.startArc({arcName: 'HotReload'});
+    const arc = runtime.getArcById(arcId);
+
     await arc.idle;
 
     // TODO(sjmiles): render data no longer captured by slot objects

--- a/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
@@ -20,7 +20,7 @@ describe('Hot Code Reload for JS Particle', async () => {
       particle A in './A.js'
         root: consumes Slot
 
-      recipe
+      recipe RecipeA
         slot0: slot 'rootslotid-root'
         A
           root: consumes slot0`);
@@ -36,12 +36,7 @@ describe('Hot Code Reload for JS Particle', async () => {
       });`
     });
     const runtime = new Runtime({loader, context});
-
-    const arc = runtime.newArc('HotReload');
-
-    const [recipe] = arc.context.recipes;
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'HotReload', planName: 'RecipeA'});
     await arc.idle;
 
     // TODO(sjmiles): render data no longer captured by slot objects

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -86,10 +86,9 @@ describe('Multiplexer', () => {
       .newExpectations()
       .expectRenderSlot('List', 'root')
       .expectRenderSlot('ShowOne', 'item', {times: 2})
-      .expectRenderSlot('ShowTwo', 'item')
-      ;
+      .expectRenderSlot('ShowTwo', 'item');
 
-    await suggestions[0].instantiate(arc);
+    await runtime.allocator.runPlanInArc(arc.id, await suggestions[0].getResolvedPlan(arc));
     await arc.idle;
 
     // Add and render one more post

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -158,8 +158,7 @@ describe('Multiplexer', () => {
     const runtime = new Runtime({loader});
     const context = await runtime.parseFile('./shells/tests/artifacts/polymorphic-muxing.recipes');
     //
-    const arcId = await runtime.allocator.startArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()});
-    const arc = runtime.getArcById(arcId);
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()}));
     await arc.idle;
     //
     // NOTE: a direct translation of this to new storage is unlikely to work as

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -73,7 +73,7 @@ describe('Multiplexer', () => {
         }),
         '3', null));
     // version could be set here, but doesn't matter for tests.
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
 
     const observer = new SlotTestObserver();
     arc.peh.slotComposer.observeSlots(observer);
@@ -162,7 +162,7 @@ describe('Multiplexer', () => {
     const runtime = new Runtime({loader});
     const context = await runtime.parseFile('./shells/tests/artifacts/polymorphic-muxing.recipes');
     //
-    const arc = runtime.newArc('fooTest', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()});
     const recipe = context.recipes[0];
     const plan = await runtime.resolveRecipe(arc, recipe);
     await arc.instantiate(plan);

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -74,7 +74,7 @@ describe('Multiplexer', () => {
         '3', null));
     // version could be set here, but doesn't matter for tests.
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver}));
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
@@ -158,7 +158,8 @@ describe('Multiplexer', () => {
     const runtime = new Runtime({loader});
     const context = await runtime.parseFile('./shells/tests/artifacts/polymorphic-muxing.recipes');
     //
-    const arc = await runtime.startArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arcId = await runtime.allocator.startArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(arcId);
     await arc.idle;
     //
     // NOTE: a direct translation of this to new storage is unlikely to work as

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -73,16 +73,14 @@ describe('Multiplexer', () => {
         }),
         '3', null));
     // version could be set here, but doesn't matter for tests.
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
-
-    const observer = new SlotTestObserver();
-    arc.peh.slotComposer.observeSlots(observer);
+    const slotObserver = new SlotTestObserver();
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
 
     // Render 3 posts
-    observer
+    slotObserver
       .newExpectations()
       .expectRenderSlot('List', 'root')
       .expectRenderSlot('ShowOne', 'item', {times: 2})
@@ -95,13 +93,12 @@ describe('Multiplexer', () => {
 
     // new storage doesn't swallow duplicate writes to Singletons, so the multiplexer's behavior of always
     // updating all generated handles when the collection changes is reflected in the rendering pattern.
-    observer
+    slotObserver
       .newExpectations()
       .expectRenderSlot('List', 'root')
       .expectRenderSlot('ShowOne', 'item', {contentTypes: ['templateName', 'model']})
       .expectRenderSlot('ShowOne', 'item', {times: 2})
-      .expectRenderSlot('ShowTwo', 'item')
-      ;
+      .expectRenderSlot('ShowTwo', 'item');
 
     const postsStore = arc.findStoreById(arc.activeRecipe.handles[0].id) as StoreInfo<CollectionEntityType>;
     const postsHandle2 = await handleForStoreInfo(postsStore, arc);
@@ -161,10 +158,7 @@ describe('Multiplexer', () => {
     const runtime = new Runtime({loader});
     const context = await runtime.parseFile('./shells/tests/artifacts/polymorphic-muxing.recipes');
     //
-    const arc = runtime.newArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()});
-    const recipe = context.recipes[0];
-    const plan = await runtime.resolveRecipe(arc, recipe);
-    await arc.instantiate(plan);
+    const arc = await runtime.startArc({arcName: 'fooTest', storageKeyPrefix: storageKeyPrefixForTest()});
     await arc.idle;
     //
     // NOTE: a direct translation of this to new storage is unlikely to work as

--- a/shells/tests/arcs/ts/runtime/multiplexer-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-test.ts
@@ -36,7 +36,7 @@ describe('Multiplexer', () => {
     const recipe = manifest.recipes[0];
     const barType = checkDefined(manifest.findTypeByName('Bar')) as EntityType;
 
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
     const barHandle = await handleForStoreInfo(barStore, arc);
     recipe.handles[0].mapToStorage(barStore);

--- a/shells/tests/arcs/ts/runtime/multiplexer-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-test.ts
@@ -43,7 +43,7 @@ describe('Multiplexer', () => {
     assert(recipe.normalize(), 'normalize');
     assert(recipe.isResolved());
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     await barHandle.add(new barHandle.entityClass({value: 'one'}));

--- a/shells/tests/arcs/ts/runtime/multiplexer-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-test.ts
@@ -36,7 +36,7 @@ describe('Multiplexer', () => {
     const recipe = manifest.recipes[0];
     const barType = checkDefined(manifest.findTypeByName('Bar')) as EntityType;
 
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const barStore = await arc.createStore(barType.collectionOf(), null, 'test:1');
     const barHandle = await handleForStoreInfo(barStore, arc);
     recipe.handles[0].mapToStorage(barStore);

--- a/shells/tests/arcs/ts/runtime/particle-api-more-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-api-more-test.ts
@@ -44,11 +44,8 @@ const getCollectionData = async (arc: Arc, index: number) => {
 
 const spawnTestArc = async (loader) => {
   const runtime = new Runtime({loader});
-  const arc = runtime.newArc('test-arc', storageKeyPrefixForTest());
-  const manifest = await Manifest.load('./manifest', loader);
-  const [recipe] = manifest.recipes;
-  recipe.normalize();
-  await arc.instantiate(recipe);
+  runtime.context = await runtime.parseFile('./manifest');
+  const arc = await runtime.startArc({arcName: 'test-arc', storageKeyPrefix: storageKeyPrefixForTest()});
   await arc.idle;
   return arc;
 };

--- a/shells/tests/arcs/ts/runtime/particle-api-more-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-api-more-test.ts
@@ -45,7 +45,8 @@ const getCollectionData = async (arc: Arc, index: number) => {
 const spawnTestArc = async (loader) => {
   const runtime = new Runtime({loader});
   runtime.context = await runtime.parseFile('./manifest');
-  const arc = await runtime.startArc({arcName: 'test-arc', storageKeyPrefix: storageKeyPrefixForTest()});
+  const arcId = await runtime.allocator.startArc({arcName: 'test-arc', storageKeyPrefix: storageKeyPrefixForTest()});
+  const arc = runtime.getArcById(arcId);
   await arc.idle;
   return arc;
 };

--- a/shells/tests/arcs/ts/runtime/particle-api-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-api-test.ts
@@ -61,7 +61,7 @@ describe('particle-api', () => {
       '*': `defineParticle(({UiParticle}) => class extends UiParticle {});`,
     });
     const runtime = new Runtime({loader, context});
-    const arc = await runtime.startArc({arcName: 'demo'});
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo'}));
     await arc.idle;
 
     assert.lengthOf(arc.activeRecipe.particles, 1);

--- a/shells/tests/arcs/ts/runtime/particle-api-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-api-test.ts
@@ -61,11 +61,7 @@ describe('particle-api', () => {
       '*': `defineParticle(({UiParticle}) => class extends UiParticle {});`,
     });
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc('demo');
-    const [recipe] = arc.context.recipes;
-    recipe.normalize();
-
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'demo'});
     await arc.idle;
 
     assert.lengthOf(arc.activeRecipe.particles, 1);

--- a/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
@@ -42,7 +42,7 @@ describe('particle interface loading with slots', () => {
     assert(recipe.normalize(), `can't normalize recipe`);
     assert(recipe.isResolved(), `recipe isn't resolved`);
 
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const observer = new SlotTestObserver();
     arc.peh.slotComposer.observeSlots(observer);
 

--- a/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
@@ -47,7 +47,7 @@ describe('particle interface loading with slots', () => {
     assert(recipe.isResolved(), `recipe isn't resolved`);
 
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.newArc({arcName: 'test', slotObserver});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', slotObserver}));
 
     return {manifest, recipe, slotObserver, arc};
   }

--- a/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
@@ -21,6 +21,11 @@ import {StoreInfo} from '../../../../../build/runtime/storage/store-info.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('particle interface loading with slots', () => {
+  let runtime = null;
+  before(() => {
+    runtime = new Runtime();
+  });
+
   async function initializeManifestAndArc(contextContainer?):
     Promise<{manifest: Manifest, recipe: Recipe, observer: SlotTestObserver, arc: Arc}> {
     //const loader = new Loader();
@@ -34,7 +39,6 @@ describe('particle interface loading with slots', () => {
           foos: reads handle0
           annotationsSet: consumes slot0
     `;
-    const runtime = new Runtime();
     const manifest = await runtime.parse(manifestText);
 
     //const manifest = await Manifest.parse(manifestText/*, {loader, fileName: ''}*/);
@@ -51,7 +55,7 @@ describe('particle interface loading with slots', () => {
 
   // tslint:disable-next-line: no-any
   async function instantiateRecipeAndStore(arc: Arc, recipe: Recipe, manifest: Manifest): Promise<CollectionEntityHandle> {
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     const inStore = arc.findStoresByType(manifest.findTypeByName('Foo').collectionOf())[0] as StoreInfo<CollectionEntityType>;
     const inHandle = await handleForStoreInfo(inStore, arc);
     await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo1'}), 'subid-1', null));

--- a/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
+++ b/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
@@ -99,7 +99,7 @@ describe('plan consumer', () => {
     assert.strictEqual(suggestionsChangeCount, 1);
     assert.strictEqual(visibleSuggestionsChangeCount, 3);
 
-    await suggestions[0].instantiate(arc);
+    await runtime.allocator.runPlanInArc(arc.id, suggestions[0].plan);
     suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     await storeResults(consumer, suggestions);
     assert.lengthOf(consumer.result.suggestions, 3);

--- a/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
+++ b/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
@@ -58,7 +58,7 @@ describe('plan consumer', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parse(manifestText);
 
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
     let suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const consumer = await createPlanConsumer(arc);

--- a/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
+++ b/shells/tests/arcs/ts/runtime/plan-consumer-test.ts
@@ -58,7 +58,7 @@ describe('plan consumer', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parse(manifestText);
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
     let suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const consumer = await createPlanConsumer(arc);

--- a/shells/tests/arcs/ts/runtime/products-test.ts
+++ b/shells/tests/arcs/ts/runtime/products-test.ts
@@ -32,7 +32,8 @@ describe('products test', () => {
   it('filters', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile(manifestFilename);
-  const arc = await runtime.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), planName: 'FilterBooks'});
+  const arc = runtime.getArcById(
+      await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), planName: 'FilterBooks'}));
     await arc.idle;
     await verifyFilteredBook(arc);
   });
@@ -48,12 +49,12 @@ describe('products test', () => {
         .expectRenderSlot('List', 'root')
         .expectRenderSlot('ShowProduct', 'item')
         ;
-    const arc = await runtime.startArc({
+    const arc = runtime.getArcById(await runtime.allocator.startArc({
       arcName: 'demo',
       storageKeyPrefix: storageKeyPrefixForTest(),
       planName: 'FilterAndDisplayBooks',
       slotObserver
-    });
+    }));
     await arc.idle;
     await verifyFilteredBook(arc);
   });

--- a/shells/tests/arcs/ts/runtime/products-test.ts
+++ b/shells/tests/arcs/ts/runtime/products-test.ts
@@ -32,10 +32,7 @@ describe('products test', () => {
   it('filters', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile(manifestFilename);
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
-    const recipe = arc.context.recipes.find(r => r.name === 'FilterBooks');
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), planName: 'FilterBooks'});
     await arc.idle;
     await verifyFilteredBook(arc);
   });
@@ -43,19 +40,20 @@ describe('products test', () => {
   it('filters and displays', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile(manifestFilename);
-    const arc = runtime.newArc('demo');
-    const recipe = arc.context.recipes.find(r => r.name === 'FilterAndDisplayBooks');
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
 
-    const observer = new SlotTestObserver();
-    arc.peh.slotComposer.observeSlots(observer);
-    observer
+    const slotObserver = new SlotTestObserver();
+    slotObserver
         .newExpectations()
         .expectRenderSlot('List', 'root')
         .expectRenderSlot('List', 'root')
         .expectRenderSlot('ShowProduct', 'item')
         ;
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({
+      arcName: 'demo',
+      storageKeyPrefix: storageKeyPrefixForTest(),
+      planName: 'FilterAndDisplayBooks',
+      slotObserver
+    });
     await arc.idle;
     await verifyFilteredBook(arc);
   });

--- a/shells/tests/arcs/ts/runtime/products-test.ts
+++ b/shells/tests/arcs/ts/runtime/products-test.ts
@@ -32,7 +32,7 @@ describe('products test', () => {
   it('filters', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile(manifestFilename);
-    const arc = await runtime.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), planName: 'FilterBooks'});
+  const arc = await runtime.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), planName: 'FilterBooks'});
     await arc.idle;
     await verifyFilteredBook(arc);
   });

--- a/shells/tests/arcs/ts/runtime/slot-composer-test.ts
+++ b/shells/tests/arcs/ts/runtime/slot-composer-test.ts
@@ -42,7 +42,7 @@ async function init(recipeStr) {
   const runtime = new Runtime({loader, composerClass: TestSlotComposer});
   runtime.context = await runtime.parse(recipeStr);
 
-  const arc = runtime.newArc({arcName: 'test-arc'});
+  const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc'}));
 
   const planner = new Planner();
   const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
@@ -115,7 +115,7 @@ recipe
     runtime.context = await runtime.parseFile(manifest);
 
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver}));
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const suggestion = suggestions.find(s => s.plan.name === 'FilterAndDisplayBooks');
@@ -253,7 +253,7 @@ recipe
         .expectRenderSlot('B', 'detail')
         ;
 
-    await runtime.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+    await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
 
     await slotObserver.expectationsCompleted();
   });

--- a/shells/tests/arcs/ts/runtime/slot-composer-test.ts
+++ b/shells/tests/arcs/ts/runtime/slot-composer-test.ts
@@ -42,7 +42,7 @@ async function initSlotComposer(recipeStr) {
   const runtime = new Runtime({loader, composerClass: TestSlotComposer});
   runtime.context = await runtime.parse(recipeStr);
 
-  const arc = runtime.newArc('test-arc');
+  const arc = runtime.newArc({arcName: 'test-arc'});
 
   const planner = new Planner();
   const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
@@ -114,7 +114,7 @@ recipe
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile(manifest);
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const suggestion = suggestions.find(s => s.plan.name === 'FilterAndDisplayBooks');
@@ -250,19 +250,15 @@ recipe
     const runtime = new Runtime({loader});
     runtime.context = await runtime.parse(contextText);
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
-    const [recipe] = arc.context.recipes;
-    recipe.normalize();
-
-    const observer = new SlotTestObserver();
-    arc.peh.slotComposer.observeSlots(observer);
-
-    observer.newExpectations()
+    const slotObserver = new SlotTestObserver();
+    slotObserver.newExpectations()
         .expectRenderSlot('A', 'content')
         .expectRenderSlot('B', 'detail')
         ;
-    await arc.instantiate(recipe);
-    await observer.expectationsCompleted();
+
+    await runtime.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+
+    await slotObserver.expectationsCompleted();
   });
 
 });

--- a/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
@@ -21,7 +21,7 @@ describe('transformation slots', () => {
     runtime.context = await runtime.parseFile('./shells/tests/artifacts/provide-hosted-particle-slots.manifest');
 
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver}));
 
     slotObserver
       .newExpectations()
@@ -34,7 +34,6 @@ describe('transformation slots', () => {
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
-    // await suggestions[0].instantiate(arc);
     await runtime.allocator.runPlanInArc(arc.id, suggestions[0].plan);
     await arc.idle;
   });

--- a/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
@@ -20,7 +20,7 @@ describe('transformation slots', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./shells/tests/artifacts/provide-hosted-particle-slots.manifest');
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
     const slotComposer = arc.peh.slotComposer;
 
     const observer = new SlotTestObserver();

--- a/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
@@ -20,25 +20,22 @@ describe('transformation slots', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./shells/tests/artifacts/provide-hosted-particle-slots.manifest');
 
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
-    const slotComposer = arc.peh.slotComposer;
+    const slotObserver = new SlotTestObserver();
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
 
-    const observer = new SlotTestObserver();
-    slotComposer.observeSlots(observer);
-
-    observer
+    slotObserver
       .newExpectations()
         .expectRenderSlot('FooList', 'root')
         .expectRenderSlot('ShowFoo', 'item')
         .expectRenderSlot('ShowFoo', 'item', {times: 2})
         .expectRenderSlot('Fooxer', 'item')
         .expectRenderSlot('ShowFooAnnotation', 'annotation')
-        .expectRenderSlot('ShowFooAnnotation', 'annotation', {times: 2})
-        ;
+        .expectRenderSlot('ShowFooAnnotation', 'annotation', {times: 2});
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
-    await suggestions[0].instantiate(arc);
+    // await suggestions[0].instantiate(arc);
+    await runtime.allocator.runPlanInArc(arc.id, suggestions[0].plan);
     await arc.idle;
   });
 });

--- a/shells/tools/single-shell/app.js
+++ b/shells/tools/single-shell/app.js
@@ -16,7 +16,7 @@ import 'https://$particles/Profile/Sharing.recipe'
   `);
   console.log(`context [${context.id}]`);
 
-  const manifest = await Runtime.parse(`import 'https://$particles/${manifestPath || 'Arcs/Login.recipe'}'`);
+  const manifest = await Runtime.parse(`import 'https://$particles/${manifestPath || 'Arcs/Login.arcs'}'`);
   console.log(`manifest [${manifest.id}]`);
 
   const recipe = manifest.allRecipes[0];

--- a/shells/tools/single-shell/index.html
+++ b/shells/tools/single-shell/index.html
@@ -48,7 +48,7 @@ http://polymer.github.io/PATENTS.txt
     rootContainer: document.body
   });
 
-  const manifest = getUrlParam('manifest') || `Arcs/Login.recipe`;
+  const manifest = getUrlParam('manifest') || `Arcs/Login.arcs`;
 
   (async () => {
     try {

--- a/shells/tools/smoke-shell/app.js
+++ b/shells/tools/smoke-shell/app.js
@@ -8,11 +8,13 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Runtime} from '../../build/runtime/runtime.js';
-import {Modality} from '../../build/runtime/modality.js';
+import {Runtime} from '../../../build/runtime/runtime.js';
+import {Modality} from '../../../build/runtime/arcs-types/modality.js';
 
 export const App = async (composer, path) => {
-  const arc = await Runtime.spawnArc({id: 'smoke-arc', composer});
+  // TODO: this is still broken, investigate!
+  const arc = await new Runtime().newArc({arcName: 'smoke-arc', composer});
+  //spawnArc({id: 'smoke-arc', composer});
   arc.modality = Modality.dom;
   console.log(`arc [${arc.id}]`);
   //

--- a/shells/tools/smoke-shell/app.js
+++ b/shells/tools/smoke-shell/app.js
@@ -11,14 +11,12 @@
 import {Runtime} from '../../../build/runtime/runtime.js';
 import {Modality} from '../../../build/runtime/arcs-types/modality.js';
 
-export const App = async (composer, path) => {
-  // TODO: this is still broken, investigate!
-  const arc = await new Runtime().newArc({arcName: 'smoke-arc', composer});
-  //spawnArc({id: 'smoke-arc', composer});
+export const App = async (runtime, composer, path) => {
+  const arc = runtime.getArcById(await runtime.allocator.newArc({arcName: 'smoke-arc', composer}));
   arc.modality = Modality.dom;
   console.log(`arc [${arc.id}]`);
   //
-  const manifest = await Runtime.parse(`import 'https://$particles/${path}'`);
+  const manifest = await runtime.parse(`import 'https://$particles/${path}'`);
   console.log(`manifest [${manifest.id}]`);
   //
   //const recipe = manifest.findRecipesByVerb('login')[0];
@@ -27,10 +25,7 @@ export const App = async (composer, path) => {
   //
   if (recipe) {
     console.log(`recipe [${recipe.name}]`);
-    const plan = await Runtime.resolveRecipe(arc, recipe);
-    if (plan) {
-      await arc.instantiate(plan);
-    }
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
   }
   //
   console.log(`\narc serialization`);

--- a/shells/tools/smoke-shell/serve.sh
+++ b/shells/tools/smoke-shell/serve.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-node --no-warnings --experimental-modules --loader ../../tools/custom-loader.mjs ./smoke.js "$@"
+node --no-warnings --experimental-modules --loader ../../../tools/custom-loader.mjs ./smoke.js "$@"

--- a/shells/tools/smoke-shell/smoke.html
+++ b/shells/tools/smoke-shell/smoke.html
@@ -22,15 +22,15 @@
   (async () => {
     try {
       // read intent
-      const manifest = getUrlParam('manifest') || getUrlParam('m') || `Arcs/Login.recipe`;
+      const manifest = getUrlParam('manifest') || getUrlParam('m') || `Arcs/Login.arcs`;
       // configure arcs environment
-      const runtime = new Runtime({rootPath: '../..'});
+      const runtime = new Runtime({rootPath: '../../..'});
       // construct renderer
       const composer = new SlotComposer();
       // establish surface
       composer.observeSlots(new SlotObserver(document.body));
       // start app
-      await App(composer, manifest);
+      await App(runtime, composer, manifest);
     } catch (x) {
       console.error(x);
     }

--- a/shells/tools/smoke-shell/smoke.html
+++ b/shells/tools/smoke-shell/smoke.html
@@ -10,9 +10,9 @@
 
 <script type="module">
   import {App} from './app.js';
-  import {Runtime} from '../../build/runtime/runtime.js';
-  import {SlotComposer} from '../../build/runtime/slot-composer.js';
-  import {SlotObserver} from '../lib/xen-renderer.js';
+  import {Runtime} from '../../../build/runtime/runtime.js';
+  import {SlotComposer} from '../../../build/runtime/slot-composer.js';
+  import {SlotObserver} from '../../lib/xen-renderer.js';
 
   const getUrlParam = name => {
     return new URL(document.location.href).searchParams.get(name);

--- a/shells/tools/smoke-shell/smoke.js
+++ b/shells/tools/smoke-shell/smoke.js
@@ -21,7 +21,7 @@ console.log('\n--- Arcs Shell ---\n');
     const runtime = new Runtime({rootPath: '../..'});
     // create a composer
     const composer = new SlotComposer();
-    await App(composer, `Arcs/Login.recipe`);
+    await App(composer, `Arcs/Login.arcs`);
   } catch (x) {
     console.error(x);
   }

--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -21,15 +21,15 @@ import {ActiveSingletonEntityStore, handleForStoreInfo} from '../../runtime/stor
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
 
 describe('ArcStoresFetcher', () => {
-  before(() => DevtoolsForTests.ensureStub());
-  after(() => DevtoolsForTests.reset());
+  beforeEach(() => DevtoolsForTests.ensureStub());
+  afterEach(() => DevtoolsForTests.reset());
 
   it('allows fetching a list of arc stores', async () => {
     const context = await Manifest.parse(`
       schema Foo
         value: Text`);
     const runtime = new Runtime({context});
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
     const fooStore = await arc.createStore(new SingletonType(foo.type), 'fooStoreName', 'fooStoreId', ['awesome', 'arcs']);
@@ -108,18 +108,16 @@ describe('ArcStoresFetcher', () => {
         value: Text
       particle P in 'p.js'
         foo: reads writes Foo
-      recipe
+      recipe FooPlan
         foo: create *
         P
           foo: foo`);
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {
+    const arc = await runtime.startArc({
+      arcName: 'demo',
+      storageKeyPrefix: storageKeyPrefixForTest(),
       inspectorFactory: devtoolsArcInspectorFactory
     });
-
-    const recipe = arc.context.recipes[0];
-    recipe.normalize();
-    await arc.instantiate(recipe);
 
     assert.isEmpty(DevtoolsForTests.channel.messages.filter(
         m => m.messageType === 'store-value-changed'));

--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -48,7 +48,6 @@ describe('ArcStoresFetcher', () => {
     const results = DevtoolsForTests.channel.messages.filter(
         m => m.messageType === 'fetch-stores-result');
     assert.lengthOf(results, 1);
-
     // Location in the schema file is stored in the type and used by some tools.
     // We don't assert on it in this test.
     deleteFieldRecursively(results, 'location');
@@ -123,7 +122,6 @@ describe('ArcStoresFetcher', () => {
         m => m.messageType === 'store-value-changed'));
 
     await arc.idle;
-
     const results = DevtoolsForTests.channel.messages.filter(
         m => m.messageType === 'store-value-changed');
     assert.lengthOf(results, 1);

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -41,7 +41,7 @@ describe('DevtoolsArcInspector', () => {
         P
           foo: foo`);
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
     const fooStore = await arc.createStore(new SingletonType(foo.type), undefined, 'fooStore');

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -41,7 +41,7 @@ describe('DevtoolsArcInspector', () => {
         P
           foo: foo`);
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory}));
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
     const fooStore = await arc.createStore(new SingletonType(foo.type), undefined, 'fooStore');

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -48,8 +48,7 @@ describe('DevtoolsArcInspector', () => {
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(fooStore);
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const instantiateParticleCall = DevtoolsForTests.channel.messages.find(m =>
       m.messageType === 'PecLog' && m.messageBody.name === 'InstantiateParticle').messageBody;

--- a/src/planning/plan/plan-producer.ts
+++ b/src/planning/plan/plan-producer.ts
@@ -64,7 +64,7 @@ export class PlanProducer {
     this.runtime = runtime;
     this.result = result;
     this.recipeIndex = RecipeIndex.create(this.arc);
-    this.speculator = new Speculator();
+    this.speculator = new Speculator(this.runtime);
     this.searchStore = searchStore;
     this.inspector = inspector;
     if (this.searchStore) {

--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -63,9 +63,9 @@ ${addRecipe(['ParticleTouch'])}
 ${addRecipe(['ParticleDom', 'ParticleBoth'])}
 ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
       `);
-      //runtime.context = context;
+      runtime.context = context;
 
-      const arc = runtime.newArc('demo', storageKeyPrefixForTest(), {modality});
+      const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), modality});
       assert.lengthOf(context.allRecipes, 4);
 
       const consumer = await createPlanConsumer(arc, context);

--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -65,7 +65,7 @@ ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
       `);
       runtime.context = context;
 
-      const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), modality});
+      const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), modality}));
       assert.lengthOf(context.allRecipes, 4);
 
       const consumer = await createPlanConsumer(arc, context);

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -81,10 +81,10 @@ describe('plan producer', () => {
   async function createProducer() {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
     const suggestions = await StrategyTestHelper.planForArc(
       runtime,
-      runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()})
+      runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}))
     );
     const store = await Planificator['_initSuggestStore'](arc, storageKeyForTest(arc.id));
     assert.isNotNull(store);
@@ -167,7 +167,7 @@ describe('plan producer - search', () => {
       schema Bar
         value: Text
     `);
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix: storageKeyForTest, arcId: ArcId.newForTest('test')});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix: storageKeyForTest, arcId: ArcId.newForTest('test')}));
     const searchStore = await Planificator['_initSearchStore'](arc);
 
     const producer = new TestSearchPlanProducer(arc, runtime, searchStore);

--- a/src/planning/plan/tests/plan-producer-test.ts
+++ b/src/planning/plan/tests/plan-producer-test.ts
@@ -81,10 +81,10 @@ describe('plan producer', () => {
   async function createProducer() {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
     const suggestions = await StrategyTestHelper.planForArc(
       runtime,
-      runtime.newArc('demo', storageKeyPrefixForTest())
+      runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()})
     );
     const store = await Planificator['_initSuggestStore'](arc, storageKeyForTest(arc.id));
     assert.isNotNull(store);
@@ -167,7 +167,7 @@ describe('plan producer - search', () => {
       schema Bar
         value: Text
     `);
-    const arc = runtime.newArc('test', storageKeyForTest, {id: ArcId.newForTest('test')});
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix: storageKeyForTest, arcId: ArcId.newForTest('test')});
     const searchStore = await Planificator['_initSearchStore'](arc);
 
     const producer = new TestSearchPlanProducer(arc, runtime, searchStore);

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -88,16 +88,7 @@ describe.skip('remote planificator', () => {
     await consumePlanificator.setSearch(null);
     await consumePlanificator.consumer.result.clear();
     //
-    const deserializedArc = await Arc.deserialize({serialization,
-      slotComposer: new SlotComposer(),
-      loader: new Loader(),
-      fileName: '',
-      pecFactories: undefined,
-      context: consumePlanificator.arc.context,
-      storageService: runtime.storageService,
-      driverFactory: runtime.driverFactory,
-      storageKeyParser: runtime.storageKeyParser
-    });
+    const deserializedArc = await runtime.allocator.deserialize({slotComposer: new SlotComposer(), fileName: ''});
     //
     producePlanificator = new Planificator(
       deserializedArc,

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -88,7 +88,7 @@ describe.skip('remote planificator', () => {
     await consumePlanificator.setSearch(null);
     await consumePlanificator.consumer.result.clear();
     //
-    const deserializedArc = await runtime.allocator.deserialize({slotComposer: new SlotComposer(), fileName: ''});
+    const deserializedArc = runtime.getArcById(await runtime.allocator.deserialize({slotComposer: new SlotComposer(), fileName: ''}));
     //
     producePlanificator = new Planificator(
       deserializedArc,

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -25,7 +25,7 @@ describe('planificator', () => {
   it('constructs suggestion and search storage keys for fb arc', async () => {
     const runtime = new Runtime();
     const storageKeyPrefix = () => new MockFirebaseStorageKey('location');
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix}));
 
     const verifySuggestion = (storageKeyBase) => {
       const key = Planificator.constructSuggestionKey(arc, storageKeyBase);
@@ -58,7 +58,7 @@ describe.skip('remote planificator', () => {
     runtime.context = manifestString
         ? await runtime.parse(manifestString)
         : await runtime.parseFile(manifestFilename);
-    return runtime.newArc({arcName: 'demo', storageKeyPrefix});
+    return runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix}));
   }
 
   async function createConsumePlanificator(manifestFilename) {

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -24,8 +24,8 @@ import {MockFirebaseStorageKey} from '../../../runtime/storage/testing/mock-fire
 describe('planificator', () => {
   it('constructs suggestion and search storage keys for fb arc', async () => {
     const runtime = new Runtime();
-    const arcStorageKey = () => new MockFirebaseStorageKey('location');
-    const arc = runtime.newArc('demo', arcStorageKey);
+    const storageKeyPrefix = () => new MockFirebaseStorageKey('location');
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
 
     const verifySuggestion = (storageKeyBase) => {
       const key = Planificator.constructSuggestionKey(arc, storageKeyBase);
@@ -53,12 +53,12 @@ describe.skip('remote planificator', () => {
     runtime = new Runtime();
   });
 
-  async function createArc(options, storageKey) {
+  async function createArc(options, storageKeyPrefix) {
     const {manifestString, manifestFilename} = options;
     runtime.context = manifestString
         ? await runtime.parse(manifestString)
         : await runtime.parseFile(manifestFilename);
-    return runtime.newArc('demo', storageKey);
+    return runtime.newArc({arcName: 'demo', storageKeyPrefix});
   }
 
   async function createConsumePlanificator(manifestFilename) {

--- a/src/planning/plan/tests/planificator-test.ts
+++ b/src/planning/plan/tests/planificator-test.ts
@@ -78,7 +78,7 @@ describe.skip('remote planificator', () => {
 
   async function instantiateAndReplan(consumePlanificator, producePlanificator, suggestionIndex) {
     const suggestion = consumePlanificator.consumer.result.suggestions[suggestionIndex];
-    await consumePlanificator.arc.instantiate(suggestion.plan);
+    await runtime.allocator.runPlanInArc(consumePlanificator.arc.id, suggestion.plan);
     const serialization = await consumePlanificator.arc.serialize();
     //
     producePlanificator.arc.dispose();

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -26,7 +26,7 @@ describe('planning result', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
 
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.isNotEmpty(suggestions);
@@ -51,7 +51,7 @@ describe('planning result', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
 
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const {loader, context} = runtime;
@@ -119,7 +119,7 @@ recipe R3
         `;
   async function prepareMerge(manifestStr1, manifestStr2) {
     const runtime = new Runtime();
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
 
     const planToSuggestion = async (plan: Recipe): Promise<Suggestion> => {
       const suggestion = Suggestion.create(plan, await plan.digest(), Relevance.create(arc, plan));

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -26,7 +26,7 @@ describe('planning result', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.isNotEmpty(suggestions);
@@ -51,7 +51,7 @@ describe('planning result', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const {loader, context} = runtime;
@@ -119,7 +119,7 @@ recipe R3
         `;
   async function prepareMerge(manifestStr1, manifestStr2) {
     const runtime = new Runtime();
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
 
     const planToSuggestion = async (plan: Recipe): Promise<Suggestion> => {
       const suggestion = Suggestion.create(plan, await plan.digest(), Relevance.create(arc, plan));

--- a/src/planning/plan/tests/replan-queue-test.ts
+++ b/src/planning/plan/tests/replan-queue-test.ts
@@ -42,7 +42,7 @@ async function init(options?) {
       value: Text
   `);
   const runtime = new Runtime({loader, context});
-  const arc = runtime.newArc({arcName: 'test'});
+  const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
   const producer = new TestPlanProducer(arc, runtime);
   const queue = new ReplanQueue(producer, options);
 

--- a/src/planning/plan/tests/replan-queue-test.ts
+++ b/src/planning/plan/tests/replan-queue-test.ts
@@ -42,7 +42,7 @@ async function init(options?) {
       value: Text
   `);
   const runtime = new Runtime({loader, context});
-  const arc = runtime.newArc('test');
+  const arc = runtime.newArc({arcName: 'test'});
   const producer = new TestPlanProducer(arc, runtime);
   const queue = new ReplanQueue(producer, options);
 

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -280,13 +280,11 @@ export class Planner implements InspectablePlanner {
     if (cachedSuggestion && cachedSuggestion.isUpToDate(arc, plan)) {
       return cachedSuggestion;
     }
-    const clonnedPlan: Recipe = plan.clone();
     let relevance: Relevance|undefined = undefined;
     let description: Description|null = null;
     if (this._shouldSpeculate(plan)) {
       //log(`speculatively executing [${plan.name}]`);
-      assert(clonnedPlan.normalize() && clonnedPlan.isResolved());
-      const result = await this.speculator.speculate(this.arc, clonnedPlan, hash);
+      const result = await this.speculator.speculate(this.arc, plan, hash);
       if (!result) {
         return undefined;
       }
@@ -296,12 +294,12 @@ export class Planner implements InspectablePlanner {
       //log(`[${plan.name}] => [${description.getRecipeSuggestion()}]`);
     } else {
       const speculativeArc = await arc.cloneForSpeculativeExecution();
-      await this.runtime.allocator.assignStorageKeys(arc.id, clonnedPlan);
-      await speculativeArc.mergeIntoActiveRecipe(clonnedPlan);
-      relevance = Relevance.create(arc, clonnedPlan);
+      plan = await this.runtime.allocator.assignStorageKeys(arc.id, plan);
+      await speculativeArc.mergeIntoActiveRecipe(plan);
+      relevance = Relevance.create(arc, plan);
       description = await Description.create(speculativeArc, relevance);
     }
-    const suggestion = Suggestion.create(clonnedPlan, hash, relevance);
+    const suggestion = Suggestion.create(plan, hash, relevance);
     suggestion.setDescription(description, this.arc.modality);
     this.getCache().set(hash, suggestion);
     return suggestion;

--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -101,7 +101,8 @@ export class RecipeIndex {
       stub: true,
       storageService: arc.storageService,
       driverFactory: arc.driverFactory,
-      storageKeyParser: arc.storageKeyParser
+      storageKeyParser: arc.storageKeyParser,
+      capabilitiesResolver: arc.capabilitiesResolver
     });
     const strategizer = new Strategizer(
       [

--- a/src/planning/speculator.ts
+++ b/src/planning/speculator.ts
@@ -12,16 +12,21 @@ import {assert} from '../platform/assert-web.js';
 import {Arc} from '../runtime/arc.js';
 import {Recipe} from '../runtime/recipe/lib-recipe.js';
 import {Relevance} from '../runtime/relevance.js';
+import {Runtime} from '../runtime/runtime.js';
 
 export class Speculator {
   private speculativeArcs: Arc[] = [];
+
+  constructor(public readonly runtime: Runtime) {}
 
   async speculate(arc: Arc, plan: Recipe, hash: string): Promise<{speculativeArc: Arc, relevance: Relevance}|null> {
     assert(plan.isResolved(), `Cannot speculate on an unresolved plan: ${plan.toString({showUnresolved: true})}`);
     const speculativeArc = await arc.cloneForSpeculativeExecution();
     this.speculativeArcs.push(speculativeArc);
     const relevance = Relevance.create(arc, plan);
-    await speculativeArc.instantiate(plan);
+    const newPlan = plan.clone();
+    await this.runtime.allocator.assignStorageKeys(speculativeArc.id, newPlan, speculativeArc.idGenerator);
+    await speculativeArc.instantiate(newPlan);
     await this.awaitCompletion(relevance, speculativeArc);
 
     if (!relevance.isRelevant(plan)) {

--- a/src/planning/speculator.ts
+++ b/src/planning/speculator.ts
@@ -24,9 +24,8 @@ export class Speculator {
     const speculativeArc = await arc.cloneForSpeculativeExecution();
     this.speculativeArcs.push(speculativeArc);
     const relevance = Relevance.create(arc, plan);
-    const newPlan = plan.clone();
-    await this.runtime.allocator.assignStorageKeys(speculativeArc.id, newPlan, speculativeArc.idGenerator);
-    await speculativeArc.instantiate(newPlan);
+    plan = await this.runtime.allocator.assignStorageKeys(speculativeArc.id, plan, speculativeArc.idGenerator);
+    await speculativeArc.instantiate(plan);
     await this.awaitCompletion(relevance, speculativeArc);
 
     if (!relevance.isRelevant(plan)) {

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -20,7 +20,7 @@ import {Runtime} from '../../../runtime/runtime.js';
 describe('ConvertConstraintsToConnections', () => {
   const newArc = (manifest: Manifest) => {
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    return runtime.newArc({arcName: 'test-plan-arc'});
+    return runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc'}));
   };
 
   it('fills out an empty constraint', async () => {
@@ -297,7 +297,7 @@ describe('ConvertConstraintsToConnections', () => {
 
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}, {result: manifest.recipes[1], score: 1, derivation: [], hash: '0', valid: true}];
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    const cctc = new ConvertConstraintsToConnections(runtime.newArc({arcName: 'test-plan-arc', modality: Modality.vr}));
+    const cctc = new ConvertConstraintsToConnections(runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc', modality: Modality.vr})));
 
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -20,7 +20,7 @@ import {Runtime} from '../../../runtime/runtime.js';
 describe('ConvertConstraintsToConnections', () => {
   const newArc = (manifest: Manifest) => {
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    return runtime.newArc('test-plan-arc');
+    return runtime.newArc({arcName: 'test-plan-arc'});
   };
 
   it('fills out an empty constraint', async () => {
@@ -297,7 +297,7 @@ describe('ConvertConstraintsToConnections', () => {
 
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}, {result: manifest.recipes[1], score: 1, derivation: [], hash: '0', valid: true}];
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    const cctc = new ConvertConstraintsToConnections(runtime.newArc('test-plan-arc', null, {modality: Modality.vr}));
+    const cctc = new ConvertConstraintsToConnections(runtime.newArc({arcName: 'test-plan-arc', modality: Modality.vr}));
 
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);

--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -160,7 +160,7 @@ describe('FindHostedParticle', () => {
     `, {loader, fileName: process.cwd() + '/input.manifest'});
 
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const strategy = new FindHostedParticle(arc);
 
     const inRecipe = manifest.recipes[0];

--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -160,7 +160,7 @@ describe('FindHostedParticle', () => {
     `, {loader, fileName: process.cwd() + '/input.manifest'});
 
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const strategy = new FindHostedParticle(arc);
 
     const inRecipe = manifest.recipes[0];

--- a/src/planning/strategies/tests/find-hosted-particle-test.ts
+++ b/src/planning/strategies/tests/find-hosted-particle-test.ts
@@ -175,7 +175,7 @@ describe('FindHostedParticle', () => {
     assert(outRecipe.isResolved());
 
     assert.isEmpty(arc.stores);
-    await arc.instantiate(outRecipe);
+    await runtime.allocator.runPlanInArc(arc.id, outRecipe);
     const particleSpecStore = arc.stores.find(StoreInfo.isSingletonInterfaceStore);
     const handle = await handleForStoreInfo(particleSpecStore, arc);
     const particleSpec = await handle.fetch();

--- a/src/planning/strategies/tests/find-required-particle-test.ts
+++ b/src/planning/strategies/tests/find-required-particle-test.ts
@@ -13,8 +13,8 @@ import {assert} from '../../../platform/chai-web.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {Loader} from '../../../platform/loader.js';
 import {FindRequiredParticle} from '../../strategies/find-required-particle.js';
-
 import {StrategyTestHelper} from '../../testing/strategy-test-helper.js';
+import {Runtime} from '../../../runtime/runtime.js';
 
 describe('FindRequiredParticles', () => {
   it('find single required particle that provides a slot', async () => {
@@ -44,15 +44,15 @@ describe('FindRequiredParticles', () => {
     `));
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
-    const arc = StrategyTestHelper.createTestArc(manifest, {loader});
-    await arc.instantiate(recipes[1]);
+    const runtime = new Runtime({context: manifest, loader});
+    const arc = runtime.newArc({arcName: 'test-arc'});
+    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
     assert.isTrue(recipe.slots[0].id === arc.activeRecipe.slots[1].id, 'results recipe does not have the correct slot');
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     assert.isTrue(arc.activeRecipe.normalize());
   });
 
@@ -81,15 +81,15 @@ describe('FindRequiredParticles', () => {
     `));
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
-    const arc = StrategyTestHelper.createTestArc(manifest, {loader});
-    await arc.instantiate(recipes[1]);
+    const runtime = new Runtime({context: manifest, loader});
+    const arc = runtime.newArc({arcName: 'test-arc'});
+    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
     assert.isTrue(recipe.slots[0].id === arc.activeRecipe.slots[0].id, 'results recipe does not have the correct slot');
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     assert.isTrue(arc.activeRecipe.normalize());
   });
 
@@ -136,16 +136,16 @@ describe('FindRequiredParticles', () => {
     `));
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
-    const arc = StrategyTestHelper.createTestArc(manifest, {loader});
-    await arc.instantiate(recipes[1]);
+    const runtime = new Runtime({context: manifest, loader});
+    const arc = runtime.newArc({arcName: 'test-arc'});
+    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
     assert.isTrue(recipe.slots[0].id === arc.activeRecipe.slots[0].id, 'first slot in results recipe is not the correct slot');
     assert.isTrue(recipe.slots[1].id === arc.activeRecipe.slots[1].id, 'second slot in results recipe is not the correct slots');
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     assert.isTrue(arc.activeRecipe.normalize());
   });
   it('required particle can not provide a slot that\'s provided by the shell', async () => {
@@ -190,13 +190,14 @@ describe('FindRequiredParticles', () => {
           c: provides slot2
     `));
     const recipes = manifest.recipes;
-    assert.isTrue(recipes.every(recipe => recipe.normalize()));
-    const arc = StrategyTestHelper.createTestArc(manifest, {loader});
-    await arc.instantiate(recipes[1]);
+    const runtime = new Runtime({context: manifest, loader});
+    const arc = runtime.newArc({arcName: 'test-arc'});
+    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
+    assert(recipe.isNormalized() || recipe.normalize());
     assert.isFalse(recipe.isResolved(), 'recipe is resolved when it shouldn\'t be');
   });
   it('find two required particles that doesn\'t match the require section', async () => {
@@ -242,9 +243,11 @@ describe('FindRequiredParticles', () => {
           c: provides slot2
     `));
     const recipes = manifest.recipes;
-    assert.isTrue(recipes.every(recipe => recipe.normalize()));
-    const arc = StrategyTestHelper.createTestArc(manifest, {loader});
-    await arc.instantiate(recipes[1]);
+
+    const runtime = new Runtime({context: manifest, loader});
+    const arc = runtime.newArc({arcName: 'test-arc'});
+    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
+
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);

--- a/src/planning/strategies/tests/find-required-particle-test.ts
+++ b/src/planning/strategies/tests/find-required-particle-test.ts
@@ -45,7 +45,7 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc'}));
     await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
@@ -82,7 +82,7 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc'}));
     await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
@@ -137,7 +137,7 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc'}));
     await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
@@ -191,7 +191,7 @@ describe('FindRequiredParticles', () => {
     `));
     const recipes = manifest.recipes;
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc'}));
     await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
@@ -245,7 +245,7 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
 
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc'}));
     await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
 
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));

--- a/src/planning/strategies/tests/find-required-particle-test.ts
+++ b/src/planning/strategies/tests/find-required-particle-test.ts
@@ -197,7 +197,6 @@ describe('FindRequiredParticles', () => {
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
-    assert(recipe.isNormalized() || recipe.normalize());
     assert.isFalse(recipe.isResolved(), 'recipe is resolved when it shouldn\'t be');
   });
   it('find two required particles that doesn\'t match the require section', async () => {

--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -39,7 +39,7 @@ describe('InitPopulation', () => {
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.newArc({arcName: 'test-plan-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc'}));
 
     async function scoreOfInitPopulationOutput() {
       const results = await new InitPopulation(arc, StrategyTestHelper.createTestStrategyArgs(
@@ -66,7 +66,7 @@ describe('InitPopulation', () => {
       'A.js': 'defineParticle(({Particle}) => class extends Particle {})'
     });
     const runtime = new Runtime({loader, context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.newArc({arcName: 'test-plan-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc'}));
 
     const results = await new InitPopulation(arc, {contextual: false,
         recipeIndex: {recipes: manifest.recipes}}).generate({generation: 0});

--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -49,7 +49,7 @@ describe('InitPopulation', () => {
     }
 
     assert.strictEqual(await scoreOfInitPopulationOutput(), 1);
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     assert.strictEqual(await scoreOfInitPopulationOutput(), 0);
   });
 

--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -39,7 +39,7 @@ describe('InitPopulation', () => {
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.newArc('test-plan-arc');
+    const arc = runtime.newArc({arcName: 'test-plan-arc'});
 
     async function scoreOfInitPopulationOutput() {
       const results = await new InitPopulation(arc, StrategyTestHelper.createTestStrategyArgs(
@@ -66,7 +66,7 @@ describe('InitPopulation', () => {
       'A.js': 'defineParticle(({Particle}) => class extends Particle {})'
     });
     const runtime = new Runtime({loader, context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.newArc('test-plan-arc');
+    const arc = runtime.newArc({arcName: 'test-plan-arc'});
 
     const results = await new InitPopulation(arc, {contextual: false,
         recipeIndex: {recipes: manifest.recipes}}).generate({generation: 0});

--- a/src/planning/strategies/tests/map-slots-test.ts
+++ b/src/planning/strategies/tests/map-slots-test.ts
@@ -158,7 +158,7 @@ ${recipeManifest}
   it.skip('prefers local slots if available', async () => {
     // Arc has both a 'root' and an 'action' slot.
     const runtime = new Runtime({loader: new Loader(), context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.newArc({arcName: 'test-plan-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc'}));
 
     const particles = `
       particle A in 'A.js'

--- a/src/planning/strategies/tests/map-slots-test.ts
+++ b/src/planning/strategies/tests/map-slots-test.ts
@@ -158,7 +158,7 @@ ${recipeManifest}
   it.skip('prefers local slots if available', async () => {
     // Arc has both a 'root' and an 'action' slot.
     const runtime = new Runtime({loader: new Loader(), context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.newArc('test-plan-arc');
+    const arc = runtime.newArc({arcName: 'test-plan-arc'});
 
     const particles = `
       particle A in 'A.js'

--- a/src/planning/testing/strategy-test-helper.ts
+++ b/src/planning/testing/strategy-test-helper.ts
@@ -23,7 +23,7 @@ import {Runtime} from '../../runtime/runtime.js';
 export class StrategyTestHelper {
   static createTestArc(context: Manifest, options: {id?: Id, modality?: Modality, loader?: Loader} = {}) {
     const runtime = new Runtime({context, loader: options.loader || new Loader()});
-    return runtime.newArc({arcName: 'test-arc', ...options});
+    return runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc', ...options}));
   }
   static createTestStrategyArgs(arc: Arc, args?) {
     return {recipeIndex: RecipeIndex.create(arc), ...args};

--- a/src/planning/testing/strategy-test-helper.ts
+++ b/src/planning/testing/strategy-test-helper.ts
@@ -23,7 +23,7 @@ import {Runtime} from '../../runtime/runtime.js';
 export class StrategyTestHelper {
   static createTestArc(context: Manifest, options: {id?: Id, modality?: Modality, loader?: Loader} = {}) {
     const runtime = new Runtime({context, loader: options.loader || new Loader()});
-    return runtime.newArc('test-arc', null, options);
+    return runtime.newArc({arcName: 'test-arc', ...options});
   }
   static createTestStrategyArgs(arc: Arc, args?) {
     return {recipeIndex: RecipeIndex.create(arc), ...args};

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -94,7 +94,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   manifestLoadedCallback(loadedManifest);
 
   const runtime = new Runtime({context: loadedManifest, loader});
-  const arc = runtime.newArc({arcName: 'test-plan-arc'});
+  const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc'}));
   const planner = new Planner();
   const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator(runtime)};
   planner.init(arc, options);

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -94,7 +94,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   manifestLoadedCallback(loadedManifest);
 
   const runtime = new Runtime({context: loadedManifest, loader});
-  const arc = runtime.newArc('test-plan-arc');
+  const arc = runtime.newArc({arcName: 'test-plan-arc'});
   const planner = new Planner();
   const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator()};
   planner.init(arc, options);

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -96,7 +96,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   const runtime = new Runtime({context: loadedManifest, loader});
   const arc = runtime.newArc({arcName: 'test-plan-arc'});
   const planner = new Planner();
-  const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator()};
+  const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator(runtime)};
   planner.init(arc, options);
 
   const plans = await planner.suggest(Infinity);

--- a/src/planning/tests/planning-manifest-integration-test.ts
+++ b/src/planning/tests/planning-manifest-integration-test.ts
@@ -14,9 +14,9 @@ import {Speculator} from '../speculator.js';
 
 describe('planning manifest integration', () => {
   it('can produce a recipe that can be speculated', async () => {
-    const {arc, recipe} = await manifestTestSetup();
+    const {runtime, arc, recipe} = await manifestTestSetup();
     const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
-    const {speculativeArc, relevance} = await new Speculator().speculate(arc, recipe, hash);
+    const {speculativeArc, relevance} = await new Speculator(runtime).speculate(arc, recipe, hash);
     assert.strictEqual(relevance.calcRelevanceScore(), 1);
     assert.lengthOf(speculativeArc.recipeDeltas, 1);
   });

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -27,7 +27,7 @@ describe('RecipeIndex', () => {
     }
     const loader = new Loader();
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.newArc({arcName: 'test-plan-arc'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-plan-arc'}));
     const recipeIndex = RecipeIndex.create(arc);
     await recipeIndex.ready;
     return recipeIndex;

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -27,7 +27,7 @@ describe('RecipeIndex', () => {
     }
     const loader = new Loader();
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.newArc('test-plan-arc');
+    const arc = runtime.newArc({arcName: 'test-plan-arc'});
     const recipeIndex = RecipeIndex.create(arc);
     await recipeIndex.ready;
     return recipeIndex;

--- a/src/planning/tests/speculator-test.ts
+++ b/src/planning/tests/speculator-test.ts
@@ -25,7 +25,7 @@ describe('speculator', () => {
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
-    const speculator = new Speculator();
+    const speculator = new Speculator(runtime);
     const {speculativeArc, relevance} = await speculator.speculate(arc, recipe, hash);
     assert.strictEqual(relevance.calcRelevanceScore(), 1);
     assert.lengthOf(speculativeArc.recipeDeltas, 1);

--- a/src/planning/tests/speculator-test.ts
+++ b/src/planning/tests/speculator-test.ts
@@ -20,7 +20,7 @@ describe('speculator', () => {
   it('can speculatively produce a relevance', async () => {
     const loader = new Loader();
     const runtime = new Runtime({loader, context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/planning/tests/speculator-test.ts
+++ b/src/planning/tests/speculator-test.ts
@@ -20,7 +20,7 @@ describe('speculator', () => {
   it('can speculatively produce a relevance', async () => {
     const loader = new Loader();
     const runtime = new Runtime({loader, context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/allocator.ts
+++ b/src/runtime/allocator.ts
@@ -31,11 +31,6 @@ import {NewArcOptions, PlanPartition, DeserializeArcOptions} from './arc-info.js
 import {ArcHost, ArcHostFactory, SingletonArcHostFactory} from './arc-host.js';
 import {RecipeResolver} from './recipe-resolver.js';
 
-export type PlanInArcOptions = Readonly<{
-  arcId: ArcId;
-  planName?: string;
-}>;
-
 export interface Allocator {
   registerArcHost(factory: ArcHostFactory);
 

--- a/src/runtime/allocator.ts
+++ b/src/runtime/allocator.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright (c) 2021 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../platform/assert-web.js';
+import {Arc, ArcOptions} from './arc.js';
+import {ArcId, IdGenerator} from './id.js';
+import {Manifest} from './manifest.js';
+import {Recipe, Particle} from './recipe/lib-recipe.js';
+import {StorageService} from './storage/storage-service.js';
+import {SlotComposer} from './slot-composer.js';
+import {Runtime} from './runtime.js';
+import {Dictionary} from '../utils/lib-utils.js';
+import {newRecipe} from './recipe/lib-recipe.js';
+import {CapabilitiesResolver} from './capabilities-resolver.js';
+import {VolatileStorageKey} from './storage/drivers/volatile.js';
+import {StorageKey} from './storage/storage-key.js';
+import {PecFactory} from './particle-execution-context.js';
+import {ArcInspectorFactory} from './arc-inspector.js';
+import {AbstractSlotObserver} from './slot-observer.js';
+import {Modality} from './arcs-types/modality.js';
+
+export type StorageKeyPrefixer = (arcId: ArcId) => StorageKey;
+
+export type NewArcOptions = Readonly<{
+  arcName?: string,
+  arcId?: ArcId,
+  storageKeyPrefix?: StorageKeyPrefixer
+  pecFactories?: PecFactory[];
+  speculative?: boolean;
+  innerArc?: boolean;
+  stub?: boolean;
+  listenerClasses?: ArcInspectorFactory[];
+  inspectorFactory?: ArcInspectorFactory;
+  modality?: Modality;
+  slotObserver?: AbstractSlotObserver;
+}>;
+
+export type PlanInArcOptions = Readonly<{
+  arcId: ArcId;
+  planName?: string;
+}>;
+
+export interface Allocator {
+  arcHostFactories: ArcHostFactory[];
+  registerArcHost(factory: ArcHostFactory);
+  startArc(options: NewArcOptions): ArcId;
+  // tslint:disable-next-line: no-any
+  startArcWithPlan(options: NewArcOptions & {planName?: string}): Promise<ArcId>;
+  stopArc(arcId: ArcId);
+}
+
+export type PlanPartition = Readonly<{
+  plan?: Recipe; // TODO: plan should be mandatory, when Arc and RunningArc classes are split.
+  arcOptions: NewArcOptions;
+  arcHostId: string;
+}>;
+
+export interface ArcHostFactory {
+  isHostForParticle(particle: Particle): boolean;
+  createHost(): ArcHost;
+}
+
+export class SingletonArcHostFactory implements ArcHostFactory {
+  constructor(public readonly host: ArcHost) {}
+
+  isHostForParticle(particle: Particle): boolean {
+    return this.host.isHostForParticle(particle);
+  }
+  createHost() { return this.host; }
+}
+
+export interface ArcHost {
+  hostId: string;
+  storageService: StorageService;
+  // slotComposer: SlotComposer;  // TODO: refactor to UiBroker.
+
+  start(plan: PlanPartition);
+  stop(arcId: ArcId);
+  getArcById(arcId: ArcId): Arc;
+  isHostForParticle(particle: Particle): boolean;
+  buildArcParams(options: NewArcOptions): ArcOptions;
+}
+
+
+export class AllocatorImpl implements Allocator {
+  public readonly arcHostFactories: ArcHostFactory[] = [];
+  public readonly planPartitionsByArcId = new Map<ArcId, PlanPartition[]>();
+  public readonly hostById: Dictionary<ArcHost> = {};
+
+  constructor(public readonly runtime: Runtime) {}
+
+  registerArcHost(factory: ArcHostFactory) { this.arcHostFactories.push(factory); }
+
+  startArc(options: NewArcOptions): ArcId {
+    assert(options.arcId || options.arcName);
+    const arcId = options.arcId || IdGenerator.newSession().newArcId(options.arcName);
+    if (!this.planPartitionsByArcId.has(arcId)) {
+      this.planPartitionsByArcId.set(arcId, []);
+    }
+    return arcId;
+  }
+
+  // tslint:disable-next-line: no-any
+  protected async runInArc(arcId: ArcId, planName?: string): Promise<any> {
+    assert(this.planPartitionsByArcId.has(arcId));
+    assert(planName || this.runtime.context.recipes.length === 1);
+    const plan = planName
+      ? this.runtime.context.allRecipes.find(r => r.name === planName)
+      : this.runtime.context.recipes[0];
+    assert(plan);
+    assert(plan.normalize());
+    assert(plan.isResolved(), `Unresolved partition plan: ${plan.toString({showUnresolved: true})}`);
+    const partitionByFactory = new Map<ArcHostFactory, Particle[]>();
+    for (const particle of plan.particles) {
+      const hostFactory = [...this.arcHostFactories.values()].find(
+          factory => factory.isHostForParticle(particle));
+      assert(hostFactory); // return error?
+      if (!partitionByFactory.has(hostFactory)) {
+        partitionByFactory.set(hostFactory, []);
+      }
+      partitionByFactory.get(hostFactory).push(particle);
+    }
+    return Promise.all([...partitionByFactory.keys()].map(factory => {
+      const host = factory.createHost();
+      this.hostById[host.hostId] = host;
+      const partial = newRecipe();
+      plan.mergeInto(partial);
+      const partitionParticles = partitionByFactory.get(factory);
+      plan.particles.forEach((particle, index) => {
+        if (!partitionParticles.find(p => p.name === particle.name)) {
+          plan.particles.splice(index, 1);
+        }
+      });
+      // TODO(mmandlis): assign storage keys for all `create` & `copy` stores.
+      assert(partial.normalize());
+      assert(partial.isResolved());
+      const partition = {arcHostId: host.hostId, arcOptions: {arcId}, plan: partial};
+      this.planPartitionsByArcId.get(arcId).push(partition);
+      return host.start(partition);
+    }));
+  }
+
+  public async startArcWithPlan(options: NewArcOptions & {planName?: string}): Promise<ArcId> {
+    const arcId = this.startArc(options);
+    await this.runInArc(arcId, options.planName);
+    return arcId;
+  }
+
+  public stopArc(arcId: ArcId) {
+    assert(this.planPartitionsByArcId.has(arcId));
+    for (const partition of this.planPartitionsByArcId.get(arcId)) {
+      const host = this.hostById[partition.arcHostId];
+      assert(host);
+      host.stop(arcId);
+    }
+  }
+}
+
+// Note: This is an interim solution. It is needed while stores are created directly on the Arc,
+// hence callers need the ability to access the Arc object before any recipes were instantiated
+// (and hence Arc object created in the Host).
+export class SingletonAllocator extends AllocatorImpl {
+  constructor(public readonly runtime: Runtime,
+              public readonly host: ArcHost) {
+    super(runtime);
+    this.registerArcHost(new SingletonArcHostFactory(host));
+  }
+  startArc(options: NewArcOptions): ArcId {
+    const arcId = super.startArc(options);
+
+    this.host.start({arcOptions: {...options, arcId}, arcHostId: this.host.hostId});
+    return arcId;
+  }
+}
+
+export class ArcHostImpl implements ArcHost {
+  public readonly arcById = new Map<ArcId, Arc>();
+  constructor(public readonly hostId: string,
+              public readonly runtime: Runtime) {}
+  public get storageService() { return this.runtime.storageService; }
+
+  async start(partition: PlanPartition) {
+    const arcId = partition.arcOptions.arcId;
+    if (!arcId || !this.arcById.has(arcId)) {
+      const arc = new Arc(this.buildArcParams(partition.arcOptions));
+      this.arcById.set(arcId, arc);
+      if (partition.arcOptions.slotObserver) {
+        arc.peh.slotComposer.observeSlots(partition.arcOptions.slotObserver);
+      }
+    }
+    if (partition.plan) {
+      assert(partition.plan.isResolved(), `Unresolved partition plan: ${partition.plan.toString({showUnresolved: true})}`);
+      const arc = this.arcById.get(arcId);
+      return arc.instantiate(partition.plan);
+    }
+  }
+
+  stop(arcId: ArcId) {
+    assert(this.arcById.has(arcId));
+    this.arcById.get(arcId).dispose();
+  }
+
+  getArcById(arcId: ArcId): Arc {
+    assert(this.arcById.get(arcId));
+    return this.arcById.get(arcId);
+  }
+
+  isHostForParticle(particle: Particle): boolean { return true; }
+
+  buildArcParams(options: NewArcOptions): ArcOptions {
+    const id = options.arcId || IdGenerator.newSession().newArcId(options.arcName);
+    const factories = Object.values(this.runtime.storageKeyFactories);
+    return {
+      id,
+      loader: this.runtime.loader,
+      context: this.runtime.context,
+      pecFactories: [this.runtime.pecFactory],
+      slotComposer: this.runtime.composerClass ? new this.runtime.composerClass() : null,
+      storageService: this.runtime.storageService,
+      capabilitiesResolver: new CapabilitiesResolver({arcId: id, factories}),
+      driverFactory: this.runtime.driverFactory,
+      storageKey: options.storageKeyPrefix ? options.storageKeyPrefix(id) : new VolatileStorageKey(id, ''),
+      storageKeyParser: this.runtime.storageKeyParser,
+      ...options
+    };
+  }
+}

--- a/src/runtime/arc-host.ts
+++ b/src/runtime/arc-host.ts
@@ -39,6 +39,7 @@ export interface ArcHost {
   getArcById(arcId: ArcId): Arc;
   isHostForParticle(particle: Particle): boolean;
   buildArcParams(options: NewArcOptions): ArcOptions;
+  findArcByParticleId(particleId: string): Arc;
 }
 
 export class ArcHostImpl implements ArcHost {
@@ -97,6 +98,10 @@ export class ArcHostImpl implements ArcHost {
       idGenerator,
       ...options
     };
+  }
+
+  findArcByParticleId(particleId: string): Arc {
+    return [...this.arcById.values()].find(arc => !!arc.activeRecipe.findParticle(particleId));
   }
 }
 

--- a/src/runtime/arc-host.ts
+++ b/src/runtime/arc-host.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright (c) 2021 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../platform/assert-web.js';
+import {Arc, ArcOptions} from './arc.js';
+import {ArcId, IdGenerator} from './id.js';
+import {Manifest} from './manifest.js';
+import {Recipe, Particle} from './recipe/lib-recipe.js';
+import {StorageService} from './storage/storage-service.js';
+import {SlotComposer} from './slot-composer.js';
+import {Runtime} from './runtime.js';
+import {Dictionary} from '../utils/lib-utils.js';
+import {newRecipe} from './recipe/lib-recipe.js';
+import {CapabilitiesResolver} from './capabilities-resolver.js';
+import {VolatileStorageKey} from './storage/drivers/volatile.js';
+import {StorageKey} from './storage/storage-key.js';
+import {PecFactory} from './particle-execution-context.js';
+import {ArcInspectorFactory} from './arc-inspector.js';
+import {AbstractSlotObserver} from './slot-observer.js';
+import {Modality} from './arcs-types/modality.js';
+import {EntityType, ReferenceType, InterfaceType, SingletonType} from '../types/lib-types.js';
+import {Capabilities} from './capabilities.js';
+import {PlanPartition, NewArcOptions} from './arc-info.js';
+
+export interface ArcHost {
+  hostId: string;
+  storageService: StorageService;
+  // slotComposer: SlotComposer;  // TODO: refactor to UiBroker.
+
+  start(plan: PlanPartition);
+  stop(arcId: ArcId);
+  getArcById(arcId: ArcId): Arc;
+  isHostForParticle(particle: Particle): boolean;
+  buildArcParams(options: NewArcOptions): ArcOptions;
+}
+
+export class ArcHostImpl implements ArcHost {
+  public readonly arcById = new Map<ArcId, Arc>();
+  constructor(public readonly hostId: string,
+              public readonly runtime: Runtime) {}
+  public get storageService() { return this.runtime.storageService; }
+
+  async start(partition: PlanPartition) {
+    const arcId = partition.arcOptions.arcId;
+    if (!arcId || !this.arcById.has(arcId)) {
+      const arc = new Arc(this.buildArcParams(partition.arcOptions));
+      this.arcById.set(arcId, arc);
+      if (partition.arcOptions.slotObserver) {
+        arc.peh.slotComposer.observeSlots(partition.arcOptions.slotObserver);
+      }
+    }
+    if (partition.plan) {
+      assert(partition.plan.isResolved(), `Unresolved partition plan: ${partition.plan.toString({showUnresolved: true})}`);
+      const arc = this.arcById.get(arcId);
+      return arc.instantiate(partition.plan);
+      // TODO: add await to instantiate and return arc.idle here!
+      // TODO: move the call to ParticleExecutionHost's DefineHandle to here
+    }
+  }
+
+  stop(arcId: ArcId) {
+    assert(this.arcById.has(arcId));
+    this.arcById.get(arcId).dispose();
+  }
+
+  getArcById(arcId: ArcId): Arc {
+    assert(this.arcById.get(arcId));
+    return this.arcById.get(arcId);
+  }
+
+  isHostForParticle(particle: Particle): boolean { return true; }
+
+  buildArcParams(options: NewArcOptions): ArcOptions {
+    const idGenerator = options.idGenerator || IdGenerator.newSession();
+    const id = options.arcId || idGenerator.newArcId(options.arcName);
+    const factories = Object.values(this.runtime.storageKeyFactories);
+    return {
+      id,
+      loader: this.runtime.loader,
+      context: this.runtime.context,
+      pecFactories: [this.runtime.pecFactory],
+      slotComposer: this.runtime.composerClass ? new this.runtime.composerClass() : null,
+      storageService: this.runtime.storageService,
+      capabilitiesResolver: this.runtime.getCapabilitiesResolver(id),
+      driverFactory: this.runtime.driverFactory,
+      storageKey: options.storageKeyPrefix ? options.storageKeyPrefix(id) : new VolatileStorageKey(id, ''),
+      storageKeyParser: this.runtime.storageKeyParser,
+      idGenerator,
+      ...options
+    };
+  }
+}
+
+export interface ArcHostFactory {
+  isHostForParticle(particle: Particle): boolean;
+  createHost(): ArcHost;
+}
+
+export class SingletonArcHostFactory implements ArcHostFactory {
+  constructor(public readonly host: ArcHost) {}
+
+  isHostForParticle(particle: Particle): boolean {
+    return this.host.isHostForParticle(particle);
+  }
+  createHost() { return this.host; }
+}

--- a/src/runtime/arc-host.ts
+++ b/src/runtime/arc-host.ts
@@ -32,7 +32,7 @@ import {PlanPartition, NewArcOptions} from './arc-info.js';
 export interface ArcHost {
   hostId: string;
   storageService: StorageService;
-  // slotComposer: SlotComposer;  // TODO: refactor to UiBroker.
+  // slotComposer: SlotComposer;  // TODO(b/182410550): refactor to UiBroker.
 
   start(plan: PlanPartition);
   stop(arcId: ArcId);
@@ -61,8 +61,8 @@ export class ArcHostImpl implements ArcHost {
     if (partition.plan) {
       assert(partition.plan.isResolved(), `Unresolved partition plan: ${partition.plan.toString({showUnresolved: true})}`);
       await arc.instantiate(partition.plan, partition.reinstantiate);
-      // TODO: add await to instantiate and return arc.idle here!
-      // TODO: move the call to ParticleExecutionHost's DefineHandle to here
+      // TODO(b/182410550): add await to instantiate and return arc.idle here!
+      // TODO(b/182410550): move the call to ParticleExecutionHost's DefineHandle to here
     }
     return arc;
   }
@@ -89,7 +89,7 @@ export class ArcHostImpl implements ArcHost {
       loader: this.runtime.loader,
       context: this.runtime.context,
       pecFactories: [this.runtime.pecFactory],
-      slotComposer: this.runtime.composerClass ? new this.runtime.composerClass() : null,
+      slotComposer: new SlotComposer(),
       storageService: this.runtime.storageService,
       capabilitiesResolver: this.runtime.getCapabilitiesResolver(id),
       driverFactory: this.runtime.driverFactory,

--- a/src/runtime/arc-info.ts
+++ b/src/runtime/arc-info.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright (c) 2021 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../platform/assert-web.js';
+import {Arc, ArcOptions} from './arc.js';
+import {ArcId, IdGenerator} from './id.js';
+import {Manifest} from './manifest.js';
+import {Recipe, Particle} from './recipe/lib-recipe.js';
+import {StorageService} from './storage/storage-service.js';
+import {SlotComposer} from './slot-composer.js';
+import {Runtime} from './runtime.js';
+import {Dictionary} from '../utils/lib-utils.js';
+import {newRecipe} from './recipe/lib-recipe.js';
+import {CapabilitiesResolver} from './capabilities-resolver.js';
+import {VolatileStorageKey} from './storage/drivers/volatile.js';
+import {StorageKey} from './storage/storage-key.js';
+import {PecFactory} from './particle-execution-context.js';
+import {ArcInspectorFactory} from './arc-inspector.js';
+import {AbstractSlotObserver} from './slot-observer.js';
+import {Modality} from './arcs-types/modality.js';
+import {EntityType, ReferenceType, InterfaceType, SingletonType} from '../types/lib-types.js';
+import {Capabilities} from './capabilities.js';
+
+export type StorageKeyPrefixer = (arcId: ArcId) => StorageKey;
+
+export type NewArcOptions = Readonly<{
+  arcName?: string,
+  arcId?: ArcId,
+  storageKeyPrefix?: StorageKeyPrefixer
+  pecFactories?: PecFactory[];
+  speculative?: boolean;
+  innerArc?: boolean;
+  stub?: boolean;
+  listenerClasses?: ArcInspectorFactory[];
+  inspectorFactory?: ArcInspectorFactory;
+  modality?: Modality;
+  slotObserver?: AbstractSlotObserver;
+  idGenerator?: IdGenerator;
+}>;
+
+export type PlanPartition = Readonly<{
+  plan?: Recipe; // TODO: plan should be mandatory, when Arc and RunningArc classes are split.
+  arcOptions: NewArcOptions;
+  arcHostId: string;
+}>;
+

--- a/src/runtime/arc-info.ts
+++ b/src/runtime/arc-info.ts
@@ -47,7 +47,15 @@ export type NewArcOptions = Readonly<{
 
 export type PlanPartition = Readonly<{
   plan?: Recipe; // TODO: plan should be mandatory, when Arc and RunningArc classes are split.
+  reinstantiate?: boolean; // TODO: should this be in arcOptions, or can it apply to only selected partitions?
   arcOptions: NewArcOptions;
   arcHostId: string;
 }>;
 
+export type DeserializeArcOptions = Readonly<{
+  serialization: string;
+  pecFactories?: PecFactory[];
+  slotComposer?: SlotComposer;
+  fileName: string;
+  inspectorFactory?: ArcInspectorFactory;
+}>;

--- a/src/runtime/arc-info.ts
+++ b/src/runtime/arc-info.ts
@@ -46,8 +46,11 @@ export type NewArcOptions = Readonly<{
 }>;
 
 export type PlanPartition = Readonly<{
-  plan?: Recipe; // TODO: plan should be mandatory, when Arc and RunningArc classes are split.
-  reinstantiate?: boolean; // TODO: should this be in arcOptions, or can it apply to only selected partitions?
+  // TODO(b/182410550): plan should be mandatory, when Arc class is refactored
+  // into ArcState (like) structure, and there is no need to call ArcHost when
+  // an Arc with no running recipes is created.
+  plan?: Recipe;
+  reinstantiate?: boolean;
   arcOptions: NewArcOptions;
   arcHostId: string;
 }>;

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -14,6 +14,7 @@ import {FakePecFactory} from './fake-pec-factory.js';
 import {Id, IdGenerator} from './id.js';
 import {Loader} from '../platform/loader.js';
 import {Capabilities} from './capabilities.js';
+// TODO: get rid of capabilities resolver!
 import {CapabilitiesResolver} from './capabilities-resolver.js';
 import {Dictionary, Runnable, compareComparables, Mutex} from '../utils/lib-utils.js';
 import {Manifest} from './manifest.js';
@@ -275,6 +276,7 @@ export class Arc implements ArcInterface {
     throw new Error('persistSerialization unimplemented, pending synthetic type support in new storage stack');
   }
 
+  // TODO: move to Allocator as well!
   static async deserialize({serialization, pecFactories, slotComposer, loader, fileName, context, inspectorFactory, storageService, driverFactory, storageKeyParser}: DeserializeArcOptions): Promise<Arc> {
     const manifest = await Manifest.parse(serialization, {loader, fileName, context, storageKeyParser});
     const id = Id.fromString(manifest.meta.name);

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -121,18 +121,6 @@ export class ArcId extends Id {
   static _newArcIdInternal(root: string, name: string): ArcId {
     return new ArcId(root, [name]);
   }
-  /** Parses a string representation of an ID (see toString). */
-  static fromString(str: string): ArcId {
-    const bits = str.split(':');
-
-    if (bits[0].startsWith('!')) {
-      const root = bits[0].slice(1);
-      const idTree = bits.slice(1).filter(component => component.length > 0);
-      return new ArcId(root, idTree);
-    } else {
-      return new ArcId('', bits);
-    }
-  }
 
   /** Creates a new Arc ID with the given name. For convenience in unit testing only; otherwise use IdGenerator to create new IDs instead. */
   static newForTest(id: string): ArcId {

--- a/src/runtime/id.ts
+++ b/src/runtime/id.ts
@@ -121,6 +121,18 @@ export class ArcId extends Id {
   static _newArcIdInternal(root: string, name: string): ArcId {
     return new ArcId(root, [name]);
   }
+  /** Parses a string representation of an ID (see toString). */
+  static fromString(str: string): ArcId {
+    const bits = str.split(':');
+
+    if (bits[0].startsWith('!')) {
+      const root = bits[0].slice(1);
+      const idTree = bits.slice(1).filter(component => component.length > 0);
+      return new ArcId(root, idTree);
+    } else {
+      return new ArcId('', bits);
+    }
+  }
 
   /** Creates a new Arc ID with the given name. For convenience in unit testing only; otherwise use IdGenerator to create new IDs instead. */
   static newForTest(id: string): ArcId {

--- a/src/runtime/recipe/internal/recipe-interface.ts
+++ b/src/runtime/recipe/internal/recipe-interface.ts
@@ -112,6 +112,7 @@ export interface Handle {
   pattern: string;
 
   originalFate: Fate;
+  originalId: string;
   mappedType?: Type;
 
   isJoined: boolean;

--- a/src/runtime/recipe/internal/recipe-interface.ts
+++ b/src/runtime/recipe/internal/recipe-interface.ts
@@ -236,6 +236,7 @@ export interface Recipe {
   clone(map?: Map<RecipeComponent, RecipeComponent>): Recipe;
   digest(): Promise<string>;
   normalize(options?: IsValidOptions): boolean;
+  isNormalized(): boolean;
   toString(options?: ToStringOptions): string;
   getAnnotation(name: string): AnnotationRef | null;
   findAnnotations(name: string): AnnotationRef[];

--- a/src/runtime/recipe/internal/recipe-interface.ts
+++ b/src/runtime/recipe/internal/recipe-interface.ts
@@ -237,6 +237,7 @@ export interface Recipe {
   digest(): Promise<string>;
   normalize(options?: IsValidOptions): boolean;
   isNormalized(): boolean;
+  tryResolve(options?: IsValidOptions): boolean;
   toString(options?: ToStringOptions): string;
   getAnnotation(name: string): AnnotationRef | null;
   findAnnotations(name: string): AnnotationRef[];

--- a/src/runtime/recipe/internal/recipe.ts
+++ b/src/runtime/recipe/internal/recipe.ts
@@ -156,7 +156,7 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
   }
 
   isResolved(options?): boolean {
-    assert(Object.isFrozen(this), 'Recipe must be normalized to be resolved.');
+    assert(this.isNormalized(), 'Recipe must be normalized to be resolved.');
     const checkThat = (check: boolean, label: string) => {
       if (!check && options && options.errors) {
         options.errors.set(this.name, label);
@@ -396,7 +396,7 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
   }
 
   normalize(options?: IsValidOptions): boolean {
-    if (Object.isFrozen(this)) {
+    if (this.isNormalized()) {
       if (options && options.errors) {
         options.errors.set(this, 'already normalized');
       }
@@ -523,6 +523,10 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
     Object.freeze(this);
 
     return true;
+  }
+
+  isNormalized() {
+    return Object.isFrozen(this);
   }
 
   clone(map: Map<RecipeComponent, RecipeComponent> = undefined): Recipe {

--- a/src/runtime/recipe/internal/recipe.ts
+++ b/src/runtime/recipe/internal/recipe.ts
@@ -167,7 +167,7 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
     && checkThat(this._connectionConstraints.length === 0, 'unresolved constraints')
     && checkThat(this.requires.every(require => require.isEmpty()), 'unresolved require')
     && checkThat((this._search === null || this._search.isResolved()), 'unresolved search')
-    && checkThat(this._handles.every(handle => handle.isResolved()), 'unresolved handles')
+    && checkThat(this._handles.every(handle => handle.isResolved(options)), 'unresolved handles')
     && checkThat(this._particles.every(particle => particle.isResolved(options)), 'unresolved particles')
     && checkThat(this.modality.isResolved(), 'unresolved modality')
     && checkThat(this.allRequiredSlotsPresent(options), 'unresolved required slot')
@@ -527,6 +527,22 @@ export class Recipe implements Cloneable<Recipe>, PublicRecipe {
 
   isNormalized() {
     return Object.isFrozen(this);
+  }
+
+  tryResolve(options?: IsValidOptions): boolean {
+    if (!this.isNormalized()) {
+      if (!this.normalize(options)) {
+        return false;
+      }
+    }
+
+    if (!this.isResolved()) {
+      for (const handle of this.handles) {
+        // The call to `normalize` above un-resolves typevar handle types.
+        assert(handle.type.maybeResolve());
+      }
+    }
+    return this.isResolved();
   }
 
   clone(map: Map<RecipeComponent, RecipeComponent> = undefined): Recipe {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -52,20 +52,6 @@ export type RuntimeOptions = Readonly<{
   staticMap?: {}
 }>;
 
-// export type RuntimeArcOptions = Readonly<{
-//   id?: Id;
-//   pecFactories?: PecFactory[];
-//   speculative?: boolean;
-//   innerArc?: boolean;
-//   stub?: boolean;
-//   listenerClasses?: ArcInspectorFactory[];
-//   inspectorFactory?: ArcInspectorFactory;
-//   modality?: Modality;
-//   slotObserver?: AbstractSlotObserver;
-// }>;
-
-type StartArcOptions = NewArcOptions & {planName?: string};
-
 const nob = Object.create(null);
 
 @SystemTrace
@@ -102,6 +88,7 @@ export class Runtime {
     return (await Description.create(arc)).getArcDescription();
   }
 
+  // TODO(mmandlis): move into allocator!
   async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
     if (this.normalize(recipe)) {
       if (recipe.isResolved()) {
@@ -207,7 +194,7 @@ export class Runtime {
    * (2) a deserialized arc (TODO: needs implementation)
    * (3) a newly created arc
    */
-  async startArc(options: StartArcOptions): Promise<Arc> {
+  async startArc(options: NewArcOptions & {planName?: string}): Promise<Arc> {
     const arcId = await this.allocator.startArcWithPlan(options);
     return this.host.getArcById(arcId);
   }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -131,9 +131,6 @@ export class Runtime {
   /*private*/public composerClass: typeof SlotComposer | null;
   public memoryProvider: VolatileMemoryProvider;
   public readonly storageService: StorageService;
-  public get arcById() {
-    return (this.host as ArcHostImpl).arcById; // TODO: get rid of this!
-  }
   public readonly allocator: Allocator;
   public readonly host: ArcHost;
   public driverFactory: DriverFactory;
@@ -185,35 +182,9 @@ export class Runtime {
     return this.memoryProvider;
   }
 
-  // TODO(shans): Clean up once old storage is removed.
-  // Note that this incorrectly assumes every storage key can be of the form `prefix` + `arcId`.
-  // Should ids be provided to the Arc constructor, or should they be constructed by the Arc?
-  // How best to provide default storage to an arc given whatever we decide?
-
-  /**
-   * Given an arc name, return either:
-   * (1) the already running arc
-   * (2) a deserialized arc (TODO: needs implementation)
-   * (3) a newly created arc
-   */
-  async startArc(options: NewArcOptions & {planName?: string}): Promise<Arc> {
-    const arcId = await this.allocator.startArcWithPlan(options);
-    return this.host.getArcById(arcId);
-  }
-
-  newArc(options?: NewArcOptions): Arc {
-    const arcId = this.allocator.startArc(options);
+  getArcById(arcId: ArcId): Arc {
     assert(this.host.getArcById(arcId));
     return this.host.getArcById(arcId);
-  }
-
-  stop(name: string) {
-    this.allocator.stopArc(ArcId.fromString(name));
-  }
-
-  findArcByParticleId(particleId: string): Arc {
-    //return [...this.arcById.values()]
-    return Object.values(this.arcById).find(arc => !!arc.activeRecipe.findParticle(particleId));
   }
 
   async parse(content: string, options?): Promise<Manifest> {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -34,7 +34,9 @@ import {CapabilitiesResolver} from './capabilities-resolver.js';
 import {StorageService} from './storage/storage-service.js';
 import {DirectStorageEndpointManager} from './storage/direct-storage-endpoint-manager.js';
 import {Dictionary} from '../utils/lib-utils.js';
-import {ArcHostImpl, SingletonAllocator, StorageKeyPrefixer, NewArcOptions, Allocator, ArcHost} from './allocator.js';
+import {SingletonAllocator, Allocator} from './allocator.js';
+import {StorageKeyPrefixer, NewArcOptions} from './arc-info.js';
+import {ArcHostImpl, ArcHost} from './arc-host.js';
 
 const {warn} = logsFactory('Runtime', 'orange');
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -212,7 +212,8 @@ export class Runtime {
   }
 
   findArcByParticleId(particleId: string): Arc {
-    return [...this.arcById.values()].find(arc => !!arc.activeRecipe.findParticle(particleId));
+    //return [...this.arcById.values()]
+    return Object.values(this.arcById).find(arc => !!arc.activeRecipe.findParticle(particleId));
   }
 
   async parse(content: string, options?): Promise<Manifest> {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -88,6 +88,20 @@ export class Runtime {
     return (await Description.create(arc)).getArcDescription();
   }
 
+  async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {
+    const errors = new Map();
+    if (recipe.tryResolve({errors})) {
+      return recipe;
+    }
+    const resolver = new RecipeResolver(arc);
+    const plan = await resolver.resolve(recipe);
+    if (plan && plan.isResolved()) {
+      return plan;
+    }
+    warn('failed to resolve:\n', (plan || recipe).toString({showUnresolved: true}));
+    return null;
+  }
+
   // non-static members
 
   public context: Manifest;

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -107,29 +107,29 @@ describe('VolatileStorageDriverProvider', () => {
   });
 
   it('supports VolatileStorageKeys for the same Arc ID', () => {
-    const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new VolatileStorageKey(arc.id, 'unique');
     assert.isTrue(provider.willSupport(storageKey));
   });
 
   it('does not support VolatileStorageKeys with a different Arc ID', () => {
-    const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new VolatileStorageKey(ArcId.newForTest('some-other-arc'), 'unique');
     assert.isFalse(provider.willSupport(storageKey));
   });
 
   it('does not support RamDiskStorageKeys', () => {
-    const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new RamDiskStorageKey('unique');
     assert.isFalse(provider.willSupport(storageKey));
   });
 
   it('uses separate memory for each arc', async () => {
-    const arc1 = runtime.newArc({arcName: 'arc1', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
-    const arc2 = runtime.newArc({arcName: 'arc2', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
+    const arc1 = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc1', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
+    const arc2 = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc2', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
     const provider1 = new VolatileStorageDriverProvider(arc1);
     const provider2 = new VolatileStorageDriverProvider(arc2);
     const storageKey1 = new VolatileStorageKey(arc1.id, 'unique');

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -107,29 +107,29 @@ describe('VolatileStorageDriverProvider', () => {
   });
 
   it('supports VolatileStorageKeys for the same Arc ID', () => {
-    const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, 'prefix'));
+    const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new VolatileStorageKey(arc.id, 'unique');
     assert.isTrue(provider.willSupport(storageKey));
   });
 
   it('does not support VolatileStorageKeys with a different Arc ID', () => {
-    const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, 'prefix'));
+    const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new VolatileStorageKey(ArcId.newForTest('some-other-arc'), 'unique');
     assert.isFalse(provider.willSupport(storageKey));
   });
 
   it('does not support RamDiskStorageKeys', () => {
-    const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, 'prefix'));
+    const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new RamDiskStorageKey('unique');
     assert.isFalse(provider.willSupport(storageKey));
   });
 
   it('uses separate memory for each arc', async () => {
-    const arc1 = runtime.newArc('arc1', id => new VolatileStorageKey(id, 'prefix'));
-    const arc2 = runtime.newArc('arc2', id => new VolatileStorageKey(id, 'prefix'));
+    const arc1 = runtime.newArc({arcName: 'arc1', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
+    const arc2 = runtime.newArc({arcName: 'arc2', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')});
     const provider1 = new VolatileStorageDriverProvider(arc1);
     const provider2 = new VolatileStorageDriverProvider(arc2);
     const storageKey1 = new VolatileStorageKey(arc1.id, 'unique');

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -160,9 +160,7 @@ describe('entity handle factory', () => {
       new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, '/handle/input:2'), new VolatileStorageKey(arc.id, 'b'))
     );
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     const handleForEntity = await handleForStoreInfo(refModeStore, arc);
@@ -239,9 +237,7 @@ describe('entity handle factory', () => {
       new VolatileStorageKey(arc.id, '/handle/input:2')
     );
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     // create and store an entity in the reference mode store.
@@ -368,9 +364,7 @@ describe('entity handle factory', () => {
     recipe.handles[0].mapToStorage(dsm1);
     recipe.handles[1].mapToStorage(dsm2);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     // create and store an entity in the reference mode store.

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -148,7 +148,7 @@ describe('entity handle factory', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -217,7 +217,7 @@ describe('entity handle factory', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -325,7 +325,7 @@ describe('entity handle factory', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 

--- a/src/runtime/storage/tests/entity-handle-factory-test.ts
+++ b/src/runtime/storage/tests/entity-handle-factory-test.ts
@@ -148,7 +148,7 @@ describe('entity handle factory', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -219,7 +219,7 @@ describe('entity handle factory', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -329,7 +329,7 @@ describe('entity handle factory', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -33,9 +33,9 @@ describe('ReferenceModeStore Integration', async () => {
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-      new Runtime({driverFactory}).newArc('testWritesArc'));
+      new Runtime({driverFactory}).newArc({arcName: 'testWritesArc'}));
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-      new Runtime({driverFactory}).newArc('testReadArc'));
+      new Runtime({driverFactory}).newArc({arcName: 'testReadArc'}));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -60,7 +60,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will store and retrieve entities through referenceModeStores (shared stores)', async () => {
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = new Runtime().newArc('testArc');
+    const arc = new Runtime().newArc({arcName: 'testArc'});
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -94,7 +94,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will store and retrieve entities through referenceModeStores (shared proxies)', async () => {
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = new Runtime().newArc('testArc');
+    const arc = new Runtime().newArc({arcName: 'testArc'});
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -139,9 +139,9 @@ describe('ReferenceModeStore Integration', async () => {
     // are on top of different storage stacks.
     const driverFactory = new DriverFactory();
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-        new Runtime({driverFactory}).newArc('testWriteArc'));
+        new Runtime({driverFactory}).newArc({arcName: 'testWriteArc'}));
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-        new Runtime({driverFactory}).newArc('testReadArc'));
+        new Runtime({driverFactory}).newArc({arcName: 'testReadArc'}));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -166,7 +166,7 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will send an ordered list from one handle to another (shared store)', async () => {
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = new Runtime().newArc('testArc');
+    const arc = new Runtime().newArc({arcName: 'testArc'});
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: {kind: 'schema-ordered-list', schema: {kind: 'schema-primitive', type: 'Text'}}})).collectionOf();
 

--- a/src/runtime/storage/tests/reference-mode-store-integration-test.ts
+++ b/src/runtime/storage/tests/reference-mode-store-integration-test.ts
@@ -32,10 +32,12 @@ describe('ReferenceModeStore Integration', async () => {
     const driverFactory = new DriverFactory();
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
+    const writeRuntime = new Runtime({driverFactory});
     const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-      new Runtime({driverFactory}).newArc({arcName: 'testWritesArc'}));
+      writeRuntime.getArcById(writeRuntime.allocator.newArc({arcName: 'testWritesArc'})));
+    const readRuntime = new Runtime({driverFactory});
     const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-      new Runtime({driverFactory}).newArc({arcName: 'testReadArc'}));
+      readRuntime.getArcById(readRuntime.allocator.newArc({arcName: 'testReadArc'})));
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -60,7 +62,8 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will store and retrieve entities through referenceModeStores (shared stores)', async () => {
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = new Runtime().newArc({arcName: 'testArc'});
+    const runtime = new Runtime();
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'testArc'}));
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -94,7 +97,8 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will store and retrieve entities through referenceModeStores (shared proxies)', async () => {
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = new Runtime().newArc({arcName: 'testArc'});
+    const runtime = new Runtime();
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'testArc'}));
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: 'Text'})).collectionOf();
 
@@ -138,10 +142,16 @@ describe('ReferenceModeStore Integration', async () => {
     // Use newHandle here rather than setting up a store inside the arc, as this ensures writeHandle and readHandle
     // are on top of different storage stacks.
     const driverFactory = new DriverFactory();
-    const writeHandle = await newHandle(new StoreInfo({storageKey, type, id: 'write-handle'}),
-        new Runtime({driverFactory}).newArc({arcName: 'testWriteArc'}));
-    const readHandle = await newHandle(new StoreInfo({storageKey, type, id: 'read-handle'}),
-        new Runtime({driverFactory}).newArc({arcName: 'testReadArc'}));
+    const writeRuntime = new Runtime({driverFactory});
+    const writeHandle = await newHandle(
+      new StoreInfo({storageKey, type, id: 'write-handle'}),
+      writeRuntime.getArcById(writeRuntime.allocator.newArc({arcName: 'testWriteArc'}))
+    );
+    const readRuntime = new Runtime({driverFactory});
+    const readHandle = await newHandle(
+      new StoreInfo({storageKey, type, id: 'read-handle'}),
+      readRuntime.getArcById(readRuntime.allocator.newArc({arcName: 'testReadArc'}))
+    );
 
     readHandle.particle = new Particle();
     const returnPromise = new Promise((resolve, reject) => {
@@ -166,7 +176,8 @@ describe('ReferenceModeStore Integration', async () => {
 
   it('will send an ordered list from one handle to another (shared store)', async () => {
     const storageKey = new ReferenceModeStorageKey(new RamDiskStorageKey('backing'), new RamDiskStorageKey('container'));
-    const arc = new Runtime().newArc({arcName: 'testArc'});
+    const runtime = new Runtime();
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'testArc'}));
 
     const type = new EntityType(new Schema(['AnEntity'], {foo: {kind: 'schema-ordered-list', schema: {kind: 'schema-primitive', type: 'Text'}}})).collectionOf();
 

--- a/src/runtime/storage/tests/store-sequence-test.ts
+++ b/src/runtime/storage/tests/store-sequence-test.ts
@@ -176,7 +176,7 @@ describe('Store Sequence', async () => {
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
       const storageService = runtime.storageService;
-      const arc = runtime.newArc({arcName: 'arc'});
+      const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc'}));
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate, storageService);
       const activeStore2 = await createStore(storageKey, Exists.ShouldExist, storageService);
@@ -273,7 +273,7 @@ describe('Store Sequence', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
-      const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, '')});
+      const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, '')}));
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate, runtime.storageService);
       const activeStore2 = await createStore(storageKey, Exists.ShouldExist, runtime.storageService);

--- a/src/runtime/storage/tests/store-sequence-test.ts
+++ b/src/runtime/storage/tests/store-sequence-test.ts
@@ -176,7 +176,7 @@ describe('Store Sequence', async () => {
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
       const storageService = runtime.storageService;
-      const arc = runtime.newArc('arc', null);
+      const arc = runtime.newArc({arcName: 'arc'});
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate, storageService);
       const activeStore2 = await createStore(storageKey, Exists.ShouldExist, storageService);
@@ -273,7 +273,7 @@ describe('Store Sequence', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
-      const arc = runtime.newArc('arc', id => new VolatileStorageKey(id, ''));
+      const arc = runtime.newArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, '')});
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate, runtime.storageService);
       const activeStore2 = await createStore(storageKey, Exists.ShouldExist, runtime.storageService);

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -25,5 +25,5 @@ export async function manifestTestSetup() {
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());
-  return {arc, recipe};
+  return {runtime, arc, recipe};
 }

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -21,7 +21,7 @@ export async function manifestTestSetup() {
   const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader, registry);
   assert(manifest);
   const runtime = new Runtime({loader, context: manifest});
-  const arc = runtime.newArc({arcName: 'test'});
+  const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -21,7 +21,7 @@ export async function manifestTestSetup() {
   const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader, registry);
   assert(manifest);
   const runtime = new Runtime({loader, context: manifest});
-  const arc = runtime.newArc('test');
+  const arc = runtime.newArc({arcName: 'test'});
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());

--- a/src/runtime/tests/allocator-test.ts
+++ b/src/runtime/tests/allocator-test.ts
@@ -31,7 +31,7 @@ describe('Allocator', () => {
     const host = new ArcHostImpl('myhost', runtime);
     allocator.registerArcHost(new SingletonArcHostFactory(host));
 
-    const arcId = await allocator.startArcWithPlan({planName: 'TestRecipe', arcName: 'test'});
+    const arcId = await allocator.startArc({planName: 'TestRecipe', arcName: 'test'});
     const arc = host.getArcById(arcId);
     assert.equal(arc.id, arcId);
     assert.equal(arc.activeRecipe.name, 'TestRecipe');

--- a/src/runtime/tests/allocator-test.ts
+++ b/src/runtime/tests/allocator-test.ts
@@ -9,7 +9,8 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Allocator, AllocatorImpl, ArcHostImpl, SingletonArcHostFactory} from '../allocator.js';
+import {Allocator, AllocatorImpl} from '../allocator.js';
+import {ArcHostImpl, SingletonArcHostFactory} from '../arc-host.js';
 import {Runtime} from '../runtime.js';
 import {Manifest} from '../manifest.js';
 

--- a/src/runtime/tests/allocator-test.ts
+++ b/src/runtime/tests/allocator-test.ts
@@ -36,4 +36,7 @@ describe('Allocator', () => {
     assert.equal(arc.id, arcId);
     assert.equal(arc.activeRecipe.name, 'TestRecipe');
   });
+
+  // TODO(b/182410550): Add more tests. Currently Allocator functionality is tested
+  // via other unit tests, that create Arcs and instantiate recipes using Runtime.
 });

--- a/src/runtime/tests/allocator-test.ts
+++ b/src/runtime/tests/allocator-test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2017 Google Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * Code distributed by Google as part of this project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from '../../platform/chai-web.js';
+import {Allocator, AllocatorImpl, ArcHostImpl, SingletonArcHostFactory} from '../allocator.js';
+import {Runtime} from '../runtime.js';
+import {Manifest} from '../manifest.js';
+
+describe('Allocator', () => {
+  it('starts arc with plan', async () => {
+    const runtime = new Runtime();
+    runtime.context = await runtime.parse(`
+      import 'src/runtime/tests/artifacts/test-particles.manifest'
+      recipe TestRecipe
+        handle0: create
+        handle1: create
+        TestParticle
+          foo: reads handle0
+          bar: writes handle1
+    `, {fileName: process.cwd() + '/input.manifest'});
+
+    const allocator = new AllocatorImpl(runtime);
+    const host = new ArcHostImpl('myhost', runtime);
+    allocator.registerArcHost(new SingletonArcHostFactory(host));
+
+    const arcId = await allocator.startArcWithPlan({planName: 'TestRecipe', arcName: 'test'});
+    const arc = host.getArcById(arcId);
+    assert.equal(arc.id, arcId);
+    assert.equal(arc.activeRecipe.name, 'TestRecipe');
+  });
+});

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -335,7 +335,7 @@ describe('Arc', () => {
     assert.isNull(await resolver.resolve(manifest.recipes[2]));
     const recipe3 = await resolver.resolve(manifest.recipes[3]);
     // Successfully instantiates a recipe with 'use' handle for store in an arc.
-    await arc.instantiate(recipe3);
+    await runtime.allocator.runPlanInArc(arc.id, recipe3);
   });
 
   it('required provided handles do not resolve without parent', async () => {

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -24,7 +24,7 @@ describe('entity', () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
     const runtime = new Runtime({context: new Manifest({id: ArcId.newForTest('test')}), loader: new Loader()});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const entity = new (Entity.createEntityClass(schema, null))({value: 'hello world'});
     assert.isDefined(entity);
 

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -24,7 +24,7 @@ describe('entity', () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
     const runtime = new Runtime({context: new Manifest({id: ArcId.newForTest('test')}), loader: new Loader()});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const entity = new (Entity.createEntityClass(schema, null))({value: 'hello world'});
     assert.isDefined(entity);
 

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -28,7 +28,7 @@ import {newRecipe} from '../recipe/internal/recipe-constructor.js';
 
 function createTestArc(recipe: Recipe, manifest: Manifest) {
   const runtime = new Runtime({context: manifest, loader: new Loader()});
-  const arc = runtime.newArc({arcName: 'test'});
+  const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
   // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
   arc['_activeRecipe'] = recipe;
   arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
@@ -621,7 +621,7 @@ recipe
     const recipe = manifest.recipes[0];
     // Cannot use createTestArc here, because capabilities-resolver cannot be set to null,
     // and interface returns a null schema, and cannot generate hash.
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     arc['_activeRecipe'] = recipe;
     arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
 

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -594,7 +594,9 @@ recipe
   });
 
   it('capitalizes when some particles do not have descriptions', async () => {
-    const runtime = new Runtime();
+    const runtime =  new class extends Runtime {
+      getCapabilitiesResolver(arcId: ArcId) { return null; }
+    }();
     const manifest = (await runtime.parse(`
 interface DummyInterface
 particle NoDescription
@@ -619,7 +621,7 @@ recipe
     const recipe = manifest.recipes[0];
     // Cannot use createTestArc here, because capabilities-resolver cannot be set to null,
     // and interface returns a null schema, and cannot generate hash.
-    const arc = new Arc({...runtime.host.buildArcParams({arcName: 'test'}), capabilitiesResolver: null});
+    const arc = runtime.newArc({arcName: 'test'});
     arc['_activeRecipe'] = recipe;
     arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
 

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -24,10 +24,11 @@ import {handleType, handleForStoreInfo} from '../storage/storage.js';
 import {Runtime} from '../runtime.js';
 import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
 import {StoreInfo} from '../storage/store-info.js';
+import {newRecipe} from '../recipe/internal/recipe-constructor.js';
 
 function createTestArc(recipe: Recipe, manifest: Manifest) {
   const runtime = new Runtime({context: manifest, loader: new Loader()});
-  const arc = runtime.newArc('test');
+  const arc = runtime.newArc({arcName: 'test'});
   // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
   arc['_activeRecipe'] = recipe;
   arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
@@ -546,8 +547,8 @@ particle C
   foo: reads Foo
   otherslot: consumes Slot
   description \`only c\`
-recipe
-  handle0: use 'test:1' // Foo
+recipe TestRecipe
+  handle0: create 'test:1' // Foo
   slot0: slot 'rootslotid-root'
   A as particle1
     foo: handle0
@@ -618,7 +619,7 @@ recipe
     const recipe = manifest.recipes[0];
     // Cannot use createTestArc here, because capabilities-resolver cannot be set to null,
     // and interface returns a null schema, and cannot generate hash.
-    const arc = new Arc({...runtime.buildArcParams('test'), capabilitiesResolver: null});
+    const arc = new Arc({...runtime.host.buildArcParams({arcName: 'test'}), capabilitiesResolver: null});
     arc['_activeRecipe'] = recipe;
     arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
 

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -143,9 +143,8 @@ describe('particle-api', () => {
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(resStore);
-    recipe.normalize();
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await inspector.verify('sync:null');
 
     // Drop event 2; desync is triggered by v3.
@@ -208,8 +207,7 @@ describe('particle-api', () => {
     const resultStore = await arc.createStore(result.type.collectionOf(), undefined, 'result-handle');
     const resultHandle = await handleForStoreInfo(resultStore, arc);
     const recipe = arc.context.recipes[0];
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
     const values = await resultHandle.toList();
     assert.deepStrictEqual(values as {}[], [{value: 'two'}]);
@@ -252,8 +250,7 @@ describe('particle-api', () => {
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
@@ -336,8 +333,7 @@ describe('particle-api', () => {
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
@@ -434,8 +430,7 @@ describe('particle-api', () => {
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
@@ -636,8 +631,7 @@ describe('particle-api', () => {
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
@@ -741,8 +735,7 @@ describe('particle-api', () => {
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(inputsStore);
     recipe.handles[1].mapToStorage(resultsStore);
-    recipe.normalize();
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
     assert.sameMembers((await resultsHandle.toList()).map(item => item.value), ['done', 'done', 'HELLO', 'WORLD']);
     await inspector.verify('done', 'done', 'HELLO', 'WORLD');
@@ -803,9 +796,8 @@ describe('particle-api', () => {
     const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'faz', 'test:2');
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
-    recipe.normalize();
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const inHandle = await handleForStoreInfo(inStore, arc);
     const entityType = Entity.createEntityClass(inStore.type.getEntitySchema(), null);
@@ -860,9 +852,8 @@ describe('particle-api', () => {
     const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'faz', 'test:2');
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
-    recipe.normalize();
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const inHandle = await handleForStoreInfo(inStore, arc);
     const entityType = Entity.createEntityClass(inStore.type.getEntitySchema(), null);
@@ -917,9 +908,8 @@ describe('particle-api', () => {
     const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'faz', 'test:2');
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
-    recipe.normalize();
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     await arc.idle;
     const inHandle = await handleForStoreInfo(inStore, arc);

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -85,7 +85,7 @@ describe('particle-api', () => {
   async function loadFilesIntoNewArc(fileMap: {[index:string]: string, manifest: string}): Promise<Arc> {
     const manifest = await Manifest.parse(fileMap.manifest);
     runtime = new Runtime({loader: new Loader(null, fileMap), context: manifest});
-    return runtime.newArc({arcName: 'demo'});
+    return runtime.getArcById(runtime.allocator.newArc({arcName: 'demo'}));
   }
 
   it('StorageProxy integration test', async () => {
@@ -788,7 +788,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -844,7 +844,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({loader, context: new Manifest({id})});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -900,7 +900,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -953,7 +953,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1016,7 +1016,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
@@ -1075,7 +1075,7 @@ describe('particle-api', () => {
     });
     // TODO(lindner): add strict rendering
     const runtime = new Runtime({loader, context});
-    const arc = await runtime.startArc({arcName: 'demo'});
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo'}));
     await arc.idle;
 
     assert.lengthOf(arc.activeRecipe.particles, 1);

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -82,7 +82,7 @@ class ResultInspector {
 async function loadFilesIntoNewArc(fileMap: {[index:string]: string, manifest: string}): Promise<Arc> {
   const manifest = await Manifest.parse(fileMap.manifest);
   const runtime = new Runtime({loader: new Loader(null, fileMap), context: manifest});
-  return runtime.newArc('demo');
+  return runtime.newArc({arcName: 'demo'});
 }
 
 describe('particle-api', () => {
@@ -793,7 +793,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -850,7 +850,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({loader, context: new Manifest({id})});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -907,7 +907,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -961,7 +961,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
@@ -1024,7 +1024,7 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
@@ -1083,11 +1083,7 @@ describe('particle-api', () => {
     });
     // TODO(lindner): add strict rendering
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc('demo');
-    const [recipe] = arc.context.recipes;
-    recipe.normalize();
-
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'demo'});
     await arc.idle;
 
     assert.lengthOf(arc.activeRecipe.particles, 1);

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -75,7 +75,7 @@ describe('particle interface loading', () => {
     }();
     const manifest = await runtime.parseFile('./src/runtime/tests/artifacts/test-particles.manifest');
     runtime.context = manifest;
-    const arc = runtime.newArc({arcId: ArcId.newForTest('test')});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcId: ArcId.newForTest('test')}));
     const fooType = new EntityType(manifest.schemas.Foo);
     const barType = new EntityType(manifest.schemas.Bar);
 
@@ -148,7 +148,7 @@ describe('particle interface loading', () => {
     const fooType = manifest.findTypeByName('Foo') as EntityType;
     const barType = manifest.findTypeByName('Bar') as EntityType;
 
-    const arc = await runtime.startArc({arcName: 'test'});
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
 
     const fooStore = arc.findStoresByType(new SingletonType(fooType))[0];
     const fooHandle = await handleForStoreInfo(fooStore, arc);
@@ -222,7 +222,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const fooType = manifest.findTypeByName('Foo') as EntityType;
     const fooStore = await arc.createStore(new SingletonType(fooType));
     recipe.handles[0].mapToStorage(fooStore);
@@ -268,7 +268,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooStore = await arc.createStore(new SingletonType(fooClass.type), undefined, 'test:0');
@@ -330,7 +330,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const barHandle = await mapHandleToStore(arc, recipe, fooClass, 0);
@@ -396,7 +396,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooHandle = await mapHandleToStore(arc, recipe, fooClass, 0);
@@ -444,7 +444,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooHandle = await mapHandleToStore(arc, recipe, fooClass, 0);

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -280,10 +280,10 @@ describe('particle interface loading', () => {
     assert.deepStrictEqual(await fooHandle.fetch(), new fooClass({value: 'Created!'}));
 
     const serialization = await arc.serialize();
-    arc.dispose();
+    runtime.allocator.stopArc(arc.id);
 
     const {driverFactory, storageService, storageKeyParser} = runtime;
-    const arc2 = await Arc.deserialize({serialization, loader, fileName: '', context: manifest, storageService, driverFactory, storageKeyParser});
+    const arc2 = await runtime.allocator.deserialize({serialization, fileName: ''});
     await arc2.idle;
 
     const fooHandle2 = await handleForStoreInfo(arc2.stores.find(StoreInfo.isSingletonEntityStore), arc2);

--- a/src/runtime/tests/particle-interface-loading-test.ts
+++ b/src/runtime/tests/particle-interface-loading-test.ts
@@ -144,17 +144,11 @@ describe('particle interface loading', () => {
       `, {loader, fileName: './test.manifest'});
 
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc('test');
 
     const fooType = manifest.findTypeByName('Foo') as EntityType;
     const barType = manifest.findTypeByName('Bar') as EntityType;
 
-    const recipe = manifest.recipes[0];
-
-    assert(recipe.normalize(), 'can\'t normalize recipe');
-    assert(recipe.isResolved(), 'recipe isn\'t resolved');
-
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'test'});
 
     const fooStore = arc.findStoresByType(new SingletonType(fooType))[0];
     const fooHandle = await handleForStoreInfo(fooStore, arc);
@@ -228,7 +222,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const fooType = manifest.findTypeByName('Foo') as EntityType;
     const fooStore = await arc.createStore(new SingletonType(fooType));
     recipe.handles[0].mapToStorage(fooStore);
@@ -277,7 +271,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooStore = await arc.createStore(new SingletonType(fooClass.type), undefined, 'test:0');
@@ -340,7 +334,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const barHandle = await mapHandleToStore(arc, recipe, fooClass, 0);
@@ -407,7 +401,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooHandle = await mapHandleToStore(arc, recipe, fooClass, 0);
@@ -456,7 +450,7 @@ describe('particle interface loading', () => {
       `
     });
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const fooClass = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null);
 
     const fooHandle = await mapHandleToStore(arc, recipe, fooClass, 0);

--- a/src/runtime/tests/recipe-resolver-test.ts
+++ b/src/runtime/tests/recipe-resolver-test.ts
@@ -26,7 +26,7 @@ describe('RecipeResolver', () => {
 
   const createArc = (manifest) => {
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    return runtime.newArc({arcName: 'test'});
+    return runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
   };
 
   it('resolves a recipe', async () => {

--- a/src/runtime/tests/recipe-resolver-test.ts
+++ b/src/runtime/tests/recipe-resolver-test.ts
@@ -26,7 +26,7 @@ describe('RecipeResolver', () => {
 
   const createArc = (manifest) => {
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    return runtime.newArc('test');
+    return runtime.newArc({arcName: 'test'});
   };
 
   it('resolves a recipe', async () => {

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -94,7 +94,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -178,7 +178,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -275,7 +275,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -354,7 +354,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const resultEntity = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -493,7 +493,7 @@ describe('reference', () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
 
     // create 'input:1' store to hold [Result]
@@ -615,7 +615,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
     const referenceOut = manifest.particles[0].handleConnectionMap.get('referenceOut');
@@ -699,7 +699,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test', storageKeyPrefix}));
     const recipe = manifest.recipes[0];
 
     const resultType = Entity.createEntityClass(manifest.findSchemaByName('Result'), null).type;

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -94,7 +94,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -180,7 +180,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -279,7 +279,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -360,7 +360,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const resultEntity = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
@@ -501,7 +501,7 @@ describe('reference', () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
 
     // create 'input:1' store to hold [Result]
@@ -626,7 +626,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
     const referenceOut = manifest.particles[0].handleConnectionMap.get('referenceOut');
@@ -712,7 +712,7 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.newArc('test', storageKeyPrefix);
+    const arc = runtime.newArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
 
     const resultType = Entity.createEntityClass(manifest.findSchemaByName('Result'), null).type;

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -123,9 +123,7 @@ describe('reference', () => {
     recipe.handles[0].mapToStorage(refStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     const inHandle = await handleForStoreInfo(refModeStore, arc);
@@ -216,9 +214,7 @@ describe('reference', () => {
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(outputStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     const handle1 = await handleForStoreInfo(refModeStore1, arc);
@@ -302,9 +298,7 @@ describe('reference', () => {
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(refStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const handle = await handleForStoreInfo(inputStore, arc);
     const entity = await handle.setFromData({value: 'what a result!'});
@@ -393,9 +387,7 @@ describe('reference', () => {
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     const entityHandle = await handleForStoreInfo(entityStore, arc);
@@ -535,9 +527,6 @@ describe('reference', () => {
     recipe.handles[1].mapToStorage(fooInputStore);
     recipe.handles[2].mapToStorage(fooOutputStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-
     const fooInHandle = await handleForStoreInfo(fooInputStore, arc);
     await fooInHandle.setFromData({result: null, shortForm: 'a'});
 
@@ -546,7 +535,7 @@ describe('reference', () => {
 
     const fooOutHandle = await handleForStoreInfo(fooOutputStore, arc);
     await fooOutHandle.addFromData({result: null, shortForm: 'b'});
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     const values = await fooOutHandle.toList();
@@ -650,9 +639,7 @@ describe('reference', () => {
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(refStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
 
     const handle = await handleForStoreInfo(inputStore, arc);
     assert.strictEqual((handle.type.getContainedType() as EntityType).entitySchema.name, 'Result');
@@ -744,9 +731,7 @@ describe('reference', () => {
     recipe.handles[0].mapToStorage(fooInputStore);
     recipe.handles[1].mapToStorage(resultOutputStore);
 
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
 
     const handle = await handleForStoreInfo(resultInputStore, arc);

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -22,8 +22,6 @@ describe('runtime manifest integration', () => {
     const storeInfo = arc.findStoresByType(type)[0] as StoreInfo<SingletonEntityType>;
 
     const handle = await handleForStoreInfo(storeInfo, arc);
-    // TODO: This should not be necessary.
-    type.maybeResolve();
     const result = await handle.fetch();
     assert.strictEqual(result['value'], 'Hello, world!');
   });

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -15,8 +15,8 @@ import {StoreInfo} from '../storage/store-info.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
-    const {arc, recipe} = await manifestTestSetup();
-    await arc.instantiate(recipe);
+    const {runtime, arc, recipe} = await manifestTestSetup();
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
     const type = recipe.handles[0].type;
     const storeInfo = arc.findStoresByType(type)[0] as StoreInfo<SingletonEntityType>;

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -80,7 +80,8 @@ describe('Runtime', () => {
   });
   it('runs arcs', async () => {
     const runtime = new Runtime();
-    assert.equal(runtime.arcById.size, 0);
+    // assert.equal(runtime.arcById.size, 0);
+    assert.equal(Object.keys(runtime.arcById).length, 0);
     const arc = runtime.newArc({arcName: 'test-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
     assert.isNotNull(arc);
     assert(arc.id.toString().includes('test-arc'));

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -132,9 +132,7 @@ describe('Runtime', () => {
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc1 = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc-v1', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    const recipe1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
-    assert.isTrue(recipe1 && recipe1.isResolved());
-    await runtime.allocator.runPlanInArc(volatileArc1.id, recipe1);
+    await runtime.allocator.runPlanInArc(volatileArc1.id, manifest.recipes[1]);
     assert.lengthOf(runtime.context.stores, 6);
     volatileArc1.dispose();
     assert.lengthOf(runtime.context.stores, 6);
@@ -146,9 +144,7 @@ describe('Runtime', () => {
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc2 = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc-v2', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    const recipe2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
-    assert.isTrue(recipe2 && recipe2.isResolved());
-    await runtime.allocator.runPlanInArc(volatileArc2.id, recipe2);
+    await runtime.allocator.runPlanInArc(volatileArc2.id, manifest.recipes[1]);
     assert.lengthOf(runtime.context.stores, 6);
     assert.isTrue(runtime.context.stores.map(s => s.storageKey).includes(
         volatileArc2.activeRecipe.handles[0].storageKey));

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -132,16 +132,16 @@ describe('Runtime', () => {
     assert.equal(runtime.context, ramdiskArc.context);
     assert.equal(runtime.context, volatileArc.context);
 
-    await volatileArc.instantiate(manifest.recipes[0]);
+    await runtime.allocator.runPlanInArc(volatileArc.id, manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 3);
 
-    await ramdiskArc.instantiate(manifest.recipes[0]);
+    await runtime.allocator.runPlanInArc(ramdiskArc.id, manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc1 = runtime.newArc({arcName: 'test-arc-v1', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
     const recipe1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
     assert.isTrue(recipe1 && recipe1.isResolved());
-    await volatileArc1.instantiate(recipe1);
+    await runtime.allocator.runPlanInArc(volatileArc1.id, recipe1);
     assert.lengthOf(runtime.context.stores, 6);
     volatileArc1.dispose();
     assert.lengthOf(runtime.context.stores, 6);
@@ -155,7 +155,7 @@ describe('Runtime', () => {
     const volatileArc2 = runtime.newArc({arcName: 'test-arc-v2', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
     const recipe2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
     assert.isTrue(recipe2 && recipe2.isResolved());
-    await volatileArc2.instantiate(recipe2);
+    await runtime.allocator.runPlanInArc(volatileArc2.id, recipe2);
     assert.lengthOf(runtime.context.stores, 6);
     assert.isTrue(runtime.context.stores.map(s => s.storageKey).includes(
         volatileArc2.activeRecipe.handles[0].storageKey));

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -46,16 +46,7 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
 describe('Runtime', () => {
   it('gets an arc description for an arc', async () => {
     const runtime = new Runtime();
-    const {storageService, driverFactory, storageKeyParser} = runtime;
-    const arc = new Arc({
-      slotComposer: new SlotComposer(),
-      id: ArcId.newForTest('test'),
-      loader: new Loader(),
-      context: new Manifest({id: ArcId.newForTest('test')}),
-      storageService,
-      driverFactory,
-      storageKeyParser
-    });
+    const arc = runtime.newArc({arcId: ArcId.newForTest('test')});
     const description = await Description.create(arc);
     const expected = await description.getArcDescription();
     const actual = await runtime.getArcDescription(arc);

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -90,13 +90,14 @@ describe('Runtime', () => {
   it('runs arcs', async () => {
     const runtime = new Runtime();
     assert.equal(runtime.arcById.size, 0);
-    const arc = runtime.newArc('test-arc', volatileStorageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'test-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
     assert.isNotNull(arc);
-    assert.hasAllKeys(runtime.arcById, ['test-arc']);
-    runtime.newArc('test-arc', volatileStorageKeyPrefixForTest());
-    assert.hasAllKeys(runtime.arcById, ['test-arc']);
-    runtime.newArc('other-test-arc', volatileStorageKeyPrefixForTest());
-    assert.hasAllKeys(runtime.arcById, ['test-arc', 'other-test-arc']);
+    assert(arc.id.toString().includes('test-arc'));
+    assert.hasAllKeys(runtime.arcById, [arc.id]);
+    runtime.newArc({storageKeyPrefix: volatileStorageKeyPrefixForTest(), arcId: arc.id});
+    assert.hasAllKeys(runtime.arcById, [arc.id]);
+    const otherArc = runtime.newArc({arcName: 'other-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    assert.hasAllKeys(runtime.arcById, [arc.id, otherArc.id]);
   });
   it('registers and unregisters stores', Flags.withDefaultReferenceMode(async () => {
     const loader = new Loader(null, {
@@ -126,8 +127,8 @@ describe('Runtime', () => {
     const runtime = new Runtime({loader});
     const manifest = await runtime.parseFile('manifest');
     manifest.recipes[0].normalize();
-    const volatileArc = runtime.newArc('test-arc-1', volatileStorageKeyPrefixForTest());
-    const ramdiskArc = runtime.newArc('test-arc-2', ramDiskStorageKeyPrefixForTest());
+    const volatileArc = runtime.newArc({arcName: 'test-arc-1', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    const ramdiskArc = runtime.newArc({arcName: 'test-arc-2', storageKeyPrefix: ramDiskStorageKeyPrefixForTest()});
     assert.equal(runtime.context, ramdiskArc.context);
     assert.equal(runtime.context, volatileArc.context);
 
@@ -137,7 +138,7 @@ describe('Runtime', () => {
     await ramdiskArc.instantiate(manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 6);
 
-    const volatileArc1 = runtime.newArc('test-arc-v1', volatileStorageKeyPrefixForTest());
+    const volatileArc1 = runtime.newArc({arcName: 'test-arc-v1', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
     const recipe1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
     assert.isTrue(recipe1 && recipe1.isResolved());
     await volatileArc1.instantiate(recipe1);
@@ -151,7 +152,7 @@ describe('Runtime', () => {
     ramdiskArc.dispose();
     assert.lengthOf(runtime.context.stores, 6);
 
-    const volatileArc2 = runtime.newArc('test-arc-v2', volatileStorageKeyPrefixForTest());
+    const volatileArc2 = runtime.newArc({arcName: 'test-arc-v2', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
     const recipe2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
     assert.isTrue(recipe2 && recipe2.isResolved());
     await volatileArc2.instantiate(recipe2);

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -132,7 +132,8 @@ describe('Runtime', () => {
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc1 = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc-v1', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    await runtime.allocator.runPlanInArc(volatileArc1.id, manifest.recipes[1]);
+    const plan1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
+    await runtime.allocator.runPlanInArc(volatileArc1.id, plan1);
     assert.lengthOf(runtime.context.stores, 6);
     volatileArc1.dispose();
     assert.lengthOf(runtime.context.stores, 6);
@@ -144,7 +145,8 @@ describe('Runtime', () => {
     assert.lengthOf(runtime.context.stores, 6);
 
     const volatileArc2 = runtime.getArcById(runtime.allocator.newArc({arcName: 'test-arc-v2', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    await runtime.allocator.runPlanInArc(volatileArc2.id, manifest.recipes[1]);
+    const plan2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
+    await runtime.allocator.runPlanInArc(volatileArc2.id, plan2);
     assert.lengthOf(runtime.context.stores, 6);
     assert.isTrue(runtime.context.stores.map(s => s.storageKey).includes(
         volatileArc2.activeRecipe.handles[0].storageKey));

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -43,7 +43,7 @@ describe('Arc integration', () => {
     `);
     runtime.context = manifest;
 
-    const arc = await runtime.startArc({arcName: 'demo', planName: 'TheRecipe'});
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', planName: 'TheRecipe'}));
     await arc.idle;
 
     assert.lengthOf(arc.stores, 1);

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -30,7 +30,7 @@ describe('Arc integration', () => {
         name: Text
       particle P in './p.js'
         thing: reads writes Thing
-      recipe TheRecipe
+      recipe
         thingHandle: copy 'mything'
         P
           thing: thingHandle
@@ -43,7 +43,7 @@ describe('Arc integration', () => {
     `);
     runtime.context = manifest;
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', planName: 'TheRecipe'}));
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo'}));
     await arc.idle;
 
     assert.lengthOf(arc.stores, 1);

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -30,7 +30,7 @@ describe('Arc integration', () => {
         name: Text
       particle P in './p.js'
         thing: reads writes Thing
-      recipe
+      recipe TheRecipe
         thingHandle: copy 'mything'
         P
           thing: thingHandle
@@ -43,13 +43,7 @@ describe('Arc integration', () => {
     `);
     runtime.context = manifest;
 
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
-    assert.lengthOf(arc.stores, 0);
-    assert.isEmpty(Object.keys(arc.storeTagsById));
-
-    const recipe = manifest.recipes[0];
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'demo', planName: 'TheRecipe'});
     await arc.idle;
 
     assert.lengthOf(arc.stores, 1);

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -70,7 +70,7 @@ describe('Hot Code Reload for JS Particle', async () => {
     });
 
     const runtime = new Runtime({context, loader});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const personType = context.findTypeByName('Person') as EntityType;
 
     const personStoreIn = await arc.createStore(new SingletonType(personType));
@@ -127,7 +127,7 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const context = await Manifest.load(manifestFile, loader);
 
     const runtime = new Runtime({loader, context});
-    const arc = await runtime.startArc({arcName: 'HotReload'});
+    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'HotReload'}));
     await arc.idle;
 
     // TODO(sjmiles): render data no longer captured by slot objects
@@ -149,7 +149,7 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const context = await Manifest.load(manifestFile, loader);
 
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc({arcName: 'test'});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'test'}));
     const personType = context.findTypeByName('Person') as EntityType;
 
     const personStoreIn = await arc.createStore(new SingletonType(personType));

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -82,9 +82,8 @@ describe('Hot Code Reload for JS Particle', async () => {
     const recipe = context.recipes[0];
     recipe.handles[0].mapToStorage(personStoreIn);
     recipe.handles[1].mapToStorage(personStoreOut);
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
     assert.deepStrictEqual(await personHandleOut.fetch() as {}, {name: 'Jack', age: 30});
 
@@ -128,11 +127,7 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const context = await Manifest.load(manifestFile, loader);
 
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc({arcName: 'HotReload'});
-
-    const recipe = context.recipes.filter(r => r.name === 'HotReloadRecipe')[0];
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
-    await arc.instantiate(recipe);
+    const arc = await runtime.startArc({arcName: 'HotReload'});
     await arc.idle;
 
     // TODO(sjmiles): render data no longer captured by slot objects
@@ -166,9 +161,8 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const recipe = context.recipes.filter(r => r.name === 'ReloadHandleRecipe')[0];
     recipe.handles[0].mapToStorage(personStoreIn);
     recipe.handles[1].mapToStorage(personStoreOut);
-    assert.isTrue(recipe.normalize() && recipe.isResolved());
 
-    await arc.instantiate(recipe);
+    await runtime.allocator.runPlanInArc(arc.id, recipe);
     await arc.idle;
     assert.deepStrictEqual(await personHandleOut.fetch() as {}, {name: 'Jack', age: 30});
 

--- a/src/tests/hotreload-integration-test.ts
+++ b/src/tests/hotreload-integration-test.ts
@@ -70,7 +70,7 @@ describe('Hot Code Reload for JS Particle', async () => {
     });
 
     const runtime = new Runtime({context, loader});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const personType = context.findTypeByName('Person') as EntityType;
 
     const personStoreIn = await arc.createStore(new SingletonType(personType));
@@ -128,7 +128,7 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const context = await Manifest.load(manifestFile, loader);
 
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc('HotReload');
+    const arc = runtime.newArc({arcName: 'HotReload'});
 
     const recipe = context.recipes.filter(r => r.name === 'HotReloadRecipe')[0];
     assert.isTrue(recipe.normalize() && recipe.isResolved());
@@ -154,7 +154,7 @@ describe('Hot Code Reload for WASM Particle', async () => {
     const context = await Manifest.load(manifestFile, loader);
 
     const runtime = new Runtime({loader, context});
-    const arc = runtime.newArc('test');
+    const arc = runtime.newArc({arcName: 'test'});
     const personType = context.findTypeByName('Person') as EntityType;
 
     const personStoreIn = await arc.createStore(new SingletonType(personType));

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -84,7 +84,7 @@ describe('common particles test', () => {
 
     assert.isEmpty(arc.stores);
 
-    await suggestion.instantiate(arc);
+    await runtime.allocator.runPlanInArc(arc.id, suggestion.plan)
     await arc.idle;
 
     const storeInfo = arc.findStoreById(arc.stores[2].id) as StoreInfo<CollectionEntityType>;

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -75,7 +75,7 @@ describe('common particles test', () => {
   it('copy handle test', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/tests/particles/artifacts/copy-collection-test.recipes');
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -75,7 +75,7 @@ describe('common particles test', () => {
   it('copy handle test', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/tests/particles/artifacts/copy-collection-test.recipes');
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -84,7 +84,7 @@ describe('common particles test', () => {
 
     assert.isEmpty(arc.stores);
 
-    await runtime.allocator.runPlanInArc(arc.id, suggestion.plan)
+    await runtime.allocator.runPlanInArc(arc.id, suggestion.plan);
     await arc.idle;
 
     const storeInfo = arc.findStoreById(arc.stores[2].id) as StoreInfo<CollectionEntityType>;

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -241,7 +241,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
     assert.strictEqual('Show foo.', suggestions0[0].descriptionText);
 
     // Instantiate suggestion
-    await suggestions0[0].instantiate(arc);
+    await runtime.allocator.runPlanInArc(arc.id, await suggestions0[0].getResolvedPlan(arc));
     await arc.idle;
 
     // Plan again.

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -115,8 +115,8 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
       options.manifestString || createManifestString(options),
       {fileName: 'foo.js'}
     );
-    const key = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.newArc('demo', key);
+    const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
@@ -184,7 +184,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
             foo: writes fooHandle
           description \`cannot show duplicate \${ShowFoo.foo}\`
       `, {fileName: ''});
-    const arc = runtime.newArc('demo', storageKeyPrefixForTest());
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
 
     await StrategyTestHelper.planForArc(runtime, arc).then(() => assert('expected exception for duplicate particles'))
       .catch((err) => assert.strictEqual(
@@ -233,8 +233,8 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         Dummy
         description \`show \${ShowFoo.foo} with dummy\`
     `, {fileName: ''});
-    const key = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.newArc('demo', key);
+    const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
     // Plan for arc
     const suggestions0 = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions0, 2);
@@ -267,8 +267,8 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         C
         description \`do C\`
     `, {fileName: ''});
-    const key = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.newArc('demo', key);
+    const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
+    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -116,7 +116,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
       {fileName: 'foo.js'}
     );
     const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix}));
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
@@ -184,7 +184,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
             foo: writes fooHandle
           description \`cannot show duplicate \${ShowFoo.foo}\`
       `, {fileName: ''});
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
 
     await StrategyTestHelper.planForArc(runtime, arc).then(() => assert('expected exception for duplicate particles'))
       .catch((err) => assert.strictEqual(
@@ -234,7 +234,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         description \`show \${ShowFoo.foo} with dummy\`
     `, {fileName: ''});
     const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix}));
     // Plan for arc
     const suggestions0 = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions0, 2);
@@ -268,7 +268,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         description \`do C\`
     `, {fileName: ''});
     const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.newArc({arcName: 'demo', storageKeyPrefix});
+    const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'demo', storageKeyPrefix}));
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -537,8 +537,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       const manifest = await manifestPromise;
 
       const {driverFactory, storageService, storageKeyParser} = runtime;
-      const arc2 = await runtime.allocator.deserialize({serialization, fileName: ''});
-      //await Arc.deserialize({serialization, loader, fileName: '', context: manifest, storageService, driverFactory, storageKeyParser});
+      const arc2 = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: ''}));
       await arc2.idle;
 
       const fooClass = Entity.createEntityClass(manifest.findSchemaByName('FooHandle'), null);

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -532,7 +532,8 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       const manifest = await manifestPromise;
 
       const {driverFactory, storageService, storageKeyParser} = runtime;
-      const arc2 = await Arc.deserialize({serialization, loader, fileName: '', context: manifest, storageService, driverFactory, storageKeyParser});
+      const arc2 = await runtime.allocator.deserialize({serialization, fileName: ''});
+      //await Arc.deserialize({serialization, loader, fileName: '', context: manifest, storageService, driverFactory, storageKeyParser});
       await arc2.idle;
 
       const fooClass = Entity.createEntityClass(manifest.findSchemaByName('FooHandle'), null);

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -93,23 +93,12 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       }
     });
 
-    async function setup(recipeName) {
+    async function setup(planName) {
       const runtime = new Runtime({loader, context: await manifestPromise});
-      const arc = runtime.newArc('wasm-test', storageKeyPrefixForTest());
-
-      const recipe = arc.context.allRecipes.find(r => r.name === recipeName);
-      if (!recipe) {
-        throw new Error(`Test recipe '${recipeName}' not found`);
-      }
-      recipe.normalize();
-      await arc.instantiate(recipe);
-      await arc.idle;
-
-      const [info] = arc.loadedParticleInfo.values();
-
-      const slotComposer = arc.peh.slotComposer;
       const slotObserver = new SlotTestObserver();
-      slotComposer.observeSlots(slotObserver);
+      const arc = await runtime.startArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest(), planName, slotObserver});
+      await arc.idle;
+      const [info] = arc.loadedParticleInfo.values();
 
       return {arc, stores: info.stores, slotObserver, runtime};
     }
@@ -485,7 +474,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       // extra fields are correctly ignored.
       const manifest = await manifestPromise;
       const runtime = new Runtime({loader, context: manifest});
-      const arc = runtime.newArc('wasm-test', storageKeyPrefixForTest());
+      const arc = runtime.newArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest()});
 
       const sliceClass = Entity.createEntityClass(manifest.findSchemaByName('Slice'), null);
       const sngStore = await arc.createStore(new SingletonType(sliceClass.type), undefined, 'test:0');

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -495,8 +495,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       recipe.handles[0].mapToStorage(sngStore);
       recipe.handles[1].mapToStorage(colStore);
       recipe.handles[2].mapToStorage(resStore);
-      recipe.normalize();
-      await arc.instantiate(recipe);
+      await runtime.allocator.runPlanInArc(arc.id, recipe);
       await arc.idle;
 
       const res = await handleForStoreInfo(resStore, arc);

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -96,7 +96,12 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     async function setup(planName) {
       const runtime = new Runtime({loader, context: await manifestPromise});
       const slotObserver = new SlotTestObserver();
-      const arc = await runtime.startArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest(), planName, slotObserver});
+      const arc = runtime.getArcById(await runtime.allocator.startArc({
+        arcName: 'wasm-test',
+        storageKeyPrefix: storageKeyPrefixForTest(),
+        planName,
+        slotObserver
+      }));
       await arc.idle;
       const [info] = arc.loadedParticleInfo.values();
 
@@ -474,7 +479,7 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       // extra fields are correctly ignored.
       const manifest = await manifestPromise;
       const runtime = new Runtime({loader, context: manifest});
-      const arc = runtime.newArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest()});
+      const arc = runtime.getArcById(runtime.allocator.newArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest()}));
 
       const sliceClass = Entity.createEntityClass(manifest.findSchemaByName('Slice'), null);
       const sngStore = await arc.createStore(new SingletonType(sliceClass.type), undefined, 'test:0');


### PR DESCRIPTION
    - Declare Allocator and ArcHost interfaces and classes
    - Move all Arc creation and Plan instantiation APIs from Runtime to Allocator
    - Allocator assigns storage keys for create/copy stores (moved from arc.ts)

Next steps:
    - Unify Allocator’s newArc and startArc APIs
    - Move access to storage service from Arc to ArcHost
    - Refactor PEH/PEC outside Arc class
    - Simplify Arc and getting ahold of Arc APIs
    - Incorporate Planning APIs into Allocator
    - Introduce UI composition APIs
