### PR TITLE
Catch common cases where Directions are misspelled 

### DIFF
--- a/src/runtime/manifest-ast-types/enums.ts
+++ b/src/runtime/manifest-ast-types/enums.ts
@@ -11,7 +11,17 @@
 // String-based enums.
 // TODO: convert to actual enums so that they can be iterated over.
 
-export type Direction = 'reads' | 'writes' | 'reads writes' | 'hosts' | '`consumes' | '`provides' | 'any';
+export const directions = [
+  'reads',
+  'writes',
+  'reads writes',
+  'hosts',
+  '`consumes',
+  '`provides',
+  'any'
+] as const;
+
+export type Direction = typeof directions[number];
 export type SlotDirection = 'provides' | 'consumes';
 
 /** The different types of trust claims that particles can make. */

--- a/src/runtime/manifest-ast-types/enums.ts
+++ b/src/runtime/manifest-ast-types/enums.ts
@@ -21,7 +21,9 @@ export const directions = [
   'any'
 ] as const;
 
+// Creates a union of all values in the associated list.
 export type Direction = typeof directions[number];
+
 export type SlotDirection = 'provides' | 'consumes';
 
 /** The different types of trust claims that particles can make. */

--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -7,8 +7,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {Direction, SlotDirection, ClaimType, CheckType, Fate} from '../manifest-ast-types/enums.js';
-export {Direction, SlotDirection, ClaimType, CheckType, Fate};
+import {directions, Direction, SlotDirection, ClaimType, CheckType, Fate} from '../manifest-ast-types/enums.js';
+export {directions, Direction, SlotDirection, ClaimType, CheckType, Fate};
 /**
  * Complete set of tokens used by `manifest-parser.pegjs`. To use this you
  * need to follow some simple guidelines:

--- a/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
+++ b/src/runtime/manifest-ast-types/manifest-ast-nodes.ts
@@ -760,6 +760,7 @@ export const schemaPrimitiveTypes = [
   'Duration',
 ] as const;
 
+// Creates a union of all values in the associated list.
 export type SchemaPrimitiveTypeValue = typeof schemaPrimitiveTypes[number];
 
 export const kotlinPrimitiveTypes = [
@@ -772,6 +773,7 @@ export const kotlinPrimitiveTypes = [
   'Double',
 ] as const;
 
+// Creates a union of all values in the associated list.
 export type KotlinPrimitiveTypeValue = typeof kotlinPrimitiveTypes[number];
 
 export const discreteTypes = [
@@ -782,8 +784,8 @@ export const discreteTypes = [
   'Duration',
 ] as const;
 
-export type DiscreteType
-  = typeof discreteTypes[number];
+// Creates a union of all values in the associated list.
+export type DiscreteType = typeof discreteTypes[number];
 
 export const continuousTypes = [
   'Number',
@@ -800,6 +802,7 @@ export const primitiveTypes = [
   ...discreteTypes
 ];
 
+// Creates a union of all values in the associated list.
 export type Primitive = typeof primitiveTypes[number];
 
 export const timeUnits = [
@@ -810,6 +813,7 @@ export const timeUnits = [
  'milliseconds'
 ];
 
+// Creates a union of all values in the associated list.
 export type SupportedUnit = typeof timeUnits[number];
 
 export interface NumberNode extends BaseNode {

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -790,6 +790,9 @@ ParticleHandleConnectionBody
       expression: optional(expression, e => e[3], null)
     });
   }
+  / name:NameWithColon &(!('consumes' / 'provides')) (direction:([a-zA-Z0-0?]+) {
+    expected(`a direction (${AstNode.directions.join(', ')})`)
+  })
 
 Direction "a direction (e.g. reads writes, reads, writes, hosts, `consumes, `provides, any')"
   = (('reads' ('?'?) ' writes') / 'reads' / 'writes' / 'hosts' / '`consumes' / '`provides') &([^a-zA-Z0-9] / !.)

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -579,11 +579,11 @@ Particle
 
 ParticleItem "a particle item"
   = ParticleModality
-  / ParticleSlotConnection
   / Description
-  / ParticleHandleConnection
   / ClaimStatement
   / CheckStatement
+  / ParticleSlotConnection
+  / ParticleHandleConnection
 
 ClaimStatement
   = 'claim' whiteSpace target:dottedFields whiteSpace expression:ClaimExpression eolWhiteSpace

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -791,7 +791,7 @@ ParticleHandleConnectionBody
     });
   }
   / name:NameWithColon &(!('consumes' / 'provides')) (direction:([a-zA-Z0-0?]+) {
-    expected(`a direction (${AstNode.directions.join(', ')})`)
+    expected(`a direction (${AstNode.directions.join(', ')})`);
   })
 
 Direction "a direction (e.g. reads writes, reads, writes, hosts, `consumes, `provides, any')"
@@ -1337,7 +1337,7 @@ RecipeConnection
     });
   }
   / from:ConnectionTargetWithColon? &(!('consumes' / 'provides')) (direction:([a-zA-Z0-0?]+) {
-    expected(`a direction (${AstNode.directions.join(', ')})`)
+    expected(`a direction (${AstNode.directions.join(', ')})`);
   })
 
 ConnectionTargetWithColon

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1336,6 +1336,9 @@ RecipeConnection
       to,
     });
   }
+  / from:ConnectionTargetWithColon? &(!('consumes' / 'provides')) (direction:([a-zA-Z0-0?]+) {
+    expected(`a direction (${AstNode.directions.join(', ')})`)
+  })
 
 ConnectionTargetWithColon
   = target:ConnectionTarget ':' whiteSpace?

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -1185,15 +1185,15 @@ RecipeNode
 
 // RequireHandleSection is intended to replace RecipeHandle but for now we allow for both ways to create a handle.
 RecipeItem
-  = RecipeParticle
-  / RecipeHandle
-  / RecipeSyntheticHandle
+  = Description
   / RequireHandleSection
   / RecipeRequire
-  / RecipeSlot
   / RecipeSearch
+  / RecipeParticle
+  / RecipeSyntheticHandle
+  / RecipeSlot
+  / RecipeHandle
   / RecipeConnection
-  / Description
 
 LocalName
   = 'as' whiteSpace name:(lowerIdent / [a-zA-Z0-9]* { expected(`lower identifier`); })

--- a/src/runtime/manifest-parser.pegjs
+++ b/src/runtime/manifest-parser.pegjs
@@ -426,9 +426,9 @@ Interface "an interface"
 // split into multiple capture clauses because the combined one is able to match against an empty string (this would
 // cause an infinite loop).
 InterfaceArgument
-  = name:NameWithColon direction:(Direction / SlotDirection)? isOptional:'?'? type:(whiteSpace? ParticleHandleConnectionType)? eolWhiteSpace
+  = name:NameWithColon direction:(SlotDirection / Direction)? isOptional:'?'? type:(whiteSpace? ParticleHandleConnectionType)? eolWhiteSpace
   { return buildInterfaceArgument(name, direction || 'any', isOptional, optional(type, t => t[1], null)); }
-  / direction:(Direction / SlotDirection) isOptional:'?'? type:(whiteSpace? ParticleHandleConnectionType)? eolWhiteSpace
+  / direction:(SlotDirection / Direction) isOptional:'?'? type:(whiteSpace? ParticleHandleConnectionType)? eolWhiteSpace
   { return buildInterfaceArgument(null, direction || 'any', isOptional, optional(type, t => t[1], null)); }
   / isOptional:'?'? type:(whiteSpace? ParticleHandleConnectionType) eolWhiteSpace
   { return buildInterfaceArgument(null, 'any', isOptional, type); }

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -217,6 +217,16 @@ describe('manifest parser', () => {
       'this parse should have failed, unknown capabilities/directions should not be accepted!'
     );
   });
+  it('fails to parse a recipe connection with an unknown capability/direction', () => {
+    assert.throws(() => {
+        parse(`
+          recipe MyParticle
+            foo: read bar`);
+      },
+      /Expected a direction \(reads, writes.*\) but "read" found\./,
+      'this parse should have failed, unknown capabilities/directions should not be accepted!'
+    );
+  });
   it('fails to parse an argument list that use a reserved word as an identifier', () => {
     assert.throws(() => {
         parse(`

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -207,6 +207,16 @@ describe('manifest parser', () => {
       store Store1 of Person 'some-id' @7 in 'person.json'
       store Store2 of BigCollection<Person> in 'population.json'`);
   });
+  it('fails to parse a particle handle with an unknown capability/direction', () => {
+    assert.throws(() => {
+        parse(`
+          particle MyParticle
+            foo: read MyThing`);
+      },
+      /Expected a direction (reads, writes.*) but "read" found./,
+      'this parse should have failed, unknown capabilities/directions should not be accepted!'
+    );
+  });
   it('fails to parse an argument list that use a reserved word as an identifier', () => {
     assert.throws(() => {
         parse(`

--- a/src/runtime/tests/manifest-parser-test.ts
+++ b/src/runtime/tests/manifest-parser-test.ts
@@ -213,7 +213,7 @@ describe('manifest parser', () => {
           particle MyParticle
             foo: read MyThing`);
       },
-      /Expected a direction (reads, writes.*) but "read" found./,
+      /Expected a direction \(reads, writes.*\) but "read" found\./,
       'this parse should have failed, unknown capabilities/directions should not be accepted!'
     );
   });

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -3042,6 +3042,14 @@ resource SomeName
     assert.strictEqual(recipe.particles[0].connections.a.handle, recipe.particles[1].connections.b.handle);
   });
 
+  it('can parse particles with handle connections with dependent slot connections', async () => {
+    const manifest = await runtime.parse(`
+      particle P2
+        b: reads S {}
+          details: consumes
+    `);
+  });
+
   it('can parse recipes with a require section', async () => {
     const manifest = await runtime.parse(`
       particle P1


### PR DESCRIPTION
Unfortunately, because Direction is optional, we can't simply catch any case where an unknown direction is used (as the unknown text might actually be a handle name or type etc).

I think we're starting to run into the limits of what PEGjs can do for us in terms of error messages, but we can continue to add 'common sense' error cases like this when they are common and confusing enough.