### PR TITLE
declare ArcInfo, move info structs from Arc and refactor Arc's store management functionality

### DIFF
--- a/src/planning/recipe-index.ts
+++ b/src/planning/recipe-index.ts
@@ -28,6 +28,7 @@ import * as Rulesets from './strategies/rulesets.js';
 import {IdGenerator} from '../runtime/id.js';
 import {Fate} from '../runtime/arcs-types/enums.js';
 import {SlotType} from '../types/lib-types.js';
+import {ArcInfo} from '../runtime/arc-info.js';
 
 type MatchingHandle = {
   handle?: Handle,
@@ -94,15 +95,17 @@ export class RecipeIndex {
     const trace = Tracing.start({cat: 'indexing', name: 'RecipeIndex::constructor', overview: true});
     const idGenerator = IdGenerator.newSession();
     const arcStub = new Arc({
-      id: idGenerator.newArcId('index-stub'),
-      context: new Manifest({id: idGenerator.newArcId('empty-context')}),
+      arcInfo: new ArcInfo({
+        id: idGenerator.newArcId('index-stub'),
+        context: new Manifest({id: idGenerator.newArcId('empty-context')}),
+        capabilitiesResolver: arc.capabilitiesResolver
+      }),
       loader: arc.loader,
       slotComposer: new SlotComposer({noRoot: true}),
       stub: true,
       storageService: arc.storageService,
       driverFactory: arc.driverFactory,
-      storageKeyParser: arc.storageKeyParser,
-      capabilitiesResolver: arc.capabilitiesResolver
+      storageKeyParser: arc.storageKeyParser
     });
     const strategizer = new Strategizer(
       [

--- a/src/planning/speculator.ts
+++ b/src/planning/speculator.ts
@@ -24,7 +24,7 @@ export class Speculator {
     const speculativeArc = await arc.cloneForSpeculativeExecution();
     this.speculativeArcs.push(speculativeArc);
     const relevance = Relevance.create(arc, plan);
-    plan = await this.runtime.allocator.assignStorageKeys(speculativeArc.id, plan, speculativeArc.idGenerator);
+    plan = await this.runtime.allocator.assignStorageKeys(speculativeArc.id, plan);
     await speculativeArc.instantiate(plan);
     await this.awaitCompletion(relevance, speculativeArc);
 

--- a/src/planning/strategies/tests/search-tokens-to-handles-test.ts
+++ b/src/planning/strategies/tests/search-tokens-to-handles-test.ts
@@ -38,7 +38,7 @@ describe('SearchTokensToHandles', () => {
     `);
 
     const arc = await StrategyTestHelper.createTestArc(manifest);
-    await arc._registerStore(arc.context.findStoreById('thing-id'), ['mything']);
+    await arc.arcInfo.registerStore(arc.context.findStoreById('thing-id'), ['mything']);
 
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/arc-info.ts
+++ b/src/runtime/arc-info.ts
@@ -10,13 +10,13 @@
 
 import {assert} from '../platform/assert-web.js';
 import {Arc, ArcOptions} from './arc.js';
-import {ArcId, IdGenerator} from './id.js';
+import {ArcId, IdGenerator, Id} from './id.js';
 import {Manifest} from './manifest.js';
 import {Recipe, Particle} from './recipe/lib-recipe.js';
 import {StorageService} from './storage/storage-service.js';
 import {SlotComposer} from './slot-composer.js';
 import {Runtime} from './runtime.js';
-import {Dictionary} from '../utils/lib-utils.js';
+import {Dictionary, Mutex} from '../utils/lib-utils.js';
 import {newRecipe} from './recipe/lib-recipe.js';
 import {CapabilitiesResolver} from './capabilities-resolver.js';
 import {VolatileStorageKey} from './storage/drivers/volatile.js';
@@ -27,13 +27,23 @@ import {AbstractSlotObserver} from './slot-observer.js';
 import {Modality} from './arcs-types/modality.js';
 import {EntityType, ReferenceType, InterfaceType, SingletonType} from '../types/lib-types.js';
 import {Capabilities} from './capabilities.js';
+import {StoreInfo} from './storage/store-info.js';
+import {Type} from '../types/lib-types.js';
+import {Handle, Slot} from './recipe//lib-recipe.js';
+import {Exists} from './storage/drivers/driver.js';
+import {ReferenceModeStorageKey} from './storage/reference-mode-storage-key.js';
+import {CollectionType, TupleType} from '../types/lib-types.js';
 
 export type StorageKeyPrefixer = (arcId: ArcId) => StorageKey;
 
-export type NewArcOptions = Readonly<{
-  arcName?: string,
-  arcId?: ArcId,
-  storageKeyPrefix?: StorageKeyPrefixer
+export type NewArcInfoOptions = Readonly<{
+  arcName?: string;
+  arcId?: ArcId;
+  idGenerator?: IdGenerator;
+}>;
+
+export type RunArcOptions = Readonly<{
+  storageKeyPrefix?: StorageKeyPrefixer;
   pecFactories?: PecFactory[];
   speculative?: boolean;
   innerArc?: boolean;
@@ -42,10 +52,9 @@ export type NewArcOptions = Readonly<{
   inspectorFactory?: ArcInspectorFactory;
   modality?: Modality;
   slotObserver?: AbstractSlotObserver;
-  idGenerator?: IdGenerator;
 }>;
 
-export type StartArcOptions = NewArcOptions & {planName?: string};
+export type StartArcOptions = NewArcInfoOptions & RunArcOptions & {planName?: string};
 
 export type PlanPartition = Readonly<{
   // TODO(b/182410550): plan should be mandatory, when Arc class is refactored
@@ -53,7 +62,8 @@ export type PlanPartition = Readonly<{
   // an Arc with no running recipes is created.
   plan?: Recipe;
   reinstantiate?: boolean;
-  arcOptions: NewArcOptions;
+  arcInfo: ArcInfo;
+  arcOptions: RunArcOptions;
   arcHostId: string;
 }>;
 
@@ -64,3 +74,176 @@ export type DeserializeArcOptions = Readonly<{
   fileName: string;
   inspectorFactory?: ArcInspectorFactory;
 }>;
+
+export type ArcInfoOptions = Readonly<{
+  id: ArcId;
+  context: Manifest;
+  capabilitiesResolver: CapabilitiesResolver;
+  idGenerator?: IdGenerator;
+}>;
+
+export class ArcInfo {
+  public readonly id: ArcId;
+  public readonly context: Manifest;
+  public readonly capabilitiesResolver: CapabilitiesResolver;
+  public readonly idGenerator: IdGenerator;
+  public readonly partitions: PlanPartition[] = [];
+  readonly storeInfoById: Dictionary<StoreInfo<Type>> = {};
+  public readonly storeTagsById: Dictionary<Set<string>> = {};
+  activeRecipe: Recipe = newRecipe();
+  readonly recipeDeltas: {handles: Handle[], particles: Particle[], slots: Slot[], patterns: string[]}[] = [];
+  private readonly instantiateMutex = new Mutex();
+
+  constructor(opts: ArcInfoOptions) {
+    this.id = opts.id;
+    this.context = opts.context;
+    this.capabilitiesResolver = opts.capabilitiesResolver;
+    this.idGenerator = opts.idGenerator || IdGenerator.newSession();
+  }
+
+  generateID(component: string = ''): Id {
+    return this.idGenerator.newChildId(this.id, component);
+  }
+
+  async createStoreInfo<T extends Type>(opts: {type: T, name?: string, id?: string, storageKey?: StorageKey, capabilities?: Capabilities, exists?: Exists}): Promise<StoreInfo<T>> {
+    let id = opts.id;
+    if (id == undefined) {
+      id = this.generateID().toString();
+    }
+
+    const storageKey = opts.storageKey ||
+        // Consider passing `tags` to capabilities resolver.
+        await this.capabilitiesResolver.createStorageKey(opts.capabilities || Capabilities.create(), opts.type, id);
+    return new StoreInfo({id, type: opts.type, name: opts.name, storageKey, exists: opts.exists || Exists.MayExist});
+  }
+
+  findStoreInfoByStorageKey(storageKey: StorageKey): StoreInfo<Type> {
+    return Object.values(this.storeInfoById).find(
+      storeInfo => storeInfo.storageKey.toString() === storageKey.toString());
+  }
+
+  async registerStore(storeInfo: StoreInfo<Type>, tags?: string[], registerReferenceMode?: boolean): Promise<void> {
+    assert(!this.storeInfoById[storeInfo.id], `Store already registered '${storeInfo.id}'`);
+    const type = storeInfo.type;
+    if (type instanceof TupleType) {
+      throw new Error('Tuple type is not yet supported');
+    }
+
+    // Catch legacy cases that expected us to wrap entity types in a singleton.
+    if (type.isEntity || type.isInterface || type.isReference) {
+      throw new Error('unwrapped type provided to arc.createStore');
+    }
+    tags = tags || [];
+    tags = Array.isArray(tags) ? tags : [tags];
+
+    if (!(storeInfo.type.handleConstructor())) {
+      throw new Error(`Type not supported by storage: '${storeInfo.type.tag}'`);
+    }
+    this.storeInfoById[storeInfo.id] = storeInfo;
+    this.storeTagsById[storeInfo.id] = new Set(tags);
+
+    this.context.registerStore(storeInfo, tags);
+
+    if (registerReferenceMode) {
+      const type = storeInfo.type;
+      if (storeInfo.storageKey instanceof ReferenceModeStorageKey) {
+        const refContainedType = new ReferenceType(type.getContainedType());
+        const refType = type.isSingleton ? new SingletonType(refContainedType) : new CollectionType(refContainedType);
+
+        const containerStoreInfo = await this.createStoreInfo({
+          type: refType,
+          name: storeInfo.name ? storeInfo.name + '_referenceContainer' : null,
+          storageKey: storeInfo.storageKey.storageKey
+        });
+        await this.registerStore(containerStoreInfo);
+        this.addHandleToActiveRecipe(containerStoreInfo);
+
+        const backingStoreInfo = await this.createStoreInfo({
+          type: new CollectionType(type.getContainedType()),
+          name: storeInfo.name ? storeInfo.name + '_backingStore' : null,
+          storageKey: storeInfo.storageKey.backingKey
+        });
+        await this.registerStore(backingStoreInfo);
+        this.addHandleToActiveRecipe(backingStoreInfo);
+      }
+    }
+  }
+
+  tagStore(store: StoreInfo<Type>, tags: Set<string> = new Set()): void {
+    assert(this.storeInfoById[store.id] && this.storeTagsById[store.id], `Store not registered '${store.id}'`);
+    tags.forEach(tag => this.storeTagsById[store.id].add(tag));
+  }
+
+  addHandleToActiveRecipe(storeInfo: StoreInfo<Type>) {
+    const handle = this.activeRecipe.newHandle();
+    handle.mapToStorage(storeInfo);
+    handle.fate = 'use';
+    // TODO(shans): is this the right thing to do? This seems not to be the right thing to do!
+    handle['_type'] = handle.mappedType;
+  }
+
+  async instantiate(recipe: Recipe) {
+    const release = await this.instantiateMutex.acquire();
+    try {
+      await this.mergeIntoActiveRecipe(recipe);
+    } finally {
+      release();
+    }
+  }
+
+  async mergeIntoActiveRecipe(recipe: Recipe) {
+    const {handles, particles, slots} = recipe.mergeInto(this.activeRecipe);
+    // handles represents only the new handles; it doesn't include 'use' handles that have
+    // resolved against the existing recipe.
+    this.recipeDeltas.push({particles, handles, slots, patterns: recipe.patterns});
+
+    // TODO(mmandlis, jopra): Get rid of populating the missing local slot & slandle IDs here,
+    // it should be done at planning stage.
+    slots.forEach(slot => slot.id = slot.id || this.generateID('slot').toString());
+    handles.forEach(handle => {
+      if (handle.toSlot()) {
+        handle.id = handle.id || this.generateID('slandle').toString();
+      }
+    });
+
+    for (const recipeHandle of handles) {
+      assert(recipeHandle.immediateValue || ['use', 'map'].includes(recipeHandle.fate), `Unexpected fate: ${recipeHandle.fate}`);
+      const fate = recipeHandle.originalFate && recipeHandle.originalFate !== '?'
+          ? recipeHandle.originalFate : recipeHandle.fate;
+      if (fate === 'use') {
+        throw new Error(`store '${recipeHandle.id}' with "use" fate was not found in recipe`);
+      }
+
+
+      if (['copy', 'map', 'create'].includes(fate)) {
+        let type = recipeHandle.type;
+        if (recipeHandle.fate === 'create') {
+          assert(type.maybeResolve(), `Can't assign resolved type to ${type}`);
+        }
+
+        type = type.resolvedType();
+        assert(type.isResolved(), `Can't create handle for unresolved type ${type}`);
+
+        assert(recipeHandle.id);
+        const storageKey = recipeHandle.immediateValue
+          ? new VolatileStorageKey(this.id, '').childKeyForHandle(recipeHandle.id)
+          : recipeHandle.storageKey;
+        assert(storageKey, `Missing storage for recipe handle ${recipeHandle.id}`);
+
+        // TODO(shanestephens): Remove this once singleton types are expressed directly in recipes.
+        if (type instanceof EntityType || type instanceof ReferenceType || type instanceof InterfaceType) {
+          type = new SingletonType(type);
+        }
+        const exists = fate === 'map' ? Exists.ShouldExist : Exists.MayExist;
+        const newStore = new StoreInfo({storageKey, type, exists, id: recipeHandle.id});
+        await this.registerStore(newStore, recipeHandle.tags, /* registerReferenceMode= */ fate !== 'map');
+        if (fate === 'copy' && !recipeHandle.immediateValue) {
+          const copiedStoreInfo = this.context.findStoreById(recipeHandle.originalId);
+          newStore.name = copiedStoreInfo.name && `Copy of ${copiedStoreInfo.name}`;
+          this.tagStore(newStore, this.context.findStoreTags(copiedStoreInfo));
+        }
+      }
+    }
+    return {handles, particles, slots};
+  }
+}

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -463,10 +463,7 @@ export class Arc implements ArcInterface {
   // TODO(shanestephens): Once we stop auto-wrapping in singleton types below, convert this to return a well-typed store.
   async createStore<T extends Type>(type: T, name?: string, id?: string, tags?: string[], storageKey?: StorageKey,
         capabilities?: Capabilities): Promise<StoreInfo<T>> {
-    const storeInfo = await this.arcInfo.createStoreInfo({type, name, id, storageKey, capabilities});
-    await this.arcInfo.registerStore(storeInfo, tags, /* registerReferenceMode= */ true);
-    this.arcInfo.addHandleToActiveRecipe(storeInfo);
-
+    const storeInfo = await this.arcInfo.createStoreInfo({type, name, id, storageKey, capabilities, tags});
     await this.createStoreInternal(storeInfo);
     return storeInfo;
   }

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -38,10 +38,10 @@ import {SingletonInterfaceHandle, handleForStoreInfo, TypeToCRDTTypeRecord} from
 import {StoreInfo} from './storage/store-info.js';
 import {ActiveStore} from './storage/active-store.js';
 import {StorageService} from './storage/storage-service.js';
+import {ArcInfo} from './arc-info.js';
 
 export type ArcOptions = Readonly<{
-  id: Id;
-  context: Manifest;
+  arcInfo: ArcInfo,
   storageService: StorageService;
   pecFactories?: PecFactory[];
   slotComposer?: SlotComposer;
@@ -52,32 +52,28 @@ export type ArcOptions = Readonly<{
   stub?: boolean;
   inspectorFactory?: ArcInspectorFactory;
   ports?: MessagePort[];
-  capabilitiesResolver: CapabilitiesResolver;
   modality?: Modality;
   driverFactory: DriverFactory;
   storageKeyParser: StorageKeyParser;
-  idGenerator?: IdGenerator;
 }>;
 
 @SystemTrace
 export class Arc implements ArcInterface {
-  private readonly _context: Manifest;
   private readonly pecFactories: PecFactory[];
   public readonly isSpeculative: boolean;
   public readonly isInnerArc: boolean;
   public readonly isStub: boolean;
-  private _activeRecipe: Recipe = newRecipe();
-  private _recipeDeltas: {handles: Handle[], particles: Particle[], slots: Slot[], patterns: string[]}[] = [];
   public _modality: Modality;
   // Public for debug access
   public readonly _loader: Loader;
   private readonly dataChangeCallbacks = new Map<object, Runnable>();
   // storage keys for referenced handles
-  private storeInfoById: Dictionary<StoreInfo<Type>> = {};
+  public get storeInfoById(): Dictionary<StoreInfo<Type>> { return this.arcInfo.storeInfoById; }
   public readonly storageKey?:  StorageKey;
-  readonly capabilitiesResolver?: CapabilitiesResolver;
+  public get capabilitiesResolver(): CapabilitiesResolver { return this.arcInfo.capabilitiesResolver; }
   // Map from each store ID to a set of tags. public for debug access
-  public readonly storeTagsById: Dictionary<Set<string>> = {};
+  public get storeTagsById() { return this.arcInfo.storeTagsById; }
+
   // Map from each store to its description (originating in the manifest).
   private readonly storeDescriptions = new Map<StoreInfo<Type>, string>();
   private waitForIdlePromise: Promise<void> | null;
@@ -86,8 +82,9 @@ export class Arc implements ArcInterface {
   private readonly innerArcsByParticle: Map<Particle, Arc[]> = new Map();
   private readonly instantiateMutex = new Mutex();
 
-  readonly id: Id;
-  readonly idGenerator: IdGenerator;
+  readonly arcInfo: ArcInfo;
+  public get id(): Id { return this.arcInfo.id; }
+  public get idGenerator(): IdGenerator { return this.arcInfo.idGenerator; }
   loadedParticleInfo = new Map<string, {spec: ParticleSpec, stores: Map<string, StoreInfo<Type>>}>();
   readonly peh: ParticleExecutionHost;
 
@@ -99,8 +96,7 @@ export class Arc implements ArcInterface {
   readonly volatileMemory = new VolatileMemory();
   private readonly volatileStorageDriverProvider: VolatileStorageDriverProvider;
 
-  constructor({id, context, storageService, pecFactories, slotComposer, loader, storageKey, speculative, innerArc, stub, capabilitiesResolver, inspectorFactory, modality, driverFactory, storageKeyParser, idGenerator} : ArcOptions) {
-    this._context = context;
+  constructor({arcInfo, storageService, pecFactories, slotComposer, loader, storageKey, speculative, innerArc, stub, inspectorFactory, modality, driverFactory, storageKeyParser} : ArcOptions) {
     this.modality = modality;
     this.driverFactory = driverFactory;
     this.storageKeyParser = storageKeyParser;
@@ -112,8 +108,7 @@ export class Arc implements ArcInterface {
       slotComposer['arc'] = this;
     }
 
-    this.id = id;
-    this.idGenerator = idGenerator || IdGenerator.newSession();
+    this.arcInfo = arcInfo;
     this.isSpeculative = !!speculative; // undefined => false
     this.isInnerArc = !!innerArc; // undefined => false
     this.isStub = !!stub;
@@ -125,7 +120,6 @@ export class Arc implements ArcInterface {
     this.peh = new ParticleExecutionHost({slotComposer, arc: this, ports});
     this.volatileStorageDriverProvider = new VolatileStorageDriverProvider(this);
     this.driverFactory.register(this.volatileStorageDriverProvider);
-    this.capabilitiesResolver = capabilitiesResolver;
     this.storageService = storageService;
   }
 
@@ -228,18 +222,16 @@ export class Arc implements ArcInterface {
   createInnerArc(transformationParticle: Particle): Arc {
     const id = this.generateID('inner');
     const innerArc = new Arc({
-      id,
+      arcInfo: new ArcInfo({id, context: this.context, capabilitiesResolver: this.capabilitiesResolver}),
       storageService: this.storageService,
       pecFactories: this.pecFactories,
       slotComposer: this.peh.slotComposer,
       loader: this._loader,
-      context: this.context,
       innerArc: true,
       speculative: this.isSpeculative,
       inspectorFactory: this.inspectorFactory,
       driverFactory: this.driverFactory,
-      storageKeyParser: this.storageKeyParser,
-      capabilitiesResolver: this.capabilitiesResolver
+      storageKeyParser: this.storageKeyParser
     });
 
     let particleInnerArcs = this.innerArcsByParticle.get(transformationParticle);
@@ -264,13 +256,13 @@ export class Arc implements ArcInterface {
   }
 
   get context() {
-    return this._context;
+    return this.arcInfo.context;
   }
 
-  get activeRecipe() { return this._activeRecipe; }
+  get activeRecipe() { return this.arcInfo.activeRecipe; }
   get allRecipes() { return [this.activeRecipe].concat(this.context.allRecipes); }
   get recipes() { return [this.activeRecipe]; }
-  get recipeDeltas() { return this._recipeDeltas; }
+  get recipeDeltas() { return this.arcInfo.recipeDeltas; }
 
   loadedParticleSpecs() {
     return [...this.loadedParticleInfo.values()].map(({spec}) => spec);
@@ -321,7 +313,7 @@ export class Arc implements ArcInterface {
   }
 
   generateID(component: string = ''): Id {
-    return this.idGenerator.newChildId(this.id, component);
+    return this.arcInfo.generateID(component);
   }
 
   get stores(): StoreInfo<Type>[] {
@@ -335,17 +327,15 @@ export class Arc implements ArcInterface {
   // Makes a copy of the arc used for speculative execution.
   async cloneForSpeculativeExecution(): Promise<Arc> {
     const arc = new Arc({
-      id: this.generateID(),
+      arcInfo: new ArcInfo({id: this.generateID(), context: this.context, capabilitiesResolver: this.capabilitiesResolver}),
       pecFactories: this.pecFactories,
-      context: this.context,
       loader: this._loader,
       speculative: true,
       innerArc: this.isInnerArc,
       inspectorFactory: this.inspectorFactory,
       storageService: this.storageService,
       driverFactory: this.driverFactory,
-      storageKeyParser: this.storageKeyParser,
-      capabilitiesResolver: this.capabilitiesResolver
+      storageKeyParser: this.storageKeyParser
     });
     const storeMap: Map<StoreInfo<Type>, StoreInfo<Type>> = new Map();
     for (const storeInfo of this.stores) {
@@ -369,9 +359,9 @@ export class Arc implements ArcInterface {
       arc.loadedParticleInfo.set(id, {spec: info.spec, stores});
     });
 
-    const {cloneMap} = this._activeRecipe.mergeInto(arc._activeRecipe);
+    const {cloneMap} = this.activeRecipe.mergeInto(arc.activeRecipe);
 
-    this._recipeDeltas.forEach(recipe => arc._recipeDeltas.push({
+    this.recipeDeltas.forEach(recipe => arc.recipeDeltas.push({
       particles: recipe.particles.map(p => cloneMap.get(p)),
       handles: recipe.handles.map(h => cloneMap.get(h)),
       slots: recipe.slots.map(s => cloneMap.get(s)),
@@ -385,7 +375,7 @@ export class Arc implements ArcInterface {
 
     for (const v of storeMap.values()) {
       // FIXME: Tags
-      await arc._registerStore(v, []);
+      await arc.arcInfo.registerStore(v, []);
     }
     return arc;
   }
@@ -417,98 +407,47 @@ export class Arc implements ArcInterface {
   }
 
   async mergeIntoActiveRecipe(recipe: Recipe) {
-    const {handles, particles, slots} = recipe.mergeInto(this._activeRecipe);
-    // handles represents only the new handles; it doesn't include 'use' handles that have
-    // resolved against the existing recipe.
-    this._recipeDeltas.push({particles, handles, slots, patterns: recipe.patterns});
-
-    // TODO(mmandlis, jopra): Get rid of populating the missing local slot & slandle IDs here,
-    // it should be done at planning stage.
-    slots.forEach(slot => slot.id = slot.id || this.generateID('slot').toString());
-    handles.forEach(handle => {
-      if (handle.toSlot()) {
-        handle.id = handle.id || this.generateID('slandle').toString();
-      }
-    });
-
+    await this.arcInfo.instantiate(recipe);
+    assert(this.arcInfo.recipeDeltas.length > 0);
+    const {particles, handles, slots} = this.arcInfo.recipeDeltas[this.arcInfo.recipeDeltas.length - 1];
     for (const recipeHandle of handles) {
-      assert(recipeHandle.immediateValue || ['use', 'map'].includes(recipeHandle.fate), `???? ${recipeHandle.fate}`);
       const fate = recipeHandle.originalFate && recipeHandle.originalFate !== '?'
           ? recipeHandle.originalFate : recipeHandle.fate;
-      if (fate === 'use') {
-        throw new Error(`store '${recipeHandle.id}' with "use" fate was not found in recipe`);
-      }
+      const newStore = this.storeInfoById[recipeHandle.id];
+      assert(newStore);
 
-      if (['copy', 'create'].includes(fate)) {
-        let type = recipeHandle.type;
-        if (recipeHandle.fate === 'create') {
-          assert(type.maybeResolve(), `Can't assign resolved type to ${type}`);
-        }
-
-        type = type.resolvedType();
-        assert(type.isResolved(), `Can't create handle for unresolved type ${type}`);
-
-        assert(recipeHandle.id);
-        const storageKey = recipeHandle.immediateValue
-          ? new VolatileStorageKey(this.id, '').childKeyForHandle(recipeHandle.id)
-          : recipeHandle.storageKey;
-        assert(storageKey, `Missing storage for recipe handle ${recipeHandle.id}`);
-
-        // TODO(shanestephens): Remove this once singleton types are expressed directly in recipes.
-        if (type instanceof EntityType || type instanceof ReferenceType || type instanceof InterfaceType) {
-          type = new SingletonType(type);
-        }
-        const newStore = await this.createStoreInternal(type, recipeHandle.id, storageKey, /* name= */ null);
-        await this._registerStore(newStore, recipeHandle.tags);
-
-        if (recipeHandle.immediateValue) {
-          const particleSpec = recipeHandle.immediateValue;
-          const type = recipeHandle.type;
-          if (newStore.isSingletonInterfaceStore()) {
-            assert(type instanceof InterfaceType && type.interfaceInfo.particleMatches(particleSpec));
-            const handle: SingletonInterfaceHandle = await handleForStoreInfo(newStore, this, {ttl: recipeHandle.getTtl()}) as SingletonInterfaceHandle;
-            await handle.set(particleSpec.clone());
-          } else {
-            throw new Error(`Can't currently store immediate values in non-singleton stores`);
-          }
-        } else if (fate === 'copy') {
-          const copiedStoreRef = this.context.findStoreById(recipeHandle.originalId);
-          const copiedActiveStore = await this.getActiveStore(copiedStoreRef);
-          assert(copiedActiveStore, `Cannot find store ${recipeHandle.originalId}`);
-          const activeStore = await this.getActiveStore(newStore);
-          await activeStore.cloneFrom(copiedActiveStore);
-          this._tagStore(newStore, this.context.findStoreTags(copiedStoreRef));
-          newStore.name = copiedStoreRef.name && `Copy of ${copiedStoreRef.name}`;
-          const copiedStoreDesc = this.getStoreDescription(copiedStoreRef);
-          if (copiedStoreDesc) {
-            this.storeDescriptions.set(newStore, copiedStoreDesc);
-          }
-        }
-      }
-
-      // TODO(shans/sjmiles): This shouldn't be possible, but at the moment the
-      // shell pre-populates all arcs with a set of handles so if a recipe explicitly
-      // asks for one of these there's a conflict. Ideally these will end up as a
-      // part of the context and will be populated on-demand like everything else.
-      if (this.storeInfoById[recipeHandle.id]) {
+      if (!['copy', 'map', 'create'].includes(fate)) {
         continue;
       }
-      if (recipeHandle.fate !== '`slot') {
-        let storageKey = recipeHandle.storageKey;
-        if (!storageKey) {
-          storageKey = this.keyForId(recipeHandle.id);
+
+      if (fate === 'map') {
+        await this.createActiveStore(newStore);
+      } else {
+        await this.createStoreInternal(newStore);
+      }
+
+      if (recipeHandle.immediateValue) {
+        const particleSpec = recipeHandle.immediateValue;
+        const type = recipeHandle.type;
+        if (newStore.isSingletonInterfaceStore()) {
+          assert(type instanceof InterfaceType && type.interfaceInfo.particleMatches(particleSpec));
+          const handle: SingletonInterfaceHandle = await handleForStoreInfo(newStore, this, {ttl: recipeHandle.getTtl()}) as SingletonInterfaceHandle;
+          await handle.set(particleSpec.clone());
+        } else {
+          throw new Error(`Can't currently store immediate values in non-singleton stores`);
         }
-        assert(storageKey, `couldn't find storage key for handle '${recipeHandle}'`);
-        let type = recipeHandle.type.resolvedType();
-        assert(type.isResolved());
-        if (!type.isSingleton && !type.isCollectionType()) {
-          type = new SingletonType(type);
+      } else if (fate === 'copy') {
+        const copiedStoreRef = this.context.findStoreById(recipeHandle.originalId);
+        const copiedActiveStore = await this.getActiveStore(copiedStoreRef);
+        assert(copiedActiveStore, `Cannot find store ${recipeHandle.originalId}`);
+        const activeStore = await this.getActiveStore(newStore);
+        await activeStore.cloneFrom(copiedActiveStore);
+        const copiedStoreDesc = this.getStoreDescription(copiedStoreRef);
+        if (copiedStoreDesc) {
+          this.storeDescriptions.set(newStore, copiedStoreDesc);
         }
-        const store = new StoreInfo({storageKey, exists: Exists.ShouldExist, type, id: recipeHandle.id});
-        await this._registerStore(store, recipeHandle.tags);
       }
     }
-
     return {handles, particles, slots};
   }
 
@@ -521,81 +460,33 @@ export class Arc implements ArcInterface {
     }
   }
 
-  async addStoreInfo(storeInfo: StoreInfo<Type>, tags?: string[]): Promise<void> {
-    await this._registerStore(storeInfo, tags);
-    this.addStoreToRecipe(storeInfo);
-  }
-
-  private addStoreToRecipe(storeInfo: StoreInfo<Type>) {
-    const handle = this.activeRecipe.newHandle();
-    handle.mapToStorage(storeInfo);
-    handle.fate = 'use';
-    // TODO(shans): is this the right thing to do? This seems not to be the right thing to do!
-    handle['_type'] = handle.mappedType;
-  }
-
   // TODO(shanestephens): Once we stop auto-wrapping in singleton types below, convert this to return a well-typed store.
   async createStore<T extends Type>(type: T, name?: string, id?: string, tags?: string[], storageKey?: StorageKey,
         capabilities?: Capabilities): Promise<StoreInfo<T>> {
-    if (id == undefined) {
-      id = this.generateID().toString();
-    }
+    const storeInfo = await this.arcInfo.createStoreInfo({type, name, id, storageKey, capabilities});
+    await this.arcInfo.registerStore(storeInfo, tags, /* registerReferenceMode= */ true);
+    this.arcInfo.addHandleToActiveRecipe(storeInfo);
 
-    storageKey = storageKey ||
-        // Consider passing `tags` to capabilities resolver.
-        await this.capabilitiesResolver.createStorageKey(capabilities || Capabilities.create(), type, id);
-    const storeInfo = await this.createStoreInternal(type, id, storageKey, name);
-    await this.addStoreInfo(storeInfo, tags);
+    await this.createStoreInternal(storeInfo);
     return storeInfo;
   }
 
-  private async createStoreInternal<T extends Type>(type: T, id: string, storageKey: StorageKey, name?: string): Promise<StoreInfo<T>> {
-    assert(type instanceof Type, `can't createStore with type ${type} that isn't a Type`);
-    if (type instanceof TupleType) {
-      throw new Error('Tuple type is not yet supported');
-    }
+  private async createStoreInternal<T extends Type>(storeInfo: StoreInfo<T>): Promise<void> {
+    await this.createActiveStore(storeInfo);
 
-    // Catch legacy cases that expected us to wrap entity types in a singleton.
-    if (type.isEntity || type.isInterface || type.isReference) {
-      throw new Error('unwrapped type provided to arc.createStore');
+    if (storeInfo.storageKey instanceof ReferenceModeStorageKey) {
+      const containerStoreInfo = this.arcInfo.findStoreInfoByStorageKey(storeInfo.storageKey.storageKey);
+      assert(containerStoreInfo);
+      await this.createStoreInternal(containerStoreInfo);
+      const backingStoreInfo = this.arcInfo.findStoreInfoByStorageKey(storeInfo.storageKey.backingKey);
+      assert(backingStoreInfo);
+      await this.createStoreInternal(backingStoreInfo);
     }
-    const existingStore = Object.values(this.storeInfoById).find(store => store.storageKey === storageKey);
-    if (existingStore) {
-      assert(existingStore.id === id, `Different store ids for same storage key? Is this an error?`);
-      return existingStore as StoreInfo<T>;
-    }
-
-    const store = new StoreInfo({storageKey, type, exists: Exists.MayExist, id, name});
-
-    if (storageKey instanceof ReferenceModeStorageKey) {
-      const refContainedType = new ReferenceType(type.getContainedType());
-      const refType = type.isSingleton ? new SingletonType(refContainedType) : new CollectionType(refContainedType);
-      await this.createStore(refType, name ? name + '_referenceContainer' : null, null, [], storageKey.storageKey);
-      await this.createStore(new CollectionType(type.getContainedType()), name ? name + '_backingStore' : null, null, [], storageKey.backingKey);
-    }
-    return store;
   }
 
-  async _registerStore(store: StoreInfo<Type>, tags?: string[]): Promise<void> {
-    assert(!this.storeInfoById[store.id], `Store already registered '${store.id}'`);
-    tags = tags || [];
-    tags = Array.isArray(tags) ? tags : [tags];
-
-    if (!(store.type.handleConstructor())) {
-      throw new Error(`Type not supported by storage: '${store.type.tag}'`);
-    }
-    this.storeInfoById[store.id] = store;
-    this.storeTagsById[store.id] = new Set(tags);
-
+  private async createActiveStore(store: StoreInfo<Type>): Promise<void> {
     const activeStore = await this.getActiveStore(store);
     activeStore.on(async () => this._onDataChange());
-
-    this.context.registerStore(store, tags);
-  }
-
-  _tagStore(store: StoreInfo<Type>, tags: Set<string> = new Set()): void {
-    assert(this.storeInfoById[store.id] && this.storeTagsById[store.id], `Store not registered '${store.id}'`);
-    tags.forEach(tag => this.storeTagsById[store.id].add(tag));
   }
 
   _onDataChange(): void {
@@ -679,7 +570,7 @@ export class Arc implements ArcInterface {
   }
 
   findStoreTags(storeInfo: StoreInfo<Type>): Set<string> {
-    return this.storeTagsById[storeInfo.id] || this._context.findStoreTags(storeInfo);
+    return this.storeTagsById[storeInfo.id] || this.context.findStoreTags(storeInfo);
   }
 
   getStoreDescription(storeInfo: StoreInfo<Type>): string {
@@ -695,7 +586,7 @@ export class Arc implements ArcInterface {
       }
     }
     if (includeContext) {
-      this._context.allStores.forEach(handle => versionById[handle.id] = handle.versionToken);
+      this.context.allStores.forEach(handle => versionById[handle.id] = handle.versionToken);
     }
     return versionById;
   }
@@ -714,8 +605,8 @@ export class Arc implements ArcInterface {
     // TODO: include stores entities
     // TODO: include (remote) slots?
 
-    if (!this._activeRecipe.isEmpty()) {
-      results.push(this._activeRecipe.toString());
+    if (!this.activeRecipe.isEmpty()) {
+      results.push(this.activeRecipe.toString());
     }
 
     return results.join('\n');

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -301,7 +301,7 @@ class PECOuterPortImpl extends PECOuterPort {
               // TODO: pass tags through too, and reconcile with similar logic
               // in Arc.deserialize.
               for (const store of manifest.stores) {
-                await this.arc._registerStore(store, []);
+                await this.arc.arcInfo.registerStore(store, []);
               }
               // TODO: Awaiting this promise causes tests to fail...
               const instantiateAndCaptureError = async () => {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -34,7 +34,6 @@ import {StorageService} from './storage/storage-service.js';
 import {DirectStorageEndpointManager} from './storage/direct-storage-endpoint-manager.js';
 import {Dictionary} from '../utils/lib-utils.js';
 import {SingletonAllocator, Allocator} from './allocator.js';
-import {StorageKeyPrefixer, NewArcOptions} from './arc-info.js';
 import {ArcHostImpl, ArcHost} from './arc-host.js';
 
 const {warn} = logsFactory('Runtime', 'orange');

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -31,8 +31,8 @@ async function createTestArc(recipe: Recipe, manifest: Manifest) {
   const runtime = new Runtime({context: manifest, loader: new Loader()});
   const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
   // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
-  arc['_activeRecipe'] = recipe;
-  arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
+  arc.arcInfo['activeRecipe'] = recipe;
+  arc.arcInfo['recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
   return arc;
 }
 
@@ -621,8 +621,8 @@ recipe
     // Cannot use createTestArc here, because capabilities-resolver cannot be set to null,
     // and interface returns a null schema, and cannot generate hash.
     const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
-    arc['_activeRecipe'] = recipe;
-    arc['_recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
+    arc.arcInfo['activeRecipe'] = recipe;
+    arc.arcInfo['recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
 
     const hostedParticle = manifest.findParticleByName('NoDescription');
     const hostedType = manifest.findParticleByName('NoDescMuxer').handleConnections[0].type as InterfaceType;
@@ -800,8 +800,9 @@ recipe
     assert.isUndefined(description.getArcDescription());
 
     const recipeClone = recipe.clone();
-    arc['_activeRecipe'] = recipeClone;
-    arc['_recipeDeltas'] = [recipeClone];
+    arc.arcInfo['activeRecipe'] = recipeClone;
+    arc.arcInfo['recipeDeltas'].splice(0, arc.arcInfo['recipeDeltas'].length, recipeClone);
+
 
     // Particle (static) spec pattern.
     recipeClone.particles[0].spec.pattern = 'hello world';


### PR DESCRIPTION
Next steps:
- ArcInfo::instantiate to be called from Allocator (not Arc; requires proper handling for inner arcs)
- move createStore from Arc to ArcHost
- move handleForStoreInfo and handleForActiveStore to ArcHost (from storage.ts)
