### PR TITLE
Small refactor to make particle and test harness generator classes in Schema2Kotlin

### DIFF
--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -80,9 +80,61 @@ ${imports.join('\n')}
     return new KotlinEntityGenerator(node, this.opts);
   }
 
-  /** Returns the container type of the handle, e.g. Singleton or Collection. */
-  private handleContainerType(type: Type): string {
-    return type.isCollectionType() ? 'Collection' : 'Singleton';
+  async generateParticleClass(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]): Promise<string> {
+    const generator = new KotlinParticleGenerator(this, particle, nodeGenerators);
+    return generator.generateParticleClass()
+  }
+
+  async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string> {
+    const generator = new KotlinTestHarnessGenerator(this, particle, nodes);
+    return generator.generateTestHarness()
+  }
+}
+
+export class GeneratorBase {
+  constructor(readonly isWasm: boolean, readonly namespace: string) {}
+
+  /**
+   * Returns the handle interface type, e.g. WriteSingletonHandle,
+   * ReadWriteCollectionHandle. Includes generic arguments.
+   *
+   * @param particleScope whether the generated declaration will be used inside the particle or outside it.
+   *
+   * Visible for testing.
+   */
+  handleInterfaceType(connection: HandleConnectionSpec, nodes: SchemaNode[], particleScope: boolean) {
+    if (connection.direction !== 'reads' && connection.direction !== 'writes' && connection.direction !== 'reads writes') {
+      throw new Error(`Unsupported handle direction: ${connection.direction}`);
+    }
+
+    const containerType = this.handleContainerType(connection.type);
+    if (this.isWasm) {
+      const topLevelNodes = SchemaNode.topLevelNodes(connection, nodes);
+      if (topLevelNodes.length !== 1) throw new Error('Wasm does not support handles of tuples');
+      const entityType = topLevelNodes[0].humanName(connection);
+      return `Wasm${containerType}Impl<${entityType}>`;
+    }
+
+    const handleMode = this.handleMode(connection);
+    const innerType = this.handleInnerType(connection, nodes, particleScope);
+    const typeArguments: string[] = [innerType];
+    const queryType = this.getQueryType(connection);
+    if (queryType) {
+      typeArguments.push(queryType);
+    }
+    return `arcs.sdk.${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
+  }
+
+  protected async handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
+    const mode = this.handleMode(connection);
+    const type = await generateConnectionSpecType(connection, nodes, {namespace: this.namespace});
+    // Using full names of entities, as these are aliases available outside the particle scope.
+    const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.fullName(connection));
+    return ktUtils.applyFun(
+        'arcs.core.entity.HandleSpec',
+        [`"${handleName}"`, `arcs.core.data.HandleMode.${mode}`, type, ktUtils.setOf(entityNames)],
+        {numberOfIndents: 1}
+    );
   }
 
   /**
@@ -117,7 +169,16 @@ ${imports.join('\n')}
     return generateInnerType(type);
   }
 
-  /** Returns one of Read, Write, ReadWrite. */
+  private handleContainerType(type: Type): string {
+    return type.isCollectionType() ? 'Collection' : 'Singleton';
+  }
+
+  private handleMode(connection: HandleConnectionSpec): string {
+    const direction = this.handleDirection(connection.direction);
+    const querySuffix = this.getQueryType(connection) ? 'Query' : '';
+    return `${direction}${querySuffix}`;
+  }
+
   private handleDirection(direction: Direction): string {
     switch (direction) {
       case 'reads writes':
@@ -129,145 +190,6 @@ ${imports.join('\n')}
       default:
         throw new Error(`Unsupported handle direction: ${direction}`);
     }
-  }
-
-  private handleMode(connection: HandleConnectionSpec): string {
-    const direction = this.handleDirection(connection.direction);
-    const querySuffix = this.getQueryType(connection) ? 'Query' : '';
-    return `${direction}${querySuffix}`;
-  }
-
-  /**
-   * Returns the handle interface type, e.g. WriteSingletonHandle,
-   * ReadWriteCollectionHandle. Includes generic arguments.
-   *
-   * @param particleScope whether the generated declaration will be used inside the particle or outside it.
-   */
-  handleInterfaceType(connection: HandleConnectionSpec, nodes: SchemaNode[], particleScope: boolean) {
-    if (connection.direction !== 'reads' && connection.direction !== 'writes' && connection.direction !== 'reads writes') {
-      throw new Error(`Unsupported handle direction: ${connection.direction}`);
-    }
-
-    const containerType = this.handleContainerType(connection.type);
-    if (this.opts.wasm) {
-      const topLevelNodes = SchemaNode.topLevelNodes(connection, nodes);
-      if (topLevelNodes.length !== 1) throw new Error('Wasm does not support handles of tuples');
-      const entityType = topLevelNodes[0].humanName(connection);
-      return `Wasm${containerType}Impl<${entityType}>`;
-    }
-
-    const handleMode = this.handleMode(connection);
-    const innerType = this.handleInnerType(connection, nodes, particleScope);
-    const typeArguments: string[] = [innerType];
-    const queryType = this.getQueryType(connection);
-    if (queryType) {
-      typeArguments.push(queryType);
-    }
-    return `arcs.sdk.${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
-  }
-
-  private async handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
-    const mode = this.handleMode(connection);
-    const type = await generateConnectionSpecType(connection, nodes, {namespace: this.namespace});
-    // Using full names of entities, as these are aliases available outside the particle scope.
-    const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.fullName(connection));
-    return ktUtils.applyFun(
-        'arcs.core.entity.HandleSpec',
-        [`"${handleName}"`, `arcs.core.data.HandleMode.${mode}`, type, ktUtils.setOf(entityNames)],
-        {numberOfIndents: 1}
-    );
-  }
-
-  async generateParticleClass(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]): Promise<string> {
-    const {typeAliases, classes, handleClassDecl} = await this.generateParticleClassComponents(particle, nodeGenerators);
-    return `
-${typeAliases.join(`\n`)}
-
-@Generated("src/tools/schema2kotlin.ts")
-abstract class Abstract${particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' : 'arcs.sdk.BaseParticle'}() {
-    ${this.opts.wasm ? '' : 'override '}val handles: Handles = Handles(${this.opts.wasm ? 'this' : ''})
-
-    ${ktUtils.indentFollowing(classes, 1)}
-
-    ${handleClassDecl}
-}
-`;
-  }
-
-  async generateParticleClassComponents(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]) {
-    const particleName = particle.name;
-    const handleDecls: string[] = [];
-    const specDecls: string[] = [];
-    const classes: string[] = [];
-    const typeAliases: string[] = [];
-
-    for (const nodeGenerator of nodeGenerators) {
-      const kotlinGenerator = <KotlinEntityGenerator>nodeGenerator.generator;
-      classes.push(await kotlinGenerator.generateClasses());
-      typeAliases.push(...kotlinGenerator.generateAliases(particleName));
-    }
-
-    const nodes = nodeGenerators.map(ng => ng.node);
-    for (const connection of particle.connections) {
-      const handleName = connection.name;
-      const handleInterfaceType = this.handleInterfaceType(connection, nodes, /* particleScope= */ true);
-      const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.humanName(connection));
-      if (this.opts.wasm) {
-        if (entityNames.length !== 1) throw new Error('Wasm does not support handles of tuples');
-        handleDecls.push(`val ${handleName}: ${handleInterfaceType} = ${handleInterfaceType}(particle, "${handleName}", ${entityNames[0]})`);
-      } else {
-        specDecls.push(`"${handleName}" to ${ktUtils.setOf(entityNames)}`);
-        handleDecls.push(`val ${handleName}: ${handleInterfaceType} by handles`);
-      }
-    }
-
-    const handleClassDecl = this.getHandlesClassDecl(particleName, specDecls, handleDecls);
-
-    return {typeAliases, classes, handleClassDecl};
-  }
-
-  private getHandlesClassDecl(particleName: string, entitySpecs: string[], handleDecls: string[]): string {
-    const header = this.opts.wasm
-      ? `${handleDecls.length ? '' : '@Suppress("UNUSED_PARAMETER")\n    '}class Handles(
-        particle: WasmParticleImpl
-    )`
-      : `class Handles : arcs.sdk.HandleHolderBase(
-        "${particleName}",
-        mapOf(${ktUtils.joinWithIndents(entitySpecs, {startIndent: 4, numberOfIndents: 3})})
-    )`;
-
-    return `${header} {
-        ${ktUtils.indentFollowing(handleDecls, 2)}
-    }`;
-  }
-
-  async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string> {
-    const particleName = particle.name;
-    const handleDecls: string[] = [];
-    const handleSpecs: string[] = [];
-
-    for (const connection of particle.connections) {
-      const handleName = connection.name;
-
-      // Particle handles are set up with the read/write mode from the manifest.
-      handleSpecs.push(await this.handleSpec(handleName, connection, nodes));
-
-      // The harness has a "copy" of each handle with full read/write access.
-      connection.direction = 'reads writes';
-      const interfaceType = this.handleInterfaceType(connection, nodes, /* particleScope= */ false);
-      handleDecls.push(`val ${handleName}: ${interfaceType} by handleMap`);
-    }
-
-    return `
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-class ${particleName}TestHarness<P : Particle>(
-    factory : (CoroutineScope) -> P
-) : BaseTestHarness<P>(factory, listOf(
-    ${handleSpecs.join(',\n    ')}
-)) {
-    ${handleDecls.join('\n    ')}
-}
-`;
   }
 
   private getQueryType(connection: HandleConnectionSpec): string {
@@ -287,5 +209,104 @@ class ${particleName}TestHarness<P : Particle>(
       return null;
     }
     return getPrimitiveTypeInfo(type).type;
+  }
+}
+
+export class KotlinParticleGenerator extends GeneratorBase {
+  constructor(parent: Schema2Kotlin, readonly particle: ParticleSpec, readonly nodeGenerators: NodeAndGenerator[]) {
+    super(parent.opts.wasm, parent.namespace);
+  }
+
+  async generateParticleClass(): Promise<string> {
+    const {typeAliases, classes, handleClassDecl} = await this.generateParticleClassComponents();
+    return `
+${typeAliases.join(`\n`)}
+
+@Generated("src/tools/schema2kotlin.ts")
+abstract class Abstract${this.particle.name} : ${this.isWasm ? 'WasmParticleImpl' : 'arcs.sdk.BaseParticle'}() {
+    ${this.isWasm ? '' : 'override '}val handles: Handles = Handles(${this.isWasm ? 'this' : ''})
+
+    ${ktUtils.indentFollowing(classes, 1)}
+
+    ${handleClassDecl}
+}
+`;
+  }
+
+  async generateParticleClassComponents() {
+    const handleDecls: string[] = [];
+    const specDecls: string[] = [];
+    const classes: string[] = [];
+    const typeAliases: string[] = [];
+
+    for (const nodeGenerator of this.nodeGenerators) {
+      const kotlinGenerator = <KotlinEntityGenerator>nodeGenerator.generator;
+      classes.push(await kotlinGenerator.generateClasses());
+      typeAliases.push(...kotlinGenerator.generateAliases(this.particle.name));
+    }
+
+    const nodes = this.nodeGenerators.map(ng => ng.node);
+    for (const connection of this.particle.connections) {
+      const handleName = connection.name;
+      const handleInterfaceType = this.handleInterfaceType(connection, nodes, /* particleScope= */ true);
+      const entityNames = SchemaNode.topLevelNodes(connection, nodes).map(node => node.humanName(connection));
+      if (this.isWasm) {
+        if (entityNames.length !== 1) throw new Error('Wasm does not support handles of tuples');
+        handleDecls.push(`val ${handleName}: ${handleInterfaceType} = ${handleInterfaceType}(particle, "${handleName}", ${entityNames[0]})`);
+      } else {
+        specDecls.push(`"${handleName}" to ${ktUtils.setOf(entityNames)}`);
+        handleDecls.push(`val ${handleName}: ${handleInterfaceType} by handles`);
+      }
+    }
+
+    const header = this.isWasm
+      ? `${handleDecls.length ? '' : '@Suppress("UNUSED_PARAMETER")\n    '}class Handles(
+        particle: WasmParticleImpl
+    )`
+      : `class Handles : arcs.sdk.HandleHolderBase(
+        "${this.particle.name}",
+        mapOf(${ktUtils.joinWithIndents(specDecls, {startIndent: 4, numberOfIndents: 3})})
+    )`;
+
+    const handleClassDecl = `${header} {
+        ${ktUtils.indentFollowing(handleDecls, 2)}
+    }`;
+
+    return {typeAliases, classes, handleClassDecl};
+  }
+}
+
+class KotlinTestHarnessGenerator extends GeneratorBase {
+  constructor(parent: Schema2Kotlin, readonly particle: ParticleSpec, readonly nodes: SchemaNode[]) {
+    super(parent.opts.wasm, parent.namespace);
+  }
+
+  async generateTestHarness(): Promise<string> {
+    const particleName = this.particle.name;
+    const handleDecls: string[] = [];
+    const handleSpecs: string[] = [];
+
+    for (const connection of this.particle.connections) {
+      const handleName = connection.name;
+
+      // Particle handles are set up with the read/write mode from the manifest.
+      handleSpecs.push(await this.handleSpec(handleName, connection, this.nodes));
+
+      // The harness has a "copy" of each handle with full read/write access.
+      connection.direction = 'reads writes';
+      const interfaceType = this.handleInterfaceType(connection, this.nodes, /* particleScope= */ false);
+      handleDecls.push(`val ${handleName}: ${interfaceType} by handleMap`);
+    }
+
+    return `
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class ${particleName}TestHarness<P : Particle>(
+    factory : (CoroutineScope) -> P
+) : BaseTestHarness<P>(factory, listOf(
+    ${handleSpecs.join(',\n    ')}
+)) {
+    ${handleDecls.join('\n    ')}
+}
+`;
   }
 }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -143,7 +143,7 @@ export class GeneratorBase {
    *
    * @param particleScope whether the generated declaration will be used inside the particle or outside it.
    */
-  private handleInnerType(connection: HandleConnectionSpec, nodes: SchemaNode[], particleScope: boolean): string {
+  protected handleInnerType(connection: HandleConnectionSpec, nodes: SchemaNode[], particleScope: boolean): string {
     let type = connection.type;
     if (type.isCollection || type.isSingleton) {
       // The top level collection / singleton distinction is handled by the flavour of a handle.
@@ -169,17 +169,17 @@ export class GeneratorBase {
     return generateInnerType(type);
   }
 
-  private handleContainerType(type: Type): string {
+  protected handleContainerType(type: Type): string {
     return type.isCollectionType() ? 'Collection' : 'Singleton';
   }
 
-  private handleMode(connection: HandleConnectionSpec): string {
+  protected handleMode(connection: HandleConnectionSpec): string {
     const direction = this.handleDirection(connection.direction);
     const querySuffix = this.getQueryType(connection) ? 'Query' : '';
     return `${direction}${querySuffix}`;
   }
 
-  private handleDirection(direction: Direction): string {
+  protected handleDirection(direction: Direction): string {
     switch (direction) {
       case 'reads writes':
         return 'ReadWrite';
@@ -192,7 +192,7 @@ export class GeneratorBase {
     }
   }
 
-  private getQueryType(connection: HandleConnectionSpec): string {
+  protected getQueryType(connection: HandleConnectionSpec): string {
     if (!(connection.type instanceof CollectionType)) {
       return null;
     }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -82,12 +82,12 @@ ${imports.join('\n')}
 
   async generateParticleClass(particle: ParticleSpec, nodeGenerators: NodeAndGenerator[]): Promise<string> {
     const generator = new KotlinParticleGenerator(this, particle, nodeGenerators);
-    return generator.generateParticleClass()
+    return generator.generateParticleClass();
   }
 
   async generateTestHarness(particle: ParticleSpec, nodes: SchemaNode[]): Promise<string> {
     const generator = new KotlinTestHarnessGenerator(this, particle, nodes);
-    return generator.generateTestHarness()
+    return generator.generateTestHarness();
   }
 }
 

--- a/src/tools/tests/schema2kotlin-codegen-test-suite.ts
+++ b/src/tools/tests/schema2kotlin-codegen-test-suite.ts
@@ -14,7 +14,7 @@ import {ManifestCodegenUnitTest} from './codegen-unit-test-base.js';
 import {KTExtracter} from '../kotlin-refinement-generator.js';
 import {CodegenUnitTest} from './codegen-unit-test-base.js';
 import {KotlinEntityGenerator} from '../kotlin-entity-generator.js';
-import {Schema2Kotlin} from '../schema2kotlin.js';
+import {Schema2Kotlin, GeneratorBase, KotlinParticleGenerator} from '../schema2kotlin.js';
 import {generateConnectionSpecType, generateType} from '../kotlin-type-generator.js';
 import {generateFields} from '../kotlin-schema-field.js';
 
@@ -113,8 +113,8 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
     }
     async computeFromManifest({particles}) {
       const graph = new SchemaGraph(particles[0]);
-      const schema2kotlin = new Schema2Kotlin({_: []});
-      return particles[0].connections.map(c => schema2kotlin.handleInterfaceType(c, graph.nodes, true));
+      const generatorBase = new GeneratorBase(false, '');
+      return particles[0].connections.map(c => generatorBase.handleInterfaceType(c, graph.nodes, true));
     }
   }(),
   new class extends ManifestCodegenUnitTest {
@@ -126,8 +126,9 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
     }
     async computeFromManifest({particles}) {
       const schema2kotlin = new Schema2Kotlin({_: []});
-      const generators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
-      const components = await schema2kotlin.generateParticleClassComponents(particles[0], generators);
+      const nodeGenerators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
+      const particleGenerator = new KotlinParticleGenerator(schema2kotlin, particles[0], nodeGenerators);
+      const components = await particleGenerator.generateParticleClassComponents();
       return components.handleClassDecl;
     }
   }(),
@@ -140,8 +141,9 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
     }
     async computeFromManifest({particles}) {
       const schema2kotlin = new Schema2Kotlin({_: []});
-      const generators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
-      const components = await schema2kotlin.generateParticleClassComponents(particles[0], generators);
+      const nodeGenerators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
+      const particleGenerator = new KotlinParticleGenerator(schema2kotlin, particles[0], nodeGenerators);
+      const components = await particleGenerator.generateParticleClassComponents();
       return components.typeAliases.sort();
     }
   }(),


### PR DESCRIPTION
No logical changes are introduced and the generated output is unaffected.

This is to help with future changes to the class generation (e.g. it's easier to add a flag that will modify output in multiple different places).