### PR TITLE
Add support for type union and type intersection for nullable types

### DIFF
--- a/src/types/internal/type.ts
+++ b/src/types/internal/type.ts
@@ -2226,11 +2226,7 @@ export class Schema {
         return new NullableField(unionSchema);
       }
       default:
-        if (Schema.typesEqual(field1, field2)) {
-          return field1;
-        } else {
-          return null;
-        }
+        return Schema.typesEqual(field1, field2) ? field1 : null;
     }
   }
 

--- a/src/types/internal/type.ts
+++ b/src/types/internal/type.ts
@@ -2170,7 +2170,15 @@ export class Schema {
     // Ensure that changes to the field types are non-side-effecting
     const field1 = infield1 && infield1.clone();
     const field2 = infield2 && infield2.clone();
-    if (field1.kind !== field2.kind) return null;
+    if (field1.kind !== field2.kind) {
+      if (field1.kind === 'schema-nullable') {
+        return Schema.fieldTypeUnion(field1.getFieldType(), field2);
+      }
+      if (field2.kind === 'schema-nullable') {
+        return Schema.fieldTypeUnion(field1, field2.getFieldType());
+      }
+      return null;
+    }
     switch (field1.kind) {
       case 'schema-collection': {
         const unionSchema = Schema.fieldTypeUnion(field1.getFieldType(), field2.getFieldType());
@@ -2210,8 +2218,19 @@ export class Schema {
         }
         return new OrderedListField(unionSchema);
       }
+      case 'schema-nullable': {
+        const unionSchema = Schema.fieldTypeUnion(field1.getFieldType(), field2.getFieldType());
+        if (!unionSchema) {
+          return null;
+        }
+        return new NullableField(unionSchema);
+      }
       default:
-        return Schema.typesEqual(field1, field2) ? field1 : null;
+        if (Schema.typesEqual(field1, field2)) {
+          return field1;
+        } else {
+          return null;
+        }
     }
   }
 
@@ -2247,6 +2266,14 @@ export class Schema {
       // TODO(b/174115805, b/144507619, b/144507352): Handle nullables
       // (with make it possible to store 'true' unions)
       return null;
+    }
+    if (field1.kind !== field2.kind) {
+      if (field1.kind === 'schema-nullable') {
+        return new NullableField(Schema.fieldTypeUnion(field1.getFieldType(), field2));
+      }
+      if (field2.kind === 'schema-nullable') {
+        return new NullableField(Schema.fieldTypeUnion(field1, field2.getFieldType()));
+      }
     }
     // TODO: non-eq Kinds?
     if (field1.kind !== field2.kind) return null;
@@ -2288,6 +2315,13 @@ export class Schema {
           return null;
         }
         return new OrderedListField(intersectSchema);
+      }
+      case 'schema-nullable': {
+        const intersectSchema = Schema.fieldTypeIntersection(field1.getFieldType(), field2.getFieldType());
+        if (!intersectSchema) {
+          return null;
+        }
+        return new NullableField(intersectSchema);
       }
       default:
         return Schema.typesEqual(field1, field2) ? field1 : null;

--- a/src/types/tests/schema-test.ts
+++ b/src/types/tests/schema-test.ts
@@ -631,7 +631,7 @@ describe('schema', () => {
     assert.deepEqual(intersection.refinement, schema3.refinement);
   }));
 
-  const verifyUnionOfTypes = async (type1: String, type2: String) => {
+  const verifyUnionOfTypes = async (type1: string, type2: string) => {
     const manifest = await Manifest.parse(`
             schema A
               foo: ${type1}
@@ -668,7 +668,7 @@ describe('schema', () => {
   const verifyUnionOf = async (typeBuilder: (type: string) => string) => {
     verifyUnionOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
   };
-  const verifyIntersectOfTypes = async (type1: String, type2: String) => {
+  const verifyIntersectOfTypes = async (type1: string, type2: string) => {
     const manifest = await Manifest.parse(`
             schema A
               foo: ${type1}

--- a/src/types/tests/schema-test.ts
+++ b/src/types/tests/schema-test.ts
@@ -652,12 +652,16 @@ describe('schema', () => {
     const unionT = aType.toLiteral();
     unionT.names = ['A', 'B'];
 
-    assert.deepEqual(Schema.union(aType, bType).toLiteral(), unionT);
+    const unionAB = Schema.union(aType, bType);
+    assert.isNotNull(unionAB, 'union of A and B should exist');
+    assert.deepEqual(unionAB.toLiteral(), unionT);
     assert.deepEqual(aType.toLiteral(), aTypeLit, 'input (a) to intersection should not be modified');
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
 
     unionT.names = ['B', 'A'];
-    assert.deepEqual(Schema.union(bType, aType).toLiteral(), unionT);
+    const unionBA = Schema.union(bType, aType);
+    assert.isNotNull(unionBA, 'union of B and A should exist');
+    assert.deepEqual(unionBA.toLiteral(), unionT);
     assert.deepEqual(aType.toLiteral(), aTypeLit, 'input (a) to intersection should not be modified');
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
   };
@@ -685,11 +689,15 @@ describe('schema', () => {
     const intersectT = bType.toLiteral();
     intersectT.names = [];
 
-    assert.deepEqual(Schema.intersect(aType, bType).toLiteral(), intersectT);
+    const intersectionAB = Schema.intersect(aType, bType);
+    assert.isNotNull(intersectionAB, 'intersection of A and B should exist');
+    assert.deepEqual(intersectionAB.toLiteral(), intersectT);
     assert.deepEqual(aType.toLiteral(), aTypeLit, 'input (a) to intersection should not be modified');
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
 
-    assert.deepEqual(Schema.intersect(bType, aType).toLiteral(), intersectT);
+    const intersectionBA = Schema.intersect(bType, aType);
+    assert.isNotNull(intersectionBA, 'intersection of B and A should exist');
+    assert.deepEqual(intersectionBA.toLiteral(), intersectT);
     assert.deepEqual(aType.toLiteral(), aTypeLit, 'input (a) to intersection should not be modified');
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
   };

--- a/src/types/tests/schema-test.ts
+++ b/src/types/tests/schema-test.ts
@@ -631,13 +631,13 @@ describe('schema', () => {
     assert.deepEqual(intersection.refinement, schema3.refinement);
   }));
 
-  const verifyUnionOf = async (typeBuilder: (type: string) => string) => {
+  const verifyUnionOfTypes = async (type1: String, type2: String) => {
     const manifest = await Manifest.parse(`
             schema A
-              foo: ${typeBuilder(`Foo {a: Text, b: Text}`)}
+              foo: ${type1}
 
             schema B
-              foo: ${typeBuilder(`Foo {a: Text}`)}
+              foo: ${type2}
             `);
     const aType = manifest.findSchemaByName('A');
     const bType = manifest.findSchemaByName('B');
@@ -661,13 +661,16 @@ describe('schema', () => {
     assert.deepEqual(aType.toLiteral(), aTypeLit, 'input (a) to intersection should not be modified');
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
   };
-  const verifyIntersectOf = async (typeBuilder: (type: string) => string) => {
+  const verifyUnionOf = async (typeBuilder: (type: string) => string) => {
+    verifyUnionOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
+  };
+  const verifyIntersectOfTypes = async (type1: String, type2: String) => {
     const manifest = await Manifest.parse(`
             schema A
-              foo: ${typeBuilder(`Foo {a: Text, b: Text}`)}
+              foo: ${type1}
 
             schema B
-              foo: ${typeBuilder(`Foo {a: Text}`)}
+              foo: ${type2}
             `);
     const aType = manifest.findSchemaByName('A');
     const bType = manifest.findSchemaByName('B');
@@ -690,6 +693,27 @@ describe('schema', () => {
     assert.deepEqual(aType.toLiteral(), aTypeLit, 'input (a) to intersection should not be modified');
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
   };
+  const verifyIntersectOf = async (typeBuilder: (type: string) => string) => {
+    verifyIntersectOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
+  };
+  it('tests schema union, with nullable and non-nullable ints', async () => {
+    await verifyUnionOfTypes(`Int`, `Int?`);
+  });
+  it('tests schema union, with nullable ints', async () => {
+    await verifyUnionOfTypes(`Int?`, `Int?`);
+  });
+  it('tests schema union, with nullable and non-nullable text', async () => {
+    await verifyUnionOfTypes(`Text`, `Text?`);
+  });
+  it('tests schema union, with nullable text', async () => {
+    await verifyUnionOfTypes(`Text?`, `Text?`);
+  });
+  it('tests schema union, with nullable inline entities', async () => {
+    await verifyUnionOfTypes(`inline Foo {a: Text, b: Text}?`, `inline Foo {a: Text}?`);
+  });
+  it('tests schema union, with nullable and non-nullable inline entities', async () => {
+    await verifyUnionOfTypes(`inline Foo {a: Text, b: Text}`, `inline Foo {a: Text}?`);
+  });
   it('tests schema union, with inline entities', async () => {
     await verifyUnionOf((type: string) => `inline ${type}`);
   });
@@ -713,6 +737,24 @@ describe('schema', () => {
   });
 
   it('tests schema intersection, with inline entities', async () => {
+  it('tests schema intersection, with nullable and non-nullable ints', async () => {
+    await verifyIntersectOfTypes(`Int`, `Int?`);
+  });
+  it('tests schema intersection, with nullable ints', async () => {
+    await verifyIntersectOfTypes(`Int?`, `Int?`);
+  });
+  it('tests schema intersection, with nullable and non-nullable text', async () => {
+    await verifyIntersectOfTypes(`Text`, `Text?`);
+  });
+  it('tests schema intersection, with nullable text', async () => {
+    await verifyIntersectOfTypes(`Text?`, `Text?`);
+  });
+  it('tests schema intersection, with nullable inline entities', async () => {
+    await verifyIntersectOfTypes(`inline Foo {a: Text, b: Text}?`, `inline Foo {a: Text}?`);
+  });
+  it('tests schema intersection, with nullable and non-nullable inline entities', async () => {
+    await verifyIntersectOfTypes(`inline Foo {a: Text, b: Text}`, `inline Foo {a: Text}?`);
+  });
     await verifyIntersectOf((type: string) => `inline ${type}`);
   });
   it('tests schema intersection, with referenced entities', async () => {

--- a/src/types/tests/schema-test.ts
+++ b/src/types/tests/schema-test.ts
@@ -666,7 +666,7 @@ describe('schema', () => {
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
   };
   const verifyUnionOf = async (typeBuilder: (type: string) => string) => {
-    verifyUnionOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
+    await verifyUnionOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
   };
   const verifyIntersectOfTypes = async (type1: string, type2: string) => {
     const manifest = await Manifest.parse(`
@@ -702,7 +702,7 @@ describe('schema', () => {
     assert.deepEqual(bType.toLiteral(), bTypeLit, 'input (b) to intersection should not be modified');
   };
   const verifyIntersectOf = async (typeBuilder: (type: string) => string) => {
-    verifyIntersectOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
+    await verifyIntersectOfTypes(`${typeBuilder(`Foo {a: Text, b: Text}`)}`, `${typeBuilder(`Foo {a: Text}`)}`);
   };
   it('tests schema union, with nullable and non-nullable ints', async () => {
     await verifyUnionOfTypes(`Int`, `Int?`);


### PR DESCRIPTION
This PR adds support for computing unions and intersections of nullable Schema types.

This is needed for resolving particles that make use nullable types, particularly of handles containing nullable inline schemas. 

#nullability