### PR TITLE
TS refactor: use ArcInfo where possible, refactor stores / handles management

### DIFF
--- a/shells/dev-shell/index.js
+++ b/shells/dev-shell/index.js
@@ -123,22 +123,23 @@ async function wrappedExecute() {
 async function createRecipeArc(recipe, runtime, index) {
   const arcId = IdGenerator.newSession().newArcId(`arc${index}`);
   // establish a UI Surface
-  const arcPanel = outputPane.addArcPanel(arcId);
+  const arcPanel = outputPane.addArcPanel(arcId, runtime);
   // attach arc to bespoke shell ui
   const slotObserver = new SlotObserver(arcPanel.shadowRoot);
   // construct the arc
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcId, slotObserver, ...extraArcParams}));
+  const arcInfo = await runtime.allocator.startArc({arcId, slotObserver, ...extraArcParams});
+  const arc = runtime.getArcById(arcInfo.id);
   arcPanel.attachArc(arc);
   arc.arcPanel = arcPanel;
   try {
     const plan = await runtime.resolveRecipe(arc, recipe);
-    await runtime.allocator.runPlanInArc(arc.id, plan);
+    await runtime.allocator.runPlanInArc(arcInfo, plan);
   } catch (x) {
     arcPanel.showError('recipe error', x);
     return;
   }
   // display description
-  await arcPanel.arcInstantiated(await runtime.getArcDescription(arc));
+  await arcPanel.arcInstantiated(await runtime.getArcDescription(arcInfo.id));
 }
 
 function showHelp() {

--- a/shells/dev-shell/output-pane.js
+++ b/shells/dev-shell/output-pane.js
@@ -38,10 +38,10 @@ export class OutputPane extends HTMLElement {
     this.error.clear();
   }
 
-  addArcPanel(arcId) {
+  addArcPanel(arcId, runtime) {
     const arcPanel = document.createElement('arc-panel');
     this.arcs.appendChild(arcPanel);
-    arcPanel.init(this, arcId);
+    arcPanel.init(this, arcId, runtime);
     return arcPanel;
   }
 
@@ -192,8 +192,9 @@ class ArcPanel extends HTMLElement {
     });
   }
 
-  init(host, arcId) {
+  init(host, arcId, runtime) {
     this.host = host;
+    this.runtime = runtime;
     this.arcLabel.textContent = arcId.idTree[0];
   }
 
@@ -211,7 +212,7 @@ class ArcPanel extends HTMLElement {
       for (const storeInfo of this.linkedArc.stores) {
         const storePanel = document.createElement('store-panel');
         this.stores.appendChild(storePanel);
-        await storePanel.attach(await this.linkedArc.getActiveStore(storeInfo), this.linkedArc);
+        await storePanel.attach(await this.linkedArc.getActiveStore(storeInfo), this.linkedArc, this.runtime);
       }
       this.storesCollapseAll.enabled = (this.linkedArc.stores.length > 1);
     }

--- a/shells/dev-shell/store-panel.js
+++ b/shells/dev-shell/store-panel.js
@@ -8,7 +8,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {handleForStoreInfo} from '../../build/runtime/storage/storage.js';
 import {CollectionHandle} from '../../build/runtime/storage/handle.js';
 import {Entity} from '../../build/runtime/entity.js';
 
@@ -128,9 +127,9 @@ export class StorePanel extends HTMLElement {
     this.contents.addEventListener('keypress', this.interceptCtrlEnter.bind(this));
   }
 
-  async attach(store, arc) {
+  async attach(store, arc, runtime) {
     this.store = store;
-    this.handle = await handleForStoreInfo(store, arc);
+    this.handle = await runtime.host.handleForStoreInfo(store, arc.arcInfo);
     this.storeLabel.textContent = store.storageKey;
     const schema = store.type.getEntitySchema();
     this.schema.textContent = schema ? schema.toManifestString() : '// Unknown schema';

--- a/shells/lib/components/arc-host.js
+++ b/shells/lib/components/arc-host.js
@@ -69,19 +69,19 @@ export class ArcHost {
     return serialization;
   }
   async _spawn(storage, id, serialization, inspectorFactory) {
-    return this.runtime.getArcById(serialization ?
-      await this.runtime.allocator.deserialize({
+    const arcInfo = serialization
+      ? await this.runtime.allocator.deserialize({
         serialization,
         slotObserver: this.composer['slotObserver'],
         inspectorFactory: devtoolsArcInspectorFactory,
-      }) :
-      await this.runtime.allocator.startArc({
+      })
+      : await this.runtime.allocator.startArc({
         arcName: id,
         storage: `${storage}/${id}`, // should be StorageKey instead
         slotObserver: this.composer['slotObserver'],
         inspectorFactory: devtoolsArcInspectorFactory
-      })
-    );
+    });
+    return this.runtime.getArcById(arcInfo.id);
   }
   async instantiateDefaultRecipe(arc, manifest) {
     log('instantiateDefaultRecipe');
@@ -98,7 +98,7 @@ export class ArcHost {
     // TODO(sjmiles): pass suggestion all the way from web-shell
     // and call suggestion.instantiate(arc).
     try {
-      await this.runtime.allocator.runPlanInArc(arc.id, plan);
+      await this.runtime.allocator.runPlanInArc(arc.arcInfo, plan);
     } catch (x) {
       error(x);
       //console.error(plan.toString());

--- a/shells/pipes-shell/source/verbs/run-arc.js
+++ b/shells/pipes-shell/source/verbs/run-arc.js
@@ -29,7 +29,7 @@ export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
     warn(`found no recipes matching [${recipe}]`);
     return null;
   }
-  const arc = runtime.getArcById(await runtime.allocator.startArc({
+  const arcInfo = await runtime.allocator.startArc({
     arcName: arcId,
     storageKeyPrefix: storageKeyPrefix || defaultStorageKeyPrefix,
     fileName: './serialized.manifest',
@@ -42,12 +42,13 @@ export const runArc = async (msg, bus, runtime, defaultStorageKeyPrefix) => {
       },
       dispose: () => null
     }
-  }));
+  });
+  const arc = runtime.getArcById(arcInfo.id);
   // optionally instantiate recipe
   if (action) {
     const plan = await runtime.resolveRecipe(arc, action);
-    await runtime.allocator.runPlanInArc(arc.id, plan);
-    log(`successfully instantiated ${plan} in ${arc.id}`);
+    await runtime.allocator.runPlanInArc(arcInfo, plan);
+    log(`successfully instantiated ${plan} in ${arcInfo.id}`);
   }
   return arc;
 };

--- a/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/hotreload-integration-test.ts
@@ -36,8 +36,8 @@ describe('Hot Code Reload for JS Particle', async () => {
       });`
     });
     const runtime = new Runtime({loader, context});
-    const arcId = await runtime.allocator.startArc({arcName: 'HotReload', planName: 'HotReloadRecipe'});
-    const arc = runtime.getArcById(arcId);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'HotReload', planName: 'HotReloadRecipe'});
+    const arc = runtime.getArcById(arcInfo.id);
 
     await arc.idle;
 

--- a/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
+++ b/shells/tests/arcs/ts/runtime/multiplexer-integration-test.ts
@@ -15,7 +15,7 @@ import {SlotTestObserver} from '../../../../../build/runtime/testing/slot-test-o
 import {Loader} from '../../../../../build/platform/loader.js';
 import {storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
 import {StrategyTestHelper} from '../../../../../build/planning/testing/strategy-test-helper.js';
-import {handleForStoreInfo, CollectionEntityType} from '../../../../../build/runtime/storage/storage.js';
+import {CollectionEntityType} from '../../../../../build/runtime/storage/storage.js';
 import {StoreInfo} from '../../../../../build/runtime/storage/store-info.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
@@ -48,9 +48,7 @@ describe('Multiplexer', () => {
       item: consumes s1`;
 
     const thePostsStore = context.stores.find(StoreInfo.isCollectionEntityStore);
-    const postsHandle = await handleForStoreInfo(thePostsStore, {
-      ...context, storageService: runtime.storageService
-    });
+    const postsHandle = await runtime.host.handleForStoreInfo(thePostsStore, await runtime.allocator.startArc({arcName: 'posts'}));
     await postsHandle.add(Entity.identify(
         new postsHandle.entityClass({
           message: 'x',
@@ -74,8 +72,8 @@ describe('Multiplexer', () => {
         '3', null));
     // version could be set here, but doesn't matter for tests.
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver}));
-
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+    const arc = runtime.getArcById(arcInfo.id);
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
 
@@ -86,7 +84,7 @@ describe('Multiplexer', () => {
       .expectRenderSlot('ShowOne', 'item', {times: 2})
       .expectRenderSlot('ShowTwo', 'item');
 
-    await runtime.allocator.runPlanInArc(arc.id, await suggestions[0].getResolvedPlan(arc));
+    await runtime.allocator.runPlanInArc(arcInfo, await suggestions[0].getResolvedPlan(arc));
     await arc.idle;
 
     // Add and render one more post
@@ -100,8 +98,8 @@ describe('Multiplexer', () => {
       .expectRenderSlot('ShowOne', 'item', {times: 2})
       .expectRenderSlot('ShowTwo', 'item');
 
-    const postsStore = arc.findStoreById(arc.activeRecipe.handles[0].id) as StoreInfo<CollectionEntityType>;
-    const postsHandle2 = await handleForStoreInfo(postsStore, arc);
+    const postsStore = arcInfo.findStoreById(arcInfo.activeRecipe.handles[0].id) as StoreInfo<CollectionEntityType>;
+    const postsHandle2 = await runtime.host.handleForStoreInfo(postsStore, arcInfo);
     const entityClass = new postsHandle.entityClass({
       message: 'w',
       renderRecipe: recipeOne,
@@ -158,11 +156,11 @@ describe('Multiplexer', () => {
     const runtime = new Runtime({loader});
     const context = await runtime.parseFile('./shells/tests/artifacts/polymorphic-muxing.recipes');
     //
-    const arc = runtime.getArcById(await runtime.allocator.startArc({
+    const arc = runtime.getArcById((await runtime.allocator.startArc({
       arcName: 'fooTest',
       planName: 'MultiFoo',
       storageKeyPrefix: storageKeyPrefixForTest()
-    }));
+    })).id);
     await arc.idle;
     //
     // NOTE: a direct translation of this to new storage is unlikely to work as

--- a/shells/tests/arcs/ts/runtime/particle-api-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-api-test.ts
@@ -61,13 +61,14 @@ describe('particle-api', () => {
       '*': `defineParticle(({UiParticle}) => class extends UiParticle {});`,
     });
     const runtime = new Runtime({loader, context});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', planName: 'ApiTestRecipe'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', planName: 'ApiTestRecipe'});
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
-    assert.lengthOf(arc.activeRecipe.particles, 1);
-    const [transformationParticle] = arc.activeRecipe.particles;
+    assert.lengthOf(arcInfo.activeRecipe.particles, 1);
+    const [transformationParticle] = arcInfo.activeRecipe.particles;
 
-    assert.lengthOf(arc.recipeDeltas, 1);
+    assert.lengthOf(arcInfo.recipeDeltas, 1);
     const [innerArc] = arc.findInnerArcs(transformationParticle);
 
     const sessionId = innerArc.idGenerator.currentSessionIdForTesting;

--- a/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/particle-interface-loading-with-slots-test.ts
@@ -9,15 +9,15 @@
  */
 
 import {assert} from '../../../../../build/platform/chai-web.js';
-import {Arc} from '../../../../../build/runtime/arc.js';
 import {Loader} from '../../../../../build/platform/loader.js';
 import {Manifest} from '../../../../../build/runtime/manifest.js';
 import {SlotTestObserver} from '../../../../../build/runtime/testing/slot-test-observer.js';
 import {Recipe} from '../../../../../build/runtime/recipe/lib-recipe.js';
 import {Entity} from '../../../../../build/runtime/entity.js';
-import {CollectionEntityHandle, handleForStoreInfo, CollectionEntityType} from '../../../../../build/runtime/storage/storage.js';
+import {CollectionEntityHandle, CollectionEntityType} from '../../../../../build/runtime/storage/storage.js';
 import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {StoreInfo} from '../../../../../build/runtime/storage/store-info.js';
+import {ArcInfo} from '../../../../../build/runtime/arc-info.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('particle interface loading with slots', () => {
@@ -27,8 +27,7 @@ describe('particle interface loading with slots', () => {
   });
 
   async function initializeManifestAndArc(contextContainer?):
-    Promise<{manifest: Manifest, recipe: Recipe, slotObserver: SlotTestObserver, arc: Arc}> {
-    //const loader = new Loader();
+    Promise<{manifest: Manifest, recipe: Recipe, slotObserver: SlotTestObserver, arc: ArcInfo}> {
     const manifestText = `
       import './shells/tests/artifacts/transformations/test-slots-particles.manifest'
       recipe
@@ -41,25 +40,27 @@ describe('particle interface loading with slots', () => {
     `;
     const manifest = await runtime.parse(manifestText);
 
-    //const manifest = await Manifest.parse(manifestText/*, {loader, fileName: ''}*/);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize(), `can't normalize recipe`);
     assert(recipe.isResolved(), `recipe isn't resolved`);
 
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', slotObserver}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', slotObserver});
 
     return {manifest, recipe, slotObserver, arc};
   }
 
   // tslint:disable-next-line: no-any
-  async function instantiateRecipeAndStore(arc: Arc, recipe: Recipe, manifest: Manifest): Promise<CollectionEntityHandle> {
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+  async function instantiateRecipeAndStore(arc: ArcInfo, recipe: Recipe, manifest: Manifest): Promise<CollectionEntityHandle> {
+    await runtime.allocator.runPlanInArc(arc, recipe);
     const inStore = arc.findStoresByType(manifest.findTypeByName('Foo').collectionOf())[0] as StoreInfo<CollectionEntityType>;
-    const inHandle = await handleForStoreInfo(inStore, arc);
+    const inHandle = await runtime.host.handleForStoreInfo(inStore, arc);
     await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo1'}), 'subid-1', null));
     await inHandle.add(Entity.identify(new inHandle.entityClass({value: 'foo2'}), 'subid-2', null));
     return inHandle;
+  }
+  async function idle(arc: ArcInfo): Promise<void> {
+    return runtime.getArcById(arc.id).idle;
   }
 
   it('multiplex recipe with slots - immediate', async () => {
@@ -71,7 +72,7 @@ describe('particle interface loading with slots', () => {
       .newExpectations()
       .expectRenderSlot('SingleSlotParticle', 'annotation', {times: 2});
     const inStore = await instantiateRecipeAndStore(arc, recipe, manifest);
-    await arc.idle;
+    await idle(arc);
     await slotObserver.expectationsCompleted();
 
     // Add one more element.
@@ -79,7 +80,7 @@ describe('particle interface loading with slots', () => {
     slotObserver
        .newExpectations()
        .expectRenderSlot('SingleSlotParticle', 'annotation');
-    await arc.idle;
+    await idle(arc);
     await slotObserver.expectationsCompleted();
   });
 
@@ -94,7 +95,7 @@ describe('particle interface loading with slots', () => {
     slotObserver
       .newExpectations()
       .expectRenderSlot('SingleSlotParticle', 'annotation', {times: 2});
-    await arc.idle;
+    await idle(arc);
     await slotObserver.expectationsCompleted();
 
     // Add one more element.
@@ -102,7 +103,7 @@ describe('particle interface loading with slots', () => {
        .newExpectations()
        .expectRenderSlot('SingleSlotParticle', 'annotation');
     await inStore.add(Entity.identify(new inStore.entityClass({value: 'foo3'}), 'subid-3', null));
-    await arc.idle;
+    await idle(arc);
     await slotObserver.expectationsCompleted();
   });
 });

--- a/shells/tests/arcs/ts/runtime/products-test.ts
+++ b/shells/tests/arcs/ts/runtime/products-test.ts
@@ -9,39 +9,43 @@
  */
 
 import {assert} from '../../../../../build/platform/chai-web.js';
-import {Arc} from '../../../../../build/runtime/arc.js';
+import {ArcInfo} from '../../../../../build/runtime/arc-info.js';
 import {Runtime} from '../../../../../build/runtime/runtime.js';
 import {SlotTestObserver} from '../../../../../build/runtime/testing/slot-test-observer.js';
 import {storageKeyPrefixForTest} from '../../../../../build/runtime/testing/handle-for-test.js';
-import {CollectionEntityHandle, CollectionEntityType, handleForStoreInfo} from '../../../../../build/runtime/storage/storage.js';
+import {CollectionEntityHandle, CollectionEntityType} from '../../../../../build/runtime/storage/storage.js';
 import {StoreInfo} from '../../../../../build/runtime/storage/store-info.js';
 import '../../../../lib/arcs-ui/dist/install-ui-classes.js';
 
 describe('products test', () => {
   const manifestFilename = './shells/tests/artifacts/ProductsTestNg.arcs';
 
-  const verifyFilteredBook = async (arc: Arc) => {
+  let runtime: Runtime;
+  beforeEach(async () => {
+    runtime = new Runtime();
+    runtime.context = await runtime.parseFile(manifestFilename);
+  });
+
+  const verifyFilteredBook = async (arc: ArcInfo) => {
     const booksHandle = arc.activeRecipe.handleConnections.find(hc => hc.isOutput).handle;
     const store = arc.findStoreById(booksHandle.id) as StoreInfo<CollectionEntityType>;
-    const handle: CollectionEntityHandle = await handleForStoreInfo(store, arc);
+    const handle: CollectionEntityHandle = await runtime.host.handleForStoreInfo(store, arc);
     const list = await handle.toList();
     assert.lengthOf(list, 1);
     assert.strictEqual('Harry Potter', list[0].name);
   };
 
   it('filters', async () => {
-    const runtime = new Runtime();
-    runtime.context = await runtime.parseFile(manifestFilename);
-  const arc = runtime.getArcById(
-      await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), planName: 'FilterBooks'}));
-    await arc.idle;
+    const arc = await runtime.allocator.startArc({
+      arcName: 'demo',
+      storageKeyPrefix: storageKeyPrefixForTest(),
+      planName: 'FilterBooks'
+    });
+    await runtime.getArcById(arc.id).idle;
     await verifyFilteredBook(arc);
   });
 
   it('filters and displays', async () => {
-    const runtime = new Runtime();
-    runtime.context = await runtime.parseFile(manifestFilename);
-
     const slotObserver = new SlotTestObserver();
     slotObserver
         .newExpectations()
@@ -49,13 +53,13 @@ describe('products test', () => {
         .expectRenderSlot('List', 'root')
         .expectRenderSlot('ShowProduct', 'item')
         ;
-    const arc = runtime.getArcById(await runtime.allocator.startArc({
+    const arc = await runtime.allocator.startArc({
       arcName: 'demo',
       storageKeyPrefix: storageKeyPrefixForTest(),
       planName: 'FilterAndDisplayBooks',
       slotObserver
-    }));
-    await arc.idle;
+    });
+    await runtime.getArcById(arc.id).idle;
     await verifyFilteredBook(arc);
   });
 

--- a/shells/tests/arcs/ts/runtime/slot-composer-test.ts
+++ b/shells/tests/arcs/ts/runtime/slot-composer-test.ts
@@ -33,7 +33,7 @@ async function init(recipeStr) {
   runtime.context = await runtime.parse(recipeStr);
 
   const observer = new SlotTestObserver();
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc', slotObserver: observer}));
+  const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-arc', slotObserver: observer})).id);
 
   const planner = new Planner();
   const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc)};
@@ -87,7 +87,7 @@ recipe
         .expectRenderSlot('BB', 'mySlot')
         .expectRenderSlot('C', 'otherSlot')
         ;
-    await runtime.allocator.runPlanInArc(arc.id, plan);
+    await runtime.allocator.runPlanInArc(arc.arcInfo, plan);
     await observer.expectationsCompleted();
   });
 
@@ -105,7 +105,7 @@ recipe
     runtime.context = await runtime.parseFile(manifest);
 
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver})).id);
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
     const suggestion = suggestions.find(s => s.plan.name === 'FilterAndDisplayBooks');
@@ -119,7 +119,7 @@ recipe
         .expectRenderSlot('List', 'root')
         .expectRenderSlot('List', 'root')
         .expectRenderSlot('ShowProduct', 'item');
-    await runtime.allocator.runPlanInArc(arc.id, suggestion.plan);
+    await runtime.allocator.runPlanInArc(arc.arcInfo, suggestion.plan);
     await slotObserver.expectationsCompleted();
   });
 
@@ -154,7 +154,7 @@ recipe
         .expectRenderSlot('B', 'item')
         .expectRenderSlot('C', 'item')
         ;
-    await runtime.allocator.runPlanInArc(arc.id, plan);
+    await runtime.allocator.runPlanInArc(arc.arcInfo, plan);
     await observer.expectationsCompleted();
   });
 

--- a/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
+++ b/shells/tests/arcs/ts/runtime/transformation-slots-test.ts
@@ -21,7 +21,8 @@ describe('transformation slots', () => {
     runtime.context = await runtime.parseFile('./shells/tests/artifacts/provide-hosted-particle-slots.manifest');
 
     const slotObserver = new SlotTestObserver();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), slotObserver});
+    const arc = runtime.getArcById(arcInfo.id);
 
     slotObserver
       .newExpectations()
@@ -34,7 +35,7 @@ describe('transformation slots', () => {
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
-    await runtime.allocator.runPlanInArc(arc.id, suggestions[0].plan);
+    await runtime.allocator.runPlanInArc(arcInfo, suggestions[0].plan);
     await arc.idle;
   });
 });

--- a/shells/tools/smoke-shell/app.js
+++ b/shells/tools/smoke-shell/app.js
@@ -12,7 +12,7 @@ import {Runtime} from '../../../build/runtime/runtime.js';
 import {Modality} from '../../../build/runtime/arcs-types/modality.js';
 
 export const App = async (runtime, composer, path) => {
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'smoke-arc', composer}));
+  const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'smoke-arc', composer})).id);
   arc.modality = Modality.dom;
   console.log(`arc [${arc.id}]`);
   //
@@ -25,7 +25,7 @@ export const App = async (runtime, composer, path) => {
   //
   if (recipe) {
     console.log(`recipe [${recipe.name}]`);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc.arcInfo, recipe);
   }
   //
   console.log(`\narc serialization`);

--- a/src/devtools-connector/tests/arc-stores-fetcher-test.ts
+++ b/src/devtools-connector/tests/arc-stores-fetcher-test.ts
@@ -17,7 +17,7 @@ import {Runtime} from '../../runtime/runtime.js';
 import {SingletonType} from '../../types/lib-types.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
 import {Entity} from '../../runtime/entity.js';
-import {ActiveSingletonEntityStore, handleForStoreInfo} from '../../runtime/storage/storage.js';
+import {ActiveSingletonEntityStore} from '../../runtime/storage/storage.js';
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
 
 describe('ArcStoresFetcher', () => {
@@ -29,11 +29,12 @@ describe('ArcStoresFetcher', () => {
       schema Foo
         value: Text`);
     const runtime = new Runtime({context});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory});
 
-    const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
-    const fooStore = await arc.createStore(new SingletonType(foo.type), 'fooStoreName', 'fooStoreId', ['awesome', 'arcs']);
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
+    const foo = Entity.createEntityClass(arcInfo.context.findSchemaByName('Foo'), null);
+    const fooStore = await arcInfo.createStoreInfo(
+      new SingletonType(foo.type), {name: 'fooStoreName', id: 'fooStoreId', tags: ['awesome', 'arcs']});
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
     const fooEntity = new foo({value: 'persistence is useful'});
     await fooHandle.set(fooEntity);
 
@@ -41,7 +42,7 @@ describe('ArcStoresFetcher', () => {
         m => m.messageType === 'fetch-stores-result'));
 
     await DevtoolsForTests.channel.receive({
-      arcId: arc.id.toString(),
+      arcId: arcInfo.id.toString(),
       messageType: 'fetch-stores'
     });
 
@@ -53,7 +54,7 @@ describe('ArcStoresFetcher', () => {
     // We don't assert on it in this test.
     deleteFieldRecursively(results, 'location');
 
-    const sessionId = arc.idGenerator.currentSessionIdForTesting;
+    const sessionId = arcInfo.idGenerator.currentSessionIdForTesting;
     const entityId = '!' + sessionId + ':fooStoreId:2';
     const creationTimestamp = Entity.creationTimestamp(fooEntity);
 
@@ -113,24 +114,25 @@ describe('ArcStoresFetcher', () => {
         P
           foo: foo`);
     const runtime = new Runtime({loader, context});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({
+    const arcInfo = await runtime.allocator.startArc({
       arcName: 'demo',
       planName: 'DemoRecipe',
       storageKeyPrefix: storageKeyPrefixForTest(),
       inspectorFactory: devtoolsArcInspectorFactory
-    }));
+    });
 
     assert.isEmpty(DevtoolsForTests.channel.messages.filter(
         m => m.messageType === 'store-value-changed'));
 
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     const results = DevtoolsForTests.channel.messages.filter(
         m => m.messageType === 'store-value-changed');
     assert.lengthOf(results, 1);
 
-    const sessionId = arc.idGenerator.currentSessionIdForTesting;
-    const storeInfo = arc.findStoreById(arc.activeRecipe.handles[0].id);
+    const sessionId = arcInfo.idGenerator.currentSessionIdForTesting;
+    const storeInfo = arcInfo.findStoreById(arcInfo.activeRecipe.handles[0].id);
     const store = await arc.getActiveStore(storeInfo) as ActiveSingletonEntityStore;
     // TODO(mmandlis): there should be a better way!
     const creationTimestamp = Object.values((await store.serializeContents()).values)[0]['value']['creationTimestamp'];

--- a/src/devtools-connector/tests/devtools-arc-inspector-test.ts
+++ b/src/devtools-connector/tests/devtools-arc-inspector-test.ts
@@ -41,14 +41,14 @@ describe('DevtoolsArcInspector', () => {
         P
           foo: foo`);
     const runtime = new Runtime({loader, context});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory}));
+    const arc = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), inspectorFactory: devtoolsArcInspectorFactory});
 
     const foo = Entity.createEntityClass(arc.context.findSchemaByName('Foo'), null);
-    const fooStore = await arc.createStore(new SingletonType(foo.type), undefined, 'fooStore');
+    const fooStore = await arc.createStoreInfo(new SingletonType(foo.type), {id: 'fooStore'});
 
     const recipe = arc.context.recipes[0];
     recipe.handles[0].mapToStorage(fooStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
 
     const instantiateParticleCall = DevtoolsForTests.channel.messages.find(m =>
       m.messageType === 'PecLog' && m.messageBody.name === 'InstantiateParticle').messageBody;

--- a/src/planning/plan/tests/plan-consumer-test.ts
+++ b/src/planning/plan/tests/plan-consumer-test.ts
@@ -21,10 +21,10 @@ import {Arc} from '../../../runtime/arc.js';
 import {Manifest} from '../../../runtime/manifest.js';
 import {ActiveSingletonEntityStore} from '../../../runtime/storage/storage.js';
 
-async function createPlanConsumer(arc: Arc, context: Manifest) {
+async function createPlanConsumer(arc: Arc, runtime: Runtime) {
   const store: ActiveSingletonEntityStore = await Planificator['_initSuggestStore'](arc);
   assert.isNotNull(store);
-  const result = new PlanningResult({context, loader: arc.loader, storageService: arc.storageService}, store);
+  const result = new PlanningResult({context: runtime.context, loader: arc.loader, storageService: runtime.storageService}, store);
   return new PlanConsumer(arc, result);
 }
 
@@ -65,10 +65,11 @@ ${addRecipe(['ParticleTouch', 'ParticleBoth'])}
       `);
       runtime.context = context;
 
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), modality}));
+      const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest(), modality});
+      const arc = runtime.getArcById(arcInfo.id);
       assert.lengthOf(context.allRecipes, 4);
 
-      const consumer = await createPlanConsumer(arc, context);
+      const consumer = await createPlanConsumer(arc, runtime);
       assert.isNotNull(consumer);
 
       await storeResults(consumer, context.allRecipes.map((plan, index) => {

--- a/src/planning/plan/tests/planning-result-test.ts
+++ b/src/planning/plan/tests/planning-result-test.ts
@@ -26,13 +26,13 @@ describe('planning result', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(arcInfo.id);
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.isNotEmpty(suggestions);
 
-    const {loader, context} = runtime;
-    const {storageService} = arc;
+    const {loader, context, storageService} = runtime;
 
     const result = new PlanningResult({context, loader, storageService});
     result.merge({suggestions}, arc);
@@ -51,11 +51,11 @@ describe('planning result', () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/runtime/tests/artifacts/Products/Products.recipes');
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(arcInfo.id);
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 
-    const {loader, context} = runtime;
-    const {storageService} = arc;
+    const {loader, context, storageService} = runtime;
 
     const result = new PlanningResult({loader, context, storageService});
 
@@ -119,7 +119,8 @@ recipe R3
         `;
   async function prepareMerge(manifestStr1, manifestStr2) {
     const runtime = new Runtime();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(arcInfo.id);
 
     const planToSuggestion = async (plan: Recipe): Promise<Suggestion> => {
       const suggestion = Suggestion.create(plan, await plan.digest(), Relevance.create(arc, plan));
@@ -133,7 +134,7 @@ recipe R3
     };
     const manifestToResult = async (manifestStr) =>  {
       const manifest = await runtime.parse(manifestStr);
-      const result = new PlanningResult({context: arc.context, loader: runtime.loader, storageService: arc.storageService});
+      const result = new PlanningResult({context: arc.context, loader: runtime.loader, storageService: runtime.storageService});
 
       const suggestions: Suggestion[] = await Promise.all(
         manifest.recipes.map(async plan => planToSuggestion(plan)) as Promise<Suggestion>[]

--- a/src/planning/plan/tests/replan-queue-test.ts
+++ b/src/planning/plan/tests/replan-queue-test.ts
@@ -22,7 +22,7 @@ class TestPlanProducer extends PlanProducer {
   produceSuggestionsCalled = 0;
 
   constructor(arc: Arc, runtime: Runtime) {
-    super(arc, runtime, new PlanningResult({context: arc.context, loader: arc.loader, storageService: arc.storageService}));
+    super(arc, runtime, new PlanningResult({context: arc.context, loader: arc.loader, storageService: runtime.storageService}));
   }
 
   async produceSuggestions(options = {}) {
@@ -42,7 +42,7 @@ async function init(options?) {
       value: Text
   `);
   const runtime = new Runtime({loader, context});
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+  const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test'})).id);
   const producer = new TestPlanProducer(arc, runtime);
   const queue = new ReplanQueue(producer, options);
 

--- a/src/planning/plan/tests/suggestion-test.ts
+++ b/src/planning/plan/tests/suggestion-test.ts
@@ -64,8 +64,8 @@ describe('suggestion', () => {
   });
 
   it('deserialize empty', async () => {
-    const storageService = new Runtime().storageService;
-    const envOptions = {loader: new Loader(), context: new Manifest({id: 'test'}), storageService};
+    const runtime = new Runtime();
+    const envOptions = {loader: runtime.loader, context: new Manifest({id: 'test'}), storageService: runtime.storageService};
     const plan = newRecipe();
     const suggestion1 = await Suggestion.fromLiteral({plan: plan.toString(), hash: '123', rank: 1}, envOptions);
     assert.isTrue(Boolean(suggestion1.plan));

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -290,14 +290,14 @@ export class Planner implements InspectablePlanner {
       }
       const speculativeArc = result.speculativeArc;
       relevance = result.relevance;
-      description = await Description.create(speculativeArc, relevance);
+      description = await Description.create(speculativeArc, this.runtime, relevance);
       //log(`[${plan.name}] => [${description.getRecipeSuggestion()}]`);
     } else {
       const speculativeArc = await arc.cloneForSpeculativeExecution();
       plan = await this.runtime.allocator.assignStorageKeys(arc.id, plan);
       await speculativeArc.mergeIntoActiveRecipe(plan);
       relevance = Relevance.create(arc, plan);
-      description = await Description.create(speculativeArc, relevance);
+      description = await Description.create(speculativeArc, this.runtime, relevance);
     }
     const suggestion = Suggestion.create(plan, hash, relevance);
     suggestion.setDescription(description, this.arc.modality);

--- a/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
+++ b/src/planning/strategies/tests/convert-constraints-to-connections-test.ts
@@ -20,7 +20,7 @@ import {Runtime} from '../../../runtime/runtime.js';
 describe('ConvertConstraintsToConnections', () => {
   const startArc = async (manifest: Manifest) => {
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    return runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc'}));
+    return runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-plan-arc'})).id);
   };
 
   it('fills out an empty constraint', async () => {
@@ -297,7 +297,7 @@ describe('ConvertConstraintsToConnections', () => {
 
     const generated = [{result: manifest.recipes[0], score: 1, derivation: [], hash: '0', valid: true}, {result: manifest.recipes[1], score: 1, derivation: [], hash: '0', valid: true}];
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    const cctc = new ConvertConstraintsToConnections(runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc', modality: Modality.vr})));
+    const cctc = new ConvertConstraintsToConnections(runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-plan-arc', modality: Modality.vr})).id));
 
     const results = await cctc.generateFrom(generated);
     assert.lengthOf(results, 1);

--- a/src/planning/strategies/tests/find-required-particle-test.ts
+++ b/src/planning/strategies/tests/find-required-particle-test.ts
@@ -45,15 +45,16 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(arcInfo.id);
+    await runtime.allocator.runPlanInArc(arcInfo, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
-    assert.isTrue(recipe.slots[0].id === arc.activeRecipe.slots[1].id, 'results recipe does not have the correct slot');
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    assert.isTrue(arc.activeRecipe.normalize());
+    assert.isTrue(recipe.slots[0].id === arcInfo.activeRecipe.slots[1].id, 'results recipe does not have the correct slot');
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    assert.isTrue(arcInfo.activeRecipe.normalize());
   });
 
   it('find single required particle that consumes slot', async () => {
@@ -82,15 +83,16 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(arcInfo.id);
+    await runtime.allocator.runPlanInArc(arcInfo, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
-    assert.isTrue(recipe.slots[0].id === arc.activeRecipe.slots[0].id, 'results recipe does not have the correct slot');
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    assert.isTrue(arc.activeRecipe.normalize());
+    assert.isTrue(recipe.slots[0].id === arcInfo.activeRecipe.slots[0].id, 'results recipe does not have the correct slot');
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    assert.isTrue(arcInfo.activeRecipe.normalize());
   });
 
   it('find two required particles', async () => {
@@ -137,16 +139,17 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
     assert.isTrue(recipes.every(recipe => recipe.normalize()));
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(arcInfo.id);
+    await runtime.allocator.runPlanInArc(arcInfo, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
     const recipe = results[0].result;
-    assert.isTrue(recipe.slots[0].id === arc.activeRecipe.slots[0].id, 'first slot in results recipe is not the correct slot');
-    assert.isTrue(recipe.slots[1].id === arc.activeRecipe.slots[1].id, 'second slot in results recipe is not the correct slots');
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    assert.isTrue(arc.activeRecipe.normalize());
+    assert.isTrue(recipe.slots[0].id === arcInfo.activeRecipe.slots[0].id, 'first slot in results recipe is not the correct slot');
+    assert.isTrue(recipe.slots[1].id === arcInfo.activeRecipe.slots[1].id, 'second slot in results recipe is not the correct slots');
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    assert.isTrue(arcInfo.activeRecipe.normalize());
   });
   it('required particle can not provide a slot that\'s provided by the shell', async () => {
     const loader = new Loader(null, {
@@ -191,8 +194,9 @@ describe('FindRequiredParticles', () => {
     `));
     const recipes = manifest.recipes;
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(arcInfo.id);
+    await runtime.allocator.runPlanInArc(arcInfo, recipes[1]);
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));
     const results = await strategy.generateFrom(inputParams);
@@ -244,8 +248,9 @@ describe('FindRequiredParticles', () => {
     const recipes = manifest.recipes;
 
     const runtime = new Runtime({context: manifest, loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipes[1]);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-arc'});
+    const arc = runtime.getArcById(arcInfo.id);
+    await runtime.allocator.runPlanInArc(arcInfo, recipes[1]);
 
     const strategy = new FindRequiredParticle(arc, StrategyTestHelper.createTestStrategyArgs(arc));
     const inputParams = recipes.map(recipe => ({result: recipe, score: 1}));

--- a/src/planning/strategies/tests/init-population-test.ts
+++ b/src/planning/strategies/tests/init-population-test.ts
@@ -39,7 +39,8 @@ describe('InitPopulation', () => {
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-plan-arc'});
+    const arc = runtime.getArcById(arcInfo.id);
 
     async function scoreOfInitPopulationOutput() {
       const results = await new InitPopulation(arc, StrategyTestHelper.createTestStrategyArgs(
@@ -49,7 +50,7 @@ describe('InitPopulation', () => {
     }
 
     assert.strictEqual(await scoreOfInitPopulationOutput(), 1);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
     assert.strictEqual(await scoreOfInitPopulationOutput(), 0);
   });
 
@@ -66,7 +67,7 @@ describe('InitPopulation', () => {
       'A.js': 'defineParticle(({Particle}) => class extends Particle {})'
     });
     const runtime = new Runtime({loader, context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-plan-arc'})).id);
 
     const results = await new InitPopulation(arc, {contextual: false,
         recipeIndex: {recipes: manifest.recipes}}).generate({generation: 0});

--- a/src/planning/strategies/tests/map-slots-test.ts
+++ b/src/planning/strategies/tests/map-slots-test.ts
@@ -158,7 +158,7 @@ ${recipeManifest}
   it.skip('prefers local slots if available', async () => {
     // Arc has both a 'root' and an 'action' slot.
     const runtime = new Runtime({loader: new Loader(), context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-plan-arc'})).id);
 
     const particles = `
       particle A in 'A.js'

--- a/src/planning/strategies/tests/resolve-recipe-test.ts
+++ b/src/planning/strategies/tests/resolve-recipe-test.ts
@@ -233,7 +233,7 @@ describe('resolve recipe', () => {
     const arc = await createTestArc(manifest);
 
     const car = Entity.createEntityClass(manifest.findSchemaByName('Car'), null);
-    await arc.createStore(new SingletonType(car.type), /* name= */ null, 'batmobile');
+    await arc.arcInfo.createStoreInfo(new SingletonType(car.type), {id: 'batmobile'});
 
     const recipe = manifest.recipes[0];
 

--- a/src/planning/testing/strategy-test-helper.ts
+++ b/src/planning/testing/strategy-test-helper.ts
@@ -23,7 +23,7 @@ import {Runtime} from '../../runtime/runtime.js';
 export class StrategyTestHelper {
   static async createTestArc(context: Manifest, options: {id?: Id, modality?: Modality, loader?: Loader} = {}): Promise<Arc> {
     const runtime = new Runtime({context, loader: options.loader || new Loader()});
-    return runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc', ...options}));
+    return runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-arc', ...options})).id);
   }
   static createTestStrategyArgs(arc: Arc, args?) {
     return {recipeIndex: RecipeIndex.create(arc), ...args};

--- a/src/planning/tests/planner-test.ts
+++ b/src/planning/tests/planner-test.ts
@@ -94,7 +94,7 @@ const loadTestArcAndRunSpeculation = async (manifest, manifestLoadedCallback) =>
   manifestLoadedCallback(loadedManifest);
 
   const runtime = new Runtime({context: loadedManifest, loader});
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc'}));
+  const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-plan-arc'})).id);
   const planner = new Planner();
   const options = {runtime, strategyArgs: StrategyTestHelper.createTestStrategyArgs(arc), speculator: new Speculator(runtime)};
   planner.init(arc, options);
@@ -913,7 +913,7 @@ describe('Automatic resolution', () => {
       `,
       async (arc, manifest) => {
         const thing = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-        await arc.createStore(new SingletonType(thing.type), undefined, 'test:1');
+        await arc.arcInfo.createStoreInfo(new SingletonType(thing.type), {id: 'test:1'});
       }
     );
 
@@ -979,7 +979,7 @@ describe('Automatic resolution', () => {
         async (arcRef, manifest) => {
           arc = arcRef;
           const thing = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-          await arc.createStore(thing.type.collectionOf(), undefined, 'test-store', ['items']);
+          await arc.arcInfo.createStoreInfo(thing.type.collectionOf(), {id: 'test-store', tags: ['items']});
         });
 
     assert.lengthOf(recipes, 1);

--- a/src/planning/tests/planning-manifest-integration-test.ts
+++ b/src/planning/tests/planning-manifest-integration-test.ts
@@ -16,7 +16,7 @@ describe('planning manifest integration', () => {
   it('can produce a recipe that can be speculated', async () => {
     const {runtime, arc, recipe} = await manifestTestSetup();
     const hash = ((hash) => hash.substring(hash.length - 4))(await recipe.digest());
-    const {speculativeArc, relevance} = await new Speculator(runtime).speculate(arc, recipe, hash);
+    const {speculativeArc, relevance} = await new Speculator(runtime).speculate(runtime.getArcById(arc.id), recipe, hash);
     assert.strictEqual(relevance.calcRelevanceScore(), 1);
     assert.lengthOf(speculativeArc.recipeDeltas, 1);
   });

--- a/src/planning/tests/recipe-index-test.ts
+++ b/src/planning/tests/recipe-index-test.ts
@@ -27,7 +27,7 @@ describe('RecipeIndex', () => {
     }
     const loader = new Loader();
     const runtime = new Runtime({loader, context: manifest});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-plan-arc'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test-plan-arc'})).id);
     const recipeIndex = RecipeIndex.create(arc);
     await recipeIndex.ready;
     return recipeIndex;

--- a/src/planning/tests/speculator-test.ts
+++ b/src/planning/tests/speculator-test.ts
@@ -20,7 +20,7 @@ describe('speculator', () => {
   it('can speculatively produce a relevance', async () => {
     const loader = new Loader();
     const runtime = new Runtime({loader, context: new Manifest({id: ArcId.newForTest('test')})});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test'})).id);
     const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader);
     const recipe = manifest.recipes[0];
     assert(recipe.normalize());

--- a/src/runtime/arc.ts
+++ b/src/runtime/arc.ts
@@ -13,18 +13,15 @@ import {ArcInspector, ArcInspectorFactory} from './arc-inspector.js';
 import {FakePecFactory} from './fake-pec-factory.js';
 import {Id, IdGenerator} from './id.js';
 import {Loader} from '../platform/loader.js';
-import {Capabilities} from './capabilities.js';
 import {CapabilitiesResolver} from './capabilities-resolver.js';
 import {Dictionary, Runnable, compareComparables, Mutex} from '../utils/lib-utils.js';
-import {Manifest} from './manifest.js';
 import {MessagePort} from './message-channel.js';
 import {Modality} from './arcs-types/modality.js';
 import {ParticleExecutionHost} from './particle-execution-host.js';
 import {ParticleSpec} from './arcs-types/particle-spec.js';
-import {Recipe, Handle, Particle, Slot, IsValidOptions, effectiveTypeForHandle, newRecipe} from './recipe/lib-recipe.js';
+import {Recipe, Particle, Slot} from './recipe/lib-recipe.js';
 import {SlotComposer} from './slot-composer.js';
-import {CollectionType, EntityType, InterfaceInfo, InterfaceType,
-        TupleType, ReferenceType, SingletonType, Type, TypeVariable} from '../types/lib-types.js';
+import {InterfaceType, Type} from '../types/lib-types.js';
 import {PecFactory} from './particle-execution-context.js';
 import {VolatileMemory, VolatileStorageDriverProvider, VolatileStorageKey} from './storage/drivers/volatile.js';
 import {DriverFactory} from './storage/drivers/driver-factory.js';
@@ -34,7 +31,7 @@ import {ArcSerializer, ArcInterface} from './arc-serializer.js';
 import {ReferenceModeStorageKey} from './storage/reference-mode-storage-key.js';
 import {SystemTrace} from '../tracelib/systrace.js';
 import {StorageKeyParser} from './storage/storage-key-parser.js';
-import {SingletonInterfaceHandle, handleForStoreInfo, TypeToCRDTTypeRecord} from './storage/storage.js';
+import {SingletonInterfaceHandle, TypeToCRDTTypeRecord} from './storage/storage.js';
 import {StoreInfo} from './storage/store-info.js';
 import {ActiveStore} from './storage/active-store.js';
 import {StorageService} from './storage/storage-service.js';
@@ -75,7 +72,7 @@ export class Arc implements ArcInterface {
   public get storeTagsById() { return this.arcInfo.storeTagsById; }
 
   // Map from each store to its description (originating in the manifest).
-  private readonly storeDescriptions = new Map<StoreInfo<Type>, string>();
+  get storeDescriptions() { return this.arcInfo.storeDescriptions; }
   private waitForIdlePromise: Promise<void> | null;
   private readonly inspectorFactory?: ArcInspectorFactory;
   public readonly inspector?: ArcInspector;
@@ -315,7 +312,7 @@ export class Arc implements ArcInterface {
   }
 
   get stores(): StoreInfo<Type>[] {
-    return Object.values(this.storeInfoById);
+    return this.arcInfo.stores;
   }
 
   async getActiveStore<T extends Type>(storeInfo: StoreInfo<T>): Promise<ActiveStore<TypeToCRDTTypeRecord<T>>> {
@@ -414,6 +411,21 @@ export class Arc implements ArcInterface {
       const newStore = this.storeInfoById[recipeHandle.id];
       assert(newStore);
 
+      if (recipeHandle.immediateValue) {
+        const particleSpec = recipeHandle.immediateValue;
+        const type = recipeHandle.type;
+        if (newStore.isSingletonInterfaceStore()) {
+          assert(type instanceof InterfaceType && type.interfaceInfo.particleMatches(particleSpec));
+          await this.getActiveStore(newStore);
+          const handle: SingletonInterfaceHandle = await this.storageService.handleForStoreInfo(
+              newStore, this.arcInfo.generateID().toString(), this.arcInfo.idGenerator, {ttl: recipeHandle.getTtl()}) as SingletonInterfaceHandle;
+          await handle.set(particleSpec.clone());
+        } else {
+          throw new Error(`Can't currently store immediate values in non-singleton stores`);
+        }
+        continue;
+      }
+
       if (!['copy', 'map', 'create'].includes(fate)) {
         continue;
       }
@@ -422,27 +434,12 @@ export class Arc implements ArcInterface {
         await this.createActiveStore(newStore);
       } else {
         await this.createStoreInternal(newStore);
-      }
-
-      if (recipeHandle.immediateValue) {
-        const particleSpec = recipeHandle.immediateValue;
-        const type = recipeHandle.type;
-        if (newStore.isSingletonInterfaceStore()) {
-          assert(type instanceof InterfaceType && type.interfaceInfo.particleMatches(particleSpec));
-          const handle: SingletonInterfaceHandle = await handleForStoreInfo(newStore, this, {ttl: recipeHandle.getTtl()}) as SingletonInterfaceHandle;
-          await handle.set(particleSpec.clone());
-        } else {
-          throw new Error(`Can't currently store immediate values in non-singleton stores`);
-        }
-      } else if (fate === 'copy') {
-        const copiedStoreRef = this.context.findStoreById(recipeHandle.originalId);
-        const copiedActiveStore = await this.getActiveStore(copiedStoreRef);
-        assert(copiedActiveStore, `Cannot find store ${recipeHandle.originalId}`);
-        const activeStore = await this.getActiveStore(newStore);
-        await activeStore.cloneFrom(copiedActiveStore);
-        const copiedStoreDesc = this.getStoreDescription(copiedStoreRef);
-        if (copiedStoreDesc) {
-          this.storeDescriptions.set(newStore, copiedStoreDesc);
+        if (fate === 'copy') {
+          const copiedStoreRef = this.context.findStoreById(recipeHandle.originalId);
+          const copiedActiveStore = await this.getActiveStore(copiedStoreRef);
+          assert(copiedActiveStore, `Cannot find store ${recipeHandle.originalId}`);
+          const activeStore = await this.getActiveStore(newStore);
+          await activeStore.cloneFrom(copiedActiveStore);
         }
       }
     }
@@ -456,14 +453,6 @@ export class Arc implements ArcInterface {
     if (this.inspector) {
       await this.inspector.recipeInstantiated(particles, this.activeRecipe.toString());
     }
-  }
-
-  // TODO(shanestephens): Once we stop auto-wrapping in singleton types below, convert this to return a well-typed store.
-  async createStore<T extends Type>(type: T, name?: string, id?: string, tags?: string[], storageKey?: StorageKey,
-        capabilities?: Capabilities): Promise<StoreInfo<T>> {
-    const storeInfo = await this.arcInfo.createStoreInfo({type, name, id, storageKey, capabilities, tags});
-    await this.createStoreInternal(storeInfo);
-    return storeInfo;
   }
 
   private async createStoreInternal<T extends Type>(storeInfo: StoreInfo<T>): Promise<void> {
@@ -498,70 +487,12 @@ export class Arc implements ArcInterface {
     this.dataChangeCallbacks.delete(registration);
   }
 
-  // Convert a type to a normalized key that we can use for
-  // equality testing.
-  //
-  // TODO: we should be testing the schemas for compatiblity instead of using just the name.
-  // TODO: now that this is only used to implement findStoresByType we can probably replace
-  // the check there with a type system equality check or similar.
-  static _typeToKey(type: Type): string | InterfaceInfo | null {
-    if (type.isSingleton) {
-      type = type.getContainedType();
-    }
-    const elementType = type.getContainedType();
-    if (elementType) {
-      const key = this._typeToKey(elementType);
-      if (key) {
-        return `list:${key}`;
-      }
-    } else if (type instanceof EntityType) {
-      return type.entitySchema.name;
-    } else if (type instanceof InterfaceType) {
-      // TODO we need to fix this too, otherwise all handles of interface type will
-      // be of the 'same type' when searching by type.
-      return type.interfaceInfo;
-    } else if (type instanceof TypeVariable && type.isResolved()) {
-      return Arc._typeToKey(type.resolvedType());
-    }
-    return null;
-  }
-
   findStoresByType<T extends Type>(type: T, options?: {tags: string[]}): StoreInfo<T>[] {
-    const typeKey = Arc._typeToKey(type);
-    let stores = Object.values(this.storeInfoById).filter(handle => {
-      if (typeKey) {
-        const handleKey = Arc._typeToKey(handle.type);
-        if (typeKey === handleKey) {
-          return true;
-        }
-      } else {
-        if (type instanceof TypeVariable && !type.isResolved() && handle.type instanceof EntityType || handle.type instanceof SingletonType) {
-          return true;
-        }
-        // elementType will only be non-null if type is either Collection or BigCollection; the tag
-        // comparison ensures that handle.type is the same sort of collection.
-        const elementType = type.getContainedType();
-        if (elementType && elementType instanceof TypeVariable && !elementType.isResolved() && type.tag === handle.type.tag) {
-          return true;
-        }
-      }
-      return false;
-    });
-
-    if (options && options.tags && options.tags.length > 0) {
-      stores = stores.filter(store => options.tags.filter(tag => !this.storeTagsById[store.id].has(tag)).length === 0);
-    }
-
-    // Quick check that a new handle can fulfill the type contract.
-    // Rewrite of this method tracked by https://github.com/PolymerLabs/arcs/issues/1636.
-    return stores.filter(s => {
-      const isInterface = s.type.getContainedType() ? s.type.getContainedType() instanceof InterfaceType : s.type instanceof InterfaceType;
-      return !!effectiveTypeForHandle(type, [{type: s.type, direction: isInterface ? 'hosts' : 'reads writes'}]);
-    }) as StoreInfo<T>[];
+    return this.arcInfo.findStoresByType(type, options);
   }
 
   findStoreById(id: string): StoreInfo<Type> {
-    return this.storeInfoById[id];
+    return this.arcInfo.findStoreById(id);
   }
 
   findStoreTags(storeInfo: StoreInfo<Type>): Set<string> {
@@ -569,8 +500,7 @@ export class Arc implements ArcInterface {
   }
 
   getStoreDescription(storeInfo: StoreInfo<Type>): string {
-    assert(storeInfo, 'Cannot fetch description for nonexistent store');
-    return this.storeDescriptions.get(storeInfo) || storeInfo.description;
+    return this.arcInfo.getStoreDescription(storeInfo);
   }
 
   getVersionByStore({includeArc=true, includeContext=false}) {

--- a/src/runtime/description.ts
+++ b/src/runtime/description.ts
@@ -15,9 +15,11 @@ import {Relevance} from './relevance.js';
 import {EntityType, InterfaceType, SingletonType, CollectionType} from '../types/lib-types.js';
 import {Recipe, Particle, Handle} from './recipe/lib-recipe.js';
 import {Dictionary} from '../utils/lib-utils.js';
-import {handleForStoreInfo, CollectionEntityType, SingletonInterfaceType, SingletonEntityType} from './storage/storage.js';
+import {CollectionEntityType, SingletonInterfaceType, SingletonEntityType} from './storage/storage.js';
 import {CRDTTypeRecord} from '../crdt/lib-crdt.js';
 import {StoreInfo} from './storage/store-info.js';
+import {Runtime} from './runtime.js';
+import {ArcInfo} from './arc-info.js';
 
 export class Description {
   private constructor(
@@ -27,14 +29,14 @@ export class Description {
     private readonly particleDescriptions: ParticleDescription[] = []) {
   }
 
-  static async createForPlan(arc: Arc, plan: Recipe): Promise<Description> {
+  static async createForPlan(arcInfo: ArcInfo, plan: Recipe, runtime: Runtime): Promise<Description> {
     const allParticles = plan.particles;
-    const particleDescriptions = await Description.initDescriptionHandles(allParticles, arc);
+    const particleDescriptions = await Description.initDescriptionHandles(allParticles, arcInfo, runtime);
     const storeDescById: {[id: string]: string} = {};
     for (const {id} of plan.handles) {
-      const store = arc.findStoreById(id);
+      const store = arcInfo.findStoreById(id);
       if (store) {
-        storeDescById[id] = arc.getStoreDescription(store);
+        storeDescById[id] = arcInfo.getStoreDescription(store);
       }
     }
     // ... and pass to the private constructor.
@@ -45,21 +47,23 @@ export class Description {
    * Create a new Description object for the given Arc with an
    * optional Relevance object.
    */
-  static async create(arc: Arc, relevance?: Relevance): Promise<Description> {
+  // TODO(b/182410550): pass `arcInfo` instead of `arc`, once ArcInfo contains inner arcs info.
+  static async create(arc: Arc, runtime: Runtime, relevance?: Relevance): Promise<Description> {
     // Execute async related code here
+    const arcInfo = arc.arcInfo;
     const allParticles = ([] as Particle[]).concat(...arc.allDescendingArcs.map(arc => arc.activeRecipe.particles));
-    const particleDescriptions = await Description.initDescriptionHandles(allParticles, arc, relevance);
+    const particleDescriptions = await Description.initDescriptionHandles(allParticles, arcInfo, runtime, relevance);
 
     const storeDescById: {[id: string]: string} = {};
-    for (const {id} of arc.activeRecipe.handles) {
-      const store = arc.findStoreById(id);
+    for (const {id} of arcInfo.activeRecipe.handles) {
+      const store = arcInfo.findStoreById(id);
       if (store) {
-        storeDescById[id] = arc.getStoreDescription(store);
+        storeDescById[id] = arcInfo.getStoreDescription(store);
       }
     }
 
     // ... and pass to the private constructor.
-    return new Description(storeDescById, arc.recipeDeltas, particleDescriptions);
+    return new Description(storeDescById, arcInfo.recipeDeltas, particleDescriptions);
   }
 
   getArcDescription(formatterClass = DescriptionFormatter): string|undefined {
@@ -98,12 +102,12 @@ export class Description {
     return allTokens;
   }
 
-  private static async initDescriptionHandles(allParticles: Particle[], arc?: Arc, relevance?: Relevance): Promise<ParticleDescription[]> {
+  private static async initDescriptionHandles(allParticles: Particle[], arcInfo?: ArcInfo, runtime?: Runtime, relevance?: Relevance): Promise<ParticleDescription[]> {
     return Promise.all(
-      allParticles.map(particle => Description._createParticleDescription(particle, arc, relevance)));
+      allParticles.map(particle => Description._createParticleDescription(particle, arcInfo, runtime, relevance)));
   }
 
-  private static async _createParticleDescription(particle: Particle, arc?: Arc, relevance?: Relevance): Promise<ParticleDescription> {
+  private static async _createParticleDescription(particle: Particle, arcInfo?: ArcInfo, runtime?: Runtime, relevance?: Relevance): Promise<ParticleDescription> {
     let pDesc : ParticleDescription = {
       _particle: particle,
       _connections: {}
@@ -113,7 +117,7 @@ export class Description {
       pDesc._rank = relevance.calcParticleRelevance(particle);
     }
 
-    const descByName = await Description._getPatternByNameFromDescriptionHandle(particle, arc);
+    const descByName = await Description._getPatternByNameFromDescriptionHandle(particle, arcInfo, runtime);
     pDesc = {...pDesc, ...descByName};
     pDesc.pattern = pDesc.pattern || particle.spec.pattern;
 
@@ -124,18 +128,18 @@ export class Description {
       pDesc._connections[handleConn.name] = {
         pattern,
         _handleConn: handleConn,
-        value: await Description._prepareStoreValue(handleConn.handle.id, arc)
+        value: await Description._prepareStoreValue(handleConn.handle.id, arcInfo, runtime)
       };
     }
     return pDesc;
   }
 
-  private static async _getPatternByNameFromDescriptionHandle(particle: Particle, arc: Arc): Promise<Dictionary<string>> {
+  private static async _getPatternByNameFromDescriptionHandle(particle: Particle, arcInfo: ArcInfo, runtime: Runtime): Promise<Dictionary<string>> {
     const descriptionConn = particle.connections['descriptions'];
     if (descriptionConn && descriptionConn.handle && descriptionConn.handle.id) {
-      const descStore = arc.findStoreById(descriptionConn.handle.id) as StoreInfo<CollectionEntityType>;
+      const descStore = arcInfo.findStoreById(descriptionConn.handle.id) as StoreInfo<CollectionEntityType>;
       if (descStore) {
-        const descHandle = await handleForStoreInfo(descStore, arc);
+        const descHandle = await runtime.host.handleForStoreInfo(descStore, arcInfo);
         const descByName: Dictionary<string> = {};
         for (const d of await descHandle.toList()) {
           descByName[d.key] = d.value;
@@ -146,16 +150,16 @@ export class Description {
     return {};
   }
 
-  private static async _prepareStoreValue(storeId: string, arc: Arc): Promise<DescriptionValue|undefined> {
-    if (!arc) {
+  private static async _prepareStoreValue(storeId: string, arcInfo: ArcInfo, runtime: Runtime): Promise<DescriptionValue|undefined> {
+    if (!arcInfo) {
       return null;
     }
-    const store = arc.findStoreById(storeId);
+    const store = arcInfo.findStoreById(storeId);
     if (!store) {
       return undefined;
     }
     if (store.type instanceof SingletonType && store.type.getContainedType() instanceof EntityType) {
-      const handle = await handleForStoreInfo(store as StoreInfo<SingletonEntityType>, arc);
+      const handle = await runtime.host.handleForStoreInfo(store as StoreInfo<SingletonEntityType>, arcInfo);
       const entityValue = await handle.fetch();
       if (entityValue) {
         const schema = store.type.getEntitySchema();
@@ -163,13 +167,13 @@ export class Description {
         return {entityValue, valueDescription};
       }
     } else if (store.type instanceof SingletonType && store.type.getContainedType() instanceof InterfaceType) {
-      const handle = await handleForStoreInfo(store as StoreInfo<SingletonInterfaceType>, arc);
+      const handle = await runtime.host.handleForStoreInfo(store as StoreInfo<SingletonInterfaceType>, arcInfo);
       const interfaceValue = await handle.fetch();
       if (interfaceValue) {
         return {interfaceValue};
       }
     } else if (store.type instanceof CollectionType) {
-      const handle = await handleForStoreInfo(store as StoreInfo<CollectionEntityType>, arc);
+      const handle = await runtime.host.handleForStoreInfo(store as StoreInfo<CollectionEntityType>, arcInfo);
       const values = await handle.toList();
       if (values && values.length > 0) {
         return {collectionValues: values};

--- a/src/runtime/particle-execution-host.ts
+++ b/src/runtime/particle-execution-host.ts
@@ -217,7 +217,7 @@ class PECOuterPortImpl extends PECOuterPort {
       type = new SingletonType(type);
     }
 
-    const store = await arc.createStore(type, name, null, [], storageKey);
+    const store = await arc.arcInfo.createStoreInfo(type, {name, storageKey});
     // Store belongs to the inner arc, but the transformation particle,
     // which itself is in the outer arc gets access to it.
     this.CreateHandleCallback(store, store, callback, name, store.id);
@@ -294,7 +294,7 @@ class PECOuterPortImpl extends PECOuterPort {
                   if (type instanceof EntityType || type instanceof InterfaceType || type instanceof ReferenceType) {
                     type = new SingletonType(type);
                   }
-                  await arc.createStore(type, handle.localName, handle.id, handle.tags, handle.storageKey);
+                  await arc.arcInfo.createStoreInfo(type, {name: handle.localName, id: handle.id, tags: handle.tags, storageKey: handle.storageKey});
                 }
               }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -81,10 +81,10 @@ export class Runtime {
   /**
    * Given an arc, returns it's description as a string.
    */
-  async getArcDescription(arc: Arc) : Promise<string> {
+  async getArcDescription(arcId: ArcId) : Promise<string> {
     // Verify that it's one of my arcs, and make this non-static, once I have
     // Runtime objects in the calling code.
-    return (await Description.create(arc)).getArcDescription();
+    return (await Description.create(this.getArcById(arcId), this)).getArcDescription();
   }
 
   async resolveRecipe(arc: Arc, recipe: Recipe): Promise<Recipe | null> {

--- a/src/runtime/storage/direct-storage-endpoint-manager.ts
+++ b/src/runtime/storage/direct-storage-endpoint-manager.ts
@@ -9,27 +9,47 @@
  */
 import {assert} from '../../platform/assert-web.js';
 import {CRDTTypeRecord} from '../../crdt//lib-crdt.js';
-import {TypeToCRDTTypeRecord, CRDTTypeRecordToType} from './storage.js';
+import {TypeToCRDTTypeRecord, CRDTTypeRecordToType, MuxEntityType, ToHandle, CRDTMuxEntity} from './storage.js';
 import {ProxyMessage, StorageCommunicationEndpoint} from './store-interface.js';
 import {ActiveStore} from './active-store.js';
 import {Type} from '../../types/lib-types.js';
 import {StoreInfo} from './store-info.js';
 import {StorageKey} from './storage-key.js';
 import {Exists} from './drivers/driver.js';
-import {StorageService} from './storage-service.js';
+import {StorageService, HandleOptions} from './storage-service.js';
 import {Consumer} from '../../utils/lib-utils.js';
 import {DirectStorageEndpoint} from './direct-storage-endpoint.js';
 import {DriverFactory} from './drivers/driver-factory.js';
 import {StorageKeyParser} from './storage-key-parser.js';
+import {MuxType, SingletonType} from '../../types/lib-types.js';
+import {SingletonHandle, CollectionHandle} from './handle.js';
+import {EntityHandleFactory} from './entity-handle-factory.js';
+import {StorageProxyMuxer} from './storage-proxy-muxer.js';
+import {IdGenerator} from '../id.js';
+import {StorageProxy} from './storage-proxy.js';
+import {Mutex} from '../../utils/lib-utils.js';
 
 export class DirectStorageEndpointManager implements StorageService {
   // All the stores, mapped by store ID
   private readonly activeStoresByKey = new Map<StorageKey, ActiveStore<CRDTTypeRecord>>();
+  private readonly activeStoreMutex = new Mutex();
 
   constructor(private readonly driverFactory: DriverFactory,
               private readonly storageKeyParser: StorageKeyParser) {}
 
   async getActiveStore<T extends Type>(storeInfo: StoreInfo<T>): Promise<ActiveStore<TypeToCRDTTypeRecord<T>>> {
+    if (!this.activeStoresByKey.has(storeInfo.storageKey)) {
+      const release = await this.activeStoreMutex.acquire();
+      try {
+        await this.getActiveStoreImpl(storeInfo);
+      } finally {
+        release();
+      }
+    }
+    return this.activeStoresByKey.get(storeInfo.storageKey) as ActiveStore<TypeToCRDTTypeRecord<T>>;
+  }
+
+  private async getActiveStoreImpl<T extends Type>(storeInfo: StoreInfo<T>): Promise<void> {
     if (!this.activeStoresByKey.has(storeInfo.storageKey)) {
       if (ActiveStore.constructors.get(storeInfo.mode) == null) {
         throw new Error(`StorageMode ${storeInfo.mode} not yet implemented`);
@@ -47,7 +67,6 @@ export class DirectStorageEndpointManager implements StorageService {
       }));
       storeInfo.exists = Exists.ShouldExist;
     }
-    return this.activeStoresByKey.get(storeInfo.storageKey) as ActiveStore<TypeToCRDTTypeRecord<T>>;
   }
 
   async onRegister(storeInfo: StoreInfo<Type>, messagesCallback: Consumer<{}>, idCallback: Consumer<{}>) {
@@ -67,5 +86,31 @@ export class DirectStorageEndpointManager implements StorageService {
     return new DirectStorageEndpoint(
       this.activeStoresByKey.get(storeInfo.storageKey) as ActiveStore<TypeToCRDTTypeRecord<T>>,
       this.storageKeyParser);
+  }
+
+  async handleForStoreInfo<T extends Type>(storeInfo: StoreInfo<T>, id: string, idGenerator: IdGenerator, options?: HandleOptions): Promise<ToHandle<TypeToCRDTTypeRecord<T>>> {
+    options = options || {};
+    await this.getActiveStore(storeInfo);
+    const type = options.type || storeInfo.type;
+    const particle = options.particle || null;
+    const canRead = (options.canRead != undefined) ? options.canRead : true;
+    const canWrite = (options.canWrite != undefined) ? options.canWrite : true;
+    const name = options.name || null;
+
+    if (storeInfo.type instanceof MuxType) {
+      const muxStoreInfo = storeInfo as unknown as StoreInfo<MuxEntityType>;
+      const proxyMuxer = new StorageProxyMuxer<CRDTMuxEntity>(this.getStorageEndpoint(muxStoreInfo));
+      return new EntityHandleFactory(proxyMuxer) as ToHandle<TypeToCRDTTypeRecord<T>>;
+    } else {
+      const proxy = new StorageProxy<TypeToCRDTTypeRecord<T>>(
+        this.getStorageEndpoint(storeInfo), options.ttl);
+      if (type instanceof SingletonType) {
+        // tslint:disable-next-line: no-any
+        return new SingletonHandle(id, proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<TypeToCRDTTypeRecord<T>>;
+      } else {
+        // tslint:disable-next-line: no-any
+        return new CollectionHandle(id, proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<TypeToCRDTTypeRecord<T>>;
+      }
+    }
   }
 }

--- a/src/runtime/storage/drivers/tests/volatile-test.ts
+++ b/src/runtime/storage/drivers/tests/volatile-test.ts
@@ -107,29 +107,29 @@ describe('VolatileStorageDriverProvider', () => {
   });
 
   it('supports VolatileStorageKeys for the same Arc ID', async () => {
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')})).id);
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new VolatileStorageKey(arc.id, 'unique');
     assert.isTrue(provider.willSupport(storageKey));
   });
 
   it('does not support VolatileStorageKeys with a different Arc ID', async () => {
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')})).id);
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new VolatileStorageKey(ArcId.newForTest('some-other-arc'), 'unique');
     assert.isFalse(provider.willSupport(storageKey));
   });
 
   it('does not support RamDiskStorageKeys', async () => {
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')})).id);
     const provider = new VolatileStorageDriverProvider(arc);
     const storageKey = new RamDiskStorageKey('unique');
     assert.isFalse(provider.willSupport(storageKey));
   });
 
   it('uses separate memory for each arc', async () => {
-    const arc1 = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc1', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
-    const arc2 = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc2', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')}));
+    const arc1 = runtime.getArcById((await runtime.allocator.startArc({arcName: 'arc1', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')})).id);
+    const arc2 = runtime.getArcById((await runtime.allocator.startArc({arcName: 'arc2', storageKeyPrefix: id => new VolatileStorageKey(id, 'prefix')})).id);
     const provider1 = new VolatileStorageDriverProvider(arc1);
     const provider2 = new VolatileStorageDriverProvider(arc2);
     const storageKey1 = new VolatileStorageKey(arc1.id, 'unique');

--- a/src/runtime/storage/storage-service.ts
+++ b/src/runtime/storage/storage-service.ts
@@ -8,7 +8,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import {CRDTTypeRecord} from '../../crdt/internal/crdt.js';
-import {CRDTMuxEntity, TypeToCRDTTypeRecord, CRDTTypeRecordToType} from './storage.js';
+import {CRDTMuxEntity, TypeToCRDTTypeRecord, CRDTTypeRecordToType, ToHandle} from './storage.js';
 import {ProxyMessage, StorageCommunicationEndpoint} from './store-interface.js';
 import {ActiveStore} from './active-store.js';
 import {Type} from '../../types/lib-types.js';
@@ -17,6 +17,9 @@ import {StoreInfo} from './store-info.js';
 import {StorageKey} from './storage-key.js';
 import {Exists} from './drivers/driver.js';
 import {Consumer} from '../../utils/lib-utils.js';
+import {IdGenerator} from '../id.js';
+import {Ttl} from '../capabilities.js';
+import {Particle} from '../particle.js';
 
 /**
  * Storage stack API.
@@ -40,4 +43,18 @@ export interface StorageService {
    * Returns StorageCommunicationEndpoint correponding to the given StoreInfo (an underlying ActiveStore must exist).
    */
   getStorageEndpoint<T extends Type>(storeInfo: StoreInfo<T>): StorageCommunicationEndpoint<TypeToCRDTTypeRecord<T>>;
+
+  /**
+   * Returns Handle correponding to the given StoreInfo (an underlying ActiveStore must exist).
+   */
+  handleForStoreInfo<T extends Type>(storeInfo: StoreInfo<T>, id: string, idGenerator: IdGenerator, options?: HandleOptions): Promise<ToHandle<TypeToCRDTTypeRecord<T>>>;
 }
+
+export type HandleOptions = {
+  type?: Type;
+  ttl?: Ttl;
+  particle?: Particle;
+  canRead?: boolean;
+  canWrite?: boolean;
+  name?: string;
+};

--- a/src/runtime/storage/storage.ts
+++ b/src/runtime/storage/storage.ts
@@ -8,39 +8,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {StorageProxy} from './storage-proxy.js';
 import {Type, CollectionType, EntityType, ReferenceType, SingletonType, InterfaceType, MuxType} from '../../types/lib-types.js';
 import {CRDTTypeRecord, CRDTSingletonTypeRecord, CRDTCollectionTypeRecord, CRDTEntityTypeRecord, Identified} from '../../crdt/lib-crdt.js';
-import {Ttl} from '../capabilities.js';
 import {SingletonHandle, CollectionHandle, Handle} from './handle.js';
-import {Particle} from '../particle.js';
 import {ActiveStore} from './active-store.js';
 import {Entity, SerializedEntity} from '../entity.js';
-import {Id, IdGenerator} from '../id.js';
 import {ParticleSpec, StorableSerializedParticleSpec} from '../arcs-types/particle-spec.js';
 import {SerializedReference, Reference} from '../reference.js';
-import {StorageKey} from './storage-key.js';
-import {Exists} from './drivers/driver.js';
 import {EntityHandleFactory} from './entity-handle-factory.js';
-import {StorageProxyMuxer} from './storage-proxy-muxer.js';
-import {DirectStoreMuxer} from './direct-store-muxer.js';
-import {StoreInfo} from './store-info.js';
-import {StorageService} from './storage-service.js';
-
-type HandleOptions = {
-  type?: Type;
-  ttl?: Ttl;
-  particle?: Particle;
-  canRead?: boolean;
-  canWrite?: boolean;
-  name?: string;
-};
-
-type ArcLike = {
-  generateID: () => Id;
-  idGenerator: IdGenerator;
-  storageService: StorageService;
-};
 
 export type SingletonEntityType = SingletonType<EntityType>;
 export type CRDTEntitySingleton = CRDTSingletonTypeRecord<SerializedEntity>;
@@ -110,49 +85,4 @@ export type ToHandle<T extends CRDTTypeRecord>
 
 export function handleType<T extends Handle<CRDTTypeRecord>>(handle: T) {
   return handle.type as HandleToType<T>;
-}
-
-export async function newHandle<T extends Type>(
-  storeInfo: StoreInfo<T>,
-  arc: ArcLike,
-  options: HandleOptions = {}
-): Promise<ToHandle<TypeToCRDTTypeRecord<T>>> {
-  storeInfo.exists = Exists.MayExist;
-  return handleForStoreInfo(storeInfo, arc, options);
-}
-
-export function handleForActiveStore<T extends Type>(
-  storeInfo: StoreInfo<T>,
-  arc: ArcLike,
-  options: HandleOptions = {}
-): ToHandle<TypeToCRDTTypeRecord<T>> {
-  const type = options.type || storeInfo.type;
-  const storageKey = storeInfo.storageKey.toString();
-
-  const idGenerator = arc.idGenerator;
-  const particle = options.particle || null;
-  const canRead = (options.canRead != undefined) ? options.canRead : true;
-  const canWrite = (options.canWrite != undefined) ? options.canWrite : true;
-  const name = options.name || null;
-  const generateID = arc.generateID ? () => arc.generateID().toString() : () => '';
-  if (storeInfo.type instanceof MuxType) {
-    const muxStoreInfo = storeInfo as unknown as StoreInfo<MuxEntityType>;
-    const proxyMuxer = new StorageProxyMuxer<CRDTMuxEntity>(arc.storageService.getStorageEndpoint(muxStoreInfo));
-    return new EntityHandleFactory(proxyMuxer) as ToHandle<TypeToCRDTTypeRecord<T>>;
-  } else {
-    const proxy = new StorageProxy<TypeToCRDTTypeRecord<T>>(
-      arc.storageService.getStorageEndpoint(storeInfo), options.ttl);
-    if (type instanceof SingletonType) {
-      // tslint:disable-next-line: no-any
-      return new SingletonHandle(generateID(), proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<TypeToCRDTTypeRecord<T>>;
-    } else {
-      // tslint:disable-next-line: no-any
-      return new CollectionHandle(generateID(), proxy as any, idGenerator, particle, canRead, canWrite, name) as ToHandle<TypeToCRDTTypeRecord<T>>;
-    }
-  }
-}
-
-export async function handleForStoreInfo<T extends Type>(storeInfo: StoreInfo<T>, arc: ArcLike, options?: HandleOptions): Promise<ToHandle<TypeToCRDTTypeRecord<T>>> {
-  await arc.storageService.getActiveStore(storeInfo);
-  return handleForActiveStore(storeInfo, arc, options);
 }

--- a/src/runtime/storage/tests/store-sequence-test.ts
+++ b/src/runtime/storage/tests/store-sequence-test.ts
@@ -176,7 +176,8 @@ describe('Store Sequence', async () => {
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
       const storageService = runtime.storageService;
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc'}));
+      const arcInfo = await runtime.allocator.startArc({arcName: 'arc'});
+      const arc = runtime.getArcById(arcInfo.id);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate, storageService);
       const activeStore2 = await createStore(storageKey, Exists.ShouldExist, storageService);
@@ -273,7 +274,8 @@ describe('Store Sequence', async () => {
     const sequenceTest = new SequenceTest();
     sequenceTest.setTestConstructor(async () => {
       const runtime = new Runtime();
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, '')}));
+      const arcInfo = await runtime.allocator.startArc({arcName: 'arc', storageKeyPrefix: id => new VolatileStorageKey(id, '')});
+      const arc = runtime.getArcById(arcInfo.id);
       const storageKey = new VolatileStorageKey(arc.id, 'unique');
       const activeStore1 = await createStore(storageKey, Exists.ShouldCreate, runtime.storageService);
       const activeStore2 = await createStore(storageKey, Exists.ShouldExist, runtime.storageService);

--- a/src/runtime/testing/manifest-integration-test-setup.ts
+++ b/src/runtime/testing/manifest-integration-test-setup.ts
@@ -21,7 +21,7 @@ export async function manifestTestSetup() {
   const manifest = await Manifest.load('./src/runtime/tests/artifacts/test.manifest', loader, registry);
   assert(manifest);
   const runtime = new Runtime({loader, context: manifest});
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+  const arc = await runtime.allocator.startArc({arcName: 'test'});
   const recipe = manifest.recipes[0];
   assert(recipe.normalize());
   assert(recipe.isResolved());

--- a/src/runtime/tests/allocator-test.ts
+++ b/src/runtime/tests/allocator-test.ts
@@ -31,10 +31,10 @@ describe('Allocator', () => {
     const host = new ArcHostImpl('myhost', runtime);
     allocator.registerArcHost(new SingletonArcHostFactory(host));
 
-    const arcId = await allocator.startArc({planName: 'TestRecipe', arcName: 'test'});
-    const arc = host.getArcById(arcId);
-    assert.equal(arc.id, arcId);
-    assert.equal(arc.activeRecipe.name, 'TestRecipe');
+    const arcInfo = await allocator.startArc({planName: 'TestRecipe', arcName: 'test'});
+    const arc = host.getArcById(arcInfo.id);
+    assert.equal(arc.id, arcInfo.id);
+    assert.equal(arcInfo.activeRecipe.name, 'TestRecipe');
   });
 
   // TODO(b/182410550): Add more tests. Currently Allocator functionality is tested

--- a/src/runtime/tests/arc-test.ts
+++ b/src/runtime/tests/arc-test.ts
@@ -32,7 +32,7 @@ import {Entity} from '../entity.js';
 import {RamDiskStorageDriverProvider} from '../storage/drivers/ramdisk.js';
 import {ReferenceModeStorageKey} from '../storage/reference-mode-storage-key.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
-import {handleForStoreInfo, SingletonEntityType, CollectionEntityType} from '../storage/storage.js';
+import {SingletonEntityType, CollectionEntityType} from '../storage/storage.js';
 import {Capabilities, Ttl, Queryable, Persistence} from '../capabilities.js';
 import {StoreInfo} from '../storage/store-info.js';
 
@@ -50,11 +50,10 @@ async function setup(storageKeyPrefix:  (arcId: ArcId) => StorageKey) {
         bar: writes handle1
   `, {loader, memoryProvider, fileName: process.cwd() + '/input.manifest'});
   const runtime = new Runtime({loader, context: manifest, memoryProvider});
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
-
+  const arcInfo = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
   return {
     runtime,
-    arc,
+    arcInfo,
     context: manifest,
     recipe: manifest.recipes[0],
     Foo: Entity.createEntityClass(manifest.findSchemaByName('Foo'), null),
@@ -96,18 +95,19 @@ describe('Arc new storage', () => {
     const runtime = new Runtime({loader});
     runtime.context = await runtime.parseFile('./manifest');
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
+    const arc = runtime.getArcById(arcInfo.id);
 
     const dataClass = Entity.createEntityClass(runtime.context.findSchemaByName('Data'), null);
-    const varStore = await arc.createStore(new SingletonType(dataClass.type), undefined, 'test:0');
-    const colStore = await arc.createStore(dataClass.type.collectionOf(), undefined, 'test:1');
+    const varStore = await arcInfo.createStoreInfo(new SingletonType(dataClass.type), {id: 'test:0'});
+    const colStore = await arcInfo.createStoreInfo(dataClass.type.collectionOf(), {id: 'test:1'});
 
-    const refVarKey  = new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'colVar'), new VolatileStorageKey(arc.id, 'refVar'));
-    const refVarStore = await arc.createStore(new SingletonType(dataClass.type), undefined, 'test:2', [], refVarKey);
+    const refVarKey = new ReferenceModeStorageKey(new VolatileStorageKey(arcInfo.id, 'colVar'), new VolatileStorageKey(arcInfo.id, 'refVar'));
+    const refVarStore = await arcInfo.createStoreInfo(new SingletonType(dataClass.type), {id: 'test:2', storageKey: refVarKey});
 
-    const varHandle = await handleForStoreInfo(varStore, arc);
-    const colHandle = await handleForStoreInfo(colStore, arc);
-    const refVarHandle = await handleForStoreInfo(refVarStore, arc);
+    const varHandle = await runtime.host.handleForStoreInfo(varStore, arcInfo);
+    const colHandle = await runtime.host.handleForStoreInfo(colStore, arcInfo);
+    const refVarHandle = await runtime.host.handleForStoreInfo(refVarStore, arcInfo);
 
     // Populate the stores, run the arc and get its serialization.
     const d1 = new dataClass({value: 'v1'});
@@ -124,29 +124,29 @@ describe('Arc new storage', () => {
     recipe.handles[1].mapToStorage(colStore);
     recipe.handles[2].mapToStorage(refVarStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
 
     const serialization = await arc.serialize();
-    runtime.allocator.stopArc(arc.id);
+    runtime.allocator.stopArc(arcInfo.id);
 
     await varHandle.clear();
     await colHandle.clear();
     await refVarHandle.clear();
 
-    const arc2 = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: ''}));
+    const arc2 = await runtime.allocator.deserialize({serialization, fileName: ''});
     const varStore2 = arc2.findStoreById(varStore.id) as StoreInfo<SingletonEntityType>;
     const colStore2 = arc2.findStoreById(colStore.id) as StoreInfo<CollectionEntityType>;
     const refVarStore2 = arc2.findStoreById(refVarStore.id) as StoreInfo<SingletonEntityType>;
 
-    const varHandle2 = await handleForStoreInfo(varStore2, arc2);
+    const varHandle2 = await runtime.host.handleForStoreInfo(varStore2, arc2);
     const varData = await varHandle2.fetch();
     assert.deepEqual(varData, d1);
 
-    const colHandle2 = await handleForStoreInfo(colStore2, arc2);
+    const colHandle2 = await runtime.host.handleForStoreInfo(colStore2, arc2);
     const colData = await colHandle2.toList();
     assert.deepEqual(colData, [d2, d3]);
 
-    const refVarHandle2 = await handleForStoreInfo(refVarStore2, arc2);
+    const refVarHandle2 = await runtime.host.handleForStoreInfo(refVarStore2, arc2);
     const refVarData = await refVarHandle2.fetch();
     assert.deepEqual(refVarData, d4);
   });
@@ -170,21 +170,22 @@ describe('Arc new storage', () => {
     `;
     const manifest = await runtime.parse(manifestText, {fileName: process.cwd() + '/input.manifest'});
     runtime.context = manifest;
-    const arc = runtime.getArcById(await runtime.allocator.startArc({
+    const arcInfo = await runtime.allocator.startArc({
       arcName: 'test',
       storageKeyPrefix: ramDiskStorageKeyPrefixForTest(),
       planName: 'TestPlan'
-    }));
+    });
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     // Reference mode store and its backing and container stores.
-    assert.lengthOf(arc.activeRecipe.handles, 3);
-    const key = arc.activeRecipe.particles[0].connections['thing'].handle.storageKey;
+    assert.lengthOf(arcInfo.activeRecipe.handles, 3);
+    const key = arcInfo.activeRecipe.particles[0].connections['thing'].handle.storageKey;
     assert.instanceOf(key, ReferenceModeStorageKey);
     const refKey = key as ReferenceModeStorageKey;
     assert.instanceOf(refKey.backingKey, VolatileStorageKey);
     assert.instanceOf(refKey.storageKey, VolatileStorageKey);
-    assert.isTrue(key.toString().includes(arc.id.toString()));
+    assert.isTrue(key.toString().includes(arcInfo.id.toString()));
   }));
 });
 
@@ -193,39 +194,39 @@ const doSetup = async () => setup(arcId => new VolatileStorageKey(arcId, ''));
 describe('Arc', () => {
   it('idle can safely be called multiple times ', async () => {
     const runtime = new Runtime();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test'})).id);
     const f = async () => { await arc.idle; };
     await Promise.all([f(), f()]);
   });
 
   it('applies existing stores to a particle', async () => {
-    const {runtime, arc, recipe, Foo, Bar} = await doSetup();
-    const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
-    const barStore = await arc.createStore(new SingletonType(Bar.type), undefined, 'test:2');
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
-    const barHandle = await handleForStoreInfo(barStore, arc);
+    const {runtime, arcInfo, recipe, Foo, Bar} = await doSetup();
+    const fooStore = await arcInfo.createStoreInfo(new SingletonType(Foo.type), {id: 'test:1'});
+    const barStore = await arcInfo.createStoreInfo(new SingletonType(Bar.type), {id: 'test:2'});
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
+    const barHandle = await runtime.host.handleForStoreInfo(barStore, arcInfo);
 
     await fooHandle.set(new Foo({value: 'a Foo'}));
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    await runtime.getArcById(arcInfo.id).idle;
     assert.deepStrictEqual(await barHandle.fetch() as {}, {value: 'a Foo1'});
   });
 
   it('applies new stores to a particle ', async () => {
-    const {runtime, arc, recipe, Foo, Bar} = await doSetup();
-    const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
-    const barStore = await arc.createStore(new SingletonType(Bar.type), undefined, 'test:2');
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
-    const barHandle = await handleForStoreInfo(barStore, arc);
+    const {runtime, arcInfo, recipe, Foo, Bar} = await doSetup();
+    const fooStore = await arcInfo.createStoreInfo(new SingletonType(Foo.type), {id: 'test:1'});
+    const barStore = await arcInfo.createStoreInfo(new SingletonType(Bar.type), {id: 'test:2'});
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
+    const barHandle = await runtime.host.handleForStoreInfo(barStore, arcInfo);
 
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
 
     await fooHandle.set(new Foo({value: 'a Foo'}));
-    await arc.idle;
+    await runtime.getArcById(arcInfo.id).idle;
     assert.deepStrictEqual(await barHandle.fetch() as {}, {value: 'a Foo1'});
   });
 
@@ -252,28 +253,28 @@ describe('Arc', () => {
           b: writes thingB
     `, {fileName: process.cwd() + '/input.manifest'});
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
 
     const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-    const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-    const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-    const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-    const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStoreInfo(aStore, arc);
-    const bHandle = await handleForStoreInfo(bStore, arc);
-    const cHandle = await handleForStoreInfo(cStore, arc);
-    const dHandle = await handleForStoreInfo(dStore, arc);
+    const aStore = await arcInfo.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+    const bStore = await arcInfo.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+    const cStore = await arcInfo.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+    const dStore = await arcInfo.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
+    const aHandle = await runtime.host.handleForStoreInfo(aStore, arcInfo);
+    const bHandle = await runtime.host.handleForStoreInfo(bStore, arcInfo);
+    const cHandle = await runtime.host.handleForStoreInfo(cStore, arcInfo);
+    const dHandle = await runtime.host.handleForStoreInfo(dStore, arcInfo);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
     recipe.handles[1].mapToStorage(bStore);
     recipe.handles[2].mapToStorage(cStore); // These might not be needed?
     recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
 
     await aHandle.set(new thingClass({value: 'from_a'}));
     await cHandle.set(new thingClass({value: 'from_c'}));
-    await arc.idle;
+    await runtime.getArcById(arcInfo.id).idle;
     assert.deepStrictEqual(await bHandle.fetch() as {}, {value: 'from_a1'});
     assert.isNull(await dHandle.fetch());
   });
@@ -326,16 +327,16 @@ describe('Arc', () => {
       assert.isTrue(e.toString().includes('store \'storeInContext\'')); // with "use" fate was not found'));
     }
 
-    const arc = await runtime.getArcById(await runtime.allocator.startArc({arcName: 'test2'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test2'});
     const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-    await arc.createStore(new SingletonType(thingClass.type), 'name', 'storeInArc');
-    const resolver = new RecipeResolver(arc);
+    await arcInfo.createStoreInfo(new SingletonType(thingClass.type), {name: 'name', id: 'storeInArc'});
+    const resolver = new RecipeResolver(runtime.getArcById(arcInfo.id));
 
     // Fails resolving a recipe with 'copy' handle for store in the arc (not in context).
     assert.isNull(await resolver.resolve(manifest.recipes[2]));
     const recipe3 = await resolver.resolve(manifest.recipes[3]);
     // Successfully instantiates a recipe with 'use' handle for store in an arc.
-    await runtime.allocator.runPlanInArc(arc.id, recipe3);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe3);
   });
 
   it('required provided handles do not resolve without parent', async () => {
@@ -361,28 +362,28 @@ describe('Arc', () => {
           b: writes thingB
     `, {fileName: process.cwd() + '/input.manifest'});
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = await runtime.allocator.startArc({arcName: 'test'});
 
     const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-    const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-    const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-    const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-    const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStoreInfo(aStore, arc);
-    const bHandle = await handleForStoreInfo(bStore, arc);
-    const cHandle = await handleForStoreInfo(cStore, arc);
-    const dHandle = await handleForStoreInfo(dStore, arc);
+    const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+    const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+    const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+    const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
+    const aHandle = await runtime.host.handleForStoreInfo(aStore, arc);
+    const bHandle = await runtime.host.handleForStoreInfo(bStore, arc);
+    const cHandle = await runtime.host.handleForStoreInfo(cStore, arc);
+    const dHandle = await runtime.host.handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
     recipe.handles[1].mapToStorage(bStore);
     recipe.handles[2].mapToStorage(cStore); // These might not be needed?
     recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
 
     await aHandle.set(new thingClass({value: 'from_a'}));
     await cHandle.set(new thingClass({value: 'from_c'}));
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
     assert.deepStrictEqual(await bHandle.fetch() as {}, {value: 'from_a1'});
     assert.isNull(await dHandle.fetch());
   });
@@ -411,20 +412,20 @@ describe('Arc', () => {
             b: writes thingB
             d: writes maybeThingD
       `, {fileName: process.cwd() + '/input.manifest'});
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+      const arc = await runtime.allocator.startArc({arcName: 'test'});
 
       const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-      const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-      const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-      const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-      const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
+      const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+      const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+      const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+      const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
 
       const recipe = manifest.recipes[0];
       recipe.handles[0].mapToStorage(aStore);
       recipe.handles[1].mapToStorage(bStore);
       recipe.handles[2].mapToStorage(cStore); // These might not be needed?
       recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-      await runtime.allocator.runPlanInArc(arc.id, recipe);
+      await runtime.allocator.runPlanInArc(arc, recipe);
     },
     /.*unresolved handle-connection: parent connection 'c' missing/);
   });
@@ -454,20 +455,20 @@ describe('Arc', () => {
             d: writes maybeThingD
       `, {fileName: process.cwd() + '/input.manifest'});
 
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+      const arc = await runtime.allocator.startArc({arcName: 'test'});
 
       const thingClass = Entity.createEntityClass(context.findSchemaByName('Thing'), null);
-      const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-      const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-      const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-      const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
+      const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+      const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+      const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+      const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
 
       const recipe = context.recipes[0];
       recipe.handles[0].mapToStorage(aStore);
       recipe.handles[1].mapToStorage(bStore);
       recipe.handles[2].mapToStorage(cStore); // These might not be needed?
       recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-      await runtime.allocator.runPlanInArc(arc.id, recipe);
+      await runtime.allocator.runPlanInArc(arc, recipe);
     },
     /.*unresolved handle-connection: parent connection 'c' missing/);
   });
@@ -495,30 +496,31 @@ describe('Arc', () => {
           b: writes thingB
           c: reads maybeThingC
     `, {fileName: process.cwd() + '/input.manifest'});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = await runtime.allocator.startArc({arcName: 'test'});
 
     const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-    const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-    const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-    const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-    const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStoreInfo(aStore, arc);
-    const bHandle = await handleForStoreInfo(bStore, arc);
-    const cHandle = await handleForStoreInfo(cStore, arc);
-    const dHandle = await handleForStoreInfo(dStore, arc);
+    const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+    const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+    const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+    const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
+
+    const aHandle = await runtime.host.handleForStoreInfo(aStore, arc);
+    const bHandle = await runtime.host.handleForStoreInfo(bStore, arc);
+    const cHandle = await runtime.host.handleForStoreInfo(cStore, arc);
+    const dHandle = await runtime.host.handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
     recipe.handles[1].mapToStorage(bStore);
     recipe.handles[2].mapToStorage(cStore); // These might not be needed?
     recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
 
     await aHandle.set(new thingClass({value: 'from_a'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
     await cHandle.set(new thingClass({value: 'from_c'}));
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
     assert.deepStrictEqual(await bHandle.fetch() as {}, {value: 'from_a1'});
     assert.isNull(await dHandle.fetch());
   });
@@ -547,20 +549,21 @@ describe('Arc', () => {
             b: writes thingB
             c: reads maybeThingC
       `, {fileName: process.cwd() + '/input.manifest'});
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+      const arc = await runtime.allocator.startArc({arcName: 'test'});
 
       const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-      const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-      const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-      const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-      const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
+
+      const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+      const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+      const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+      const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
 
       const recipe = manifest.recipes[0];
       recipe.handles[0].mapToStorage(aStore);
       recipe.handles[1].mapToStorage(bStore);
       recipe.handles[2].mapToStorage(cStore); // These might not be needed?
       recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-      await runtime.allocator.runPlanInArc(arc.id, recipe);
+      await runtime.allocator.runPlanInArc(arc, recipe);
     },
     /.*unresolved particle: unresolved connections/);
   });
@@ -589,28 +592,28 @@ describe('Arc', () => {
           c: reads maybeThingC
           d: writes maybeThingD
     `, {fileName: process.cwd() + '/input.manifest'});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = await runtime.allocator.startArc({arcName: 'test'});
 
     const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-    const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-    const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-    const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-    const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStoreInfo(aStore, arc);
-    const bHandle = await handleForStoreInfo(bStore, arc);
-    const cHandle = await handleForStoreInfo(cStore, arc);
-    const dHandle = await handleForStoreInfo(dStore, arc);
+    const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+    const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+    const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+    const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
+    const aHandle = await runtime.host.handleForStoreInfo(aStore, arc);
+    const bHandle = await runtime.host.handleForStoreInfo(bStore, arc);
+    const cHandle = await runtime.host.handleForStoreInfo(cStore, arc);
+    const dHandle = await runtime.host.handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
     recipe.handles[1].mapToStorage(bStore);
     recipe.handles[2].mapToStorage(cStore); // These might not be needed?
     recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
 
     await aHandle.set(new thingClass({value: 'from_a'}));
     await cHandle.set(new thingClass({value: 'from_c'}));
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
     assert.deepStrictEqual(await bHandle.fetch() as {}, {value: 'from_a1'});
     assert.deepStrictEqual(await dHandle.fetch() as {}, {value: 'from_c1'});
   });
@@ -639,79 +642,81 @@ describe('Arc', () => {
           c: reads maybeThingC
           d: writes maybeThingD
     `, {fileName: process.cwd() + '/input.manifest'});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = await runtime.allocator.startArc({arcName: 'test'});
 
     const thingClass = Entity.createEntityClass(manifest.findSchemaByName('Thing'), null);
-    const aStore = await arc.createStore(new SingletonType(thingClass.type), 'aStore', 'test:1');
-    const bStore = await arc.createStore(new SingletonType(thingClass.type), 'bStore', 'test:2');
-    const cStore = await arc.createStore(new SingletonType(thingClass.type), 'cStore', 'test:3');
-    const dStore = await arc.createStore(new SingletonType(thingClass.type), 'dStore', 'test:4');
-    const aHandle = await handleForStoreInfo(aStore, arc);
-    const bHandle = await handleForStoreInfo(bStore, arc);
-    const cHandle = await handleForStoreInfo(cStore, arc);
-    const dHandle = await handleForStoreInfo(dStore, arc);
+    const aStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'aStore', id: 'test:1'});
+    const bStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'bStore', id: 'test:2'});
+    const cStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'cStore', id: 'test:3'});
+    const dStore = await arc.createStoreInfo(new SingletonType(thingClass.type), {name: 'dStore', id: 'test:4'});
+    const aHandle = await runtime.host.handleForStoreInfo(aStore, arc);
+    const bHandle = await runtime.host.handleForStoreInfo(bStore, arc);
+    const cHandle = await runtime.host.handleForStoreInfo(cStore, arc);
+    const dHandle = await runtime.host.handleForStoreInfo(dStore, arc);
 
     const recipe = manifest.recipes[0];
     recipe.handles[0].mapToStorage(aStore);
     recipe.handles[1].mapToStorage(bStore);
     recipe.handles[2].mapToStorage(cStore); // These might not be needed?
     recipe.handles[3].mapToStorage(dStore); // These might not be needed?
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
 
     await aHandle.set(new thingClass({value: 'from_a'}));
     await cHandle.set(new thingClass({value: 'from_c'}));
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
     assert.deepStrictEqual(await bHandle.fetch() as {}, {value: 'from_a1'});
     assert.deepStrictEqual(await dHandle.fetch() as {}, {value: 'from_c1'});
   });
 
   it('deserializing a serialized empty arc produces an empty arc', async () => {
     const runtime = new Runtime();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test'})).id);
     await arc.idle;
 
     const serialization = await arc.serialize();
     runtime.allocator.stopArc(arc.id);
 
-    const newArc = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: 'foo.manifest'}));
+    const newArcInfo = await runtime.allocator.deserialize({serialization, fileName: 'foo.manifest'});
+    const newArc = runtime.getArcById(newArcInfo.id);
     await newArc.idle;
-    assert.strictEqual(newArc.stores.length, 0);
+    assert.strictEqual(newArcInfo.stores.length, 0);
     // Note: when empty arc is deserialized @active annotation isn't set on
     // the Arc's activeRecipe because `host.start` is never actually called
     // with an empty partition, and `arc.instantiate` isn't executed.
-    assert.strictEqual(newArc.activeRecipe.toString(),
+    assert.strictEqual(newArcInfo.activeRecipe.toString(),
                       `${arc.activeRecipe.toString()}`);
-    assert.strictEqual(newArc.id.idTreeAsString(), 'test');
-    newArc.dispose();
+    assert.strictEqual(newArcInfo.id.idTreeAsString(), 'test');
+    runtime.allocator.stopArc(newArcInfo.id);
   });
 
   it('deserializing a simple serialized arc produces that arc', async () => {
-    const {runtime, arc, context, recipe, Foo, Bar, loader} = await doSetup();
-    let fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
+    const {runtime, arcInfo, context, recipe, Foo, Bar, loader} = await doSetup();
+    const arc = runtime.getArcById(arcInfo.id);
+    let fooStore = await arcInfo.createStoreInfo(new SingletonType(Foo.type), {id: 'test:1'});
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
     const fooStoreCallbacks = CallbackTracker.create(await arc.getActiveStore(fooStore), 1);
     await fooHandle.set(new Foo({value: 'a Foo'}));
 
-    let barStore = await arc.createStore(new SingletonType(Bar.type), undefined, 'test:2', ['tag1', 'tag2']);
-    const barHandle = await handleForStoreInfo(barStore, arc);
+    let barStore = await arcInfo.createStoreInfo(new SingletonType(Bar.type), {id: 'test:2', tags: ['tag1', 'tag2']});
+    const barHandle = await runtime.host.handleForStoreInfo(barStore, arcInfo);
 
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(barStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
     await arc.idle;
 
     assert.deepStrictEqual(await barHandle.fetch() as {}, {value: 'a Foo1'});
     fooStoreCallbacks.verify();
     const serialization = await arc.serialize();
-    runtime.allocator.stopArc(arc.id);
+    runtime.allocator.stopArc(arcInfo.id);
 
-    const newArc = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: '', slotComposer: new SlotComposer()}));
-    await newArc.idle;
-    fooStore = newArc.findStoreById(fooStore.id) as StoreInfo<SingletonEntityType>;
-    barStore = newArc.findStoreById(barStore.id) as StoreInfo<SingletonEntityType>;
+    const newArcInfo = await runtime.allocator.deserialize({serialization, fileName: '', slotComposer: new SlotComposer()});
+    await runtime.getArcById(newArcInfo.id).idle;
+    fooStore = newArcInfo.findStoreById(fooStore.id) as StoreInfo<SingletonEntityType>;
+    barStore = newArcInfo.findStoreById(barStore.id) as StoreInfo<SingletonEntityType>;
     assert(fooStore);
     assert(barStore);
-    assert.lengthOf(newArc.findStoresByType(new SingletonType(Bar.type), {tags: ['tag1']}), 1);
+    assert.lengthOf(newArcInfo.findStoresByType(new SingletonType(Bar.type), {tags: ['tag1']}), 1);
   });
 
   it('serializes immediate value handles correctly', async () => {
@@ -735,10 +740,11 @@ describe('Arc', () => {
 
     const runtime = new Runtime({loader});
     const manifest = await runtime.parseFile('./manifest');
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
+    const arc = runtime.getArcById(arcInfo.id);
     const recipe = manifest.recipes[0];
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
     await arc.idle;
 
     const serialization = await Manifest.parse(await arc.serialize());
@@ -762,10 +768,10 @@ describe('Arc', () => {
     const runtime = new Runtime();
     assert.equal(runtime.driverFactory.providers.size, 1);
 
-    const arc1 = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test1'}));
+    const arc1 = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test1'})).id);
     assert.strictEqual(runtime.driverFactory.providers.size, 2);
 
-    const arc2 = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test2'}));
+    const arc2 = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test2'})).id);
     assert.strictEqual(runtime.driverFactory.providers.size, 3);
 
     arc1.dispose();
@@ -794,7 +800,7 @@ describe('Arc', () => {
         `, {memoryProvider});
 
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test0', planName: 'TestPlan'}));
+    const arc = await runtime.allocator.startArc({arcName: 'test0', planName: 'TestPlan'});
     assert.lengthOf(arc.activeRecipe.handles, 3);
     const myThingHandle = arc.activeRecipe.handles.find(h => h.id === 'mything');
     assert.isNotNull(myThingHandle);
@@ -809,10 +815,10 @@ describe('Arc', () => {
 
 describe('Arc storage migration', () => {
   it('supports new StorageKey type', Flags.withDefaultReferenceMode(async () => {
-    const {arc, Foo} = await setup(arcId => new VolatileStorageKey(arcId, ''));
-    const fooStore = await arc.createStore(new SingletonType(Foo.type), undefined, 'test:1');
+    const {runtime, arcInfo, Foo} = await setup(arcId => new VolatileStorageKey(arcId, ''));
+    const fooStore = await arcInfo.createStoreInfo(new SingletonType(Foo.type), {id: 'test:1'});
     assert.instanceOf(fooStore, StoreInfo);
-    const activeStore = await arc.getActiveStore(fooStore);
+    const activeStore = await runtime.getArcById(arcInfo.id).getActiveStore(fooStore);
     assert.instanceOf(activeStore, ReferenceModeStore);
     assert.instanceOf(activeStore['backingStore'], DirectStoreMuxer);
     const backingStore = activeStore['containerStore'] as DirectStore<CRDTTypeRecord>;
@@ -870,11 +876,11 @@ describe('Arc storage migration', () => {
       }
     }();
     const runtime = new Runtime({loader, context: manifest, storageKeyFactories: [volatileFactory]});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({
+    const arc = runtime.getArcById((await runtime.allocator.startArc({
       arcName: 'test',
       storageKeyPrefix: volatileStorageKeyPrefixForTest(),
       planName: 'TestPlan'
-    }));
+    })).id);
     await arc.idle;
 
     const getStoreByConnectionName = async (connectionName) => {

--- a/src/runtime/tests/data-layer-test.ts
+++ b/src/runtime/tests/data-layer-test.ts
@@ -9,33 +9,29 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Arc} from '../arc.js';
-import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
-import {SlotComposer} from '../slot-composer.js';
 import {EntityType, Schema} from '../../types/lib-types.js';
 import {Entity} from '../entity.js';
 import {ArcId} from '../id.js';
-import {handleForStoreInfo} from '../storage/storage.js';
 import {Runtime} from '../runtime.js';
 import {StoreInfo} from '../storage/store-info.js';
 
 describe('entity', () => {
   it('can be created, stored, and restored', async () => {
     const schema = new Schema(['TestSchema'], {value: 'Text'});
-    const runtime = new Runtime({context: new Manifest({id: ArcId.newForTest('test')}), loader: new Loader()});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const runtime = new Runtime({context: new Manifest({id: ArcId.newForTest('test')})});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
     const entity = new (Entity.createEntityClass(schema, null))({value: 'hello world'});
     assert.isDefined(entity);
 
     const collectionType = new EntityType(schema).collectionOf();
 
-    const storage = await arc.createStore(collectionType);
-    const handle = await handleForStoreInfo(storage, arc);
+    const storage = await arcInfo.createStoreInfo(collectionType);
+    const handle = await runtime.host.handleForStoreInfo(storage, arcInfo);
     await handle.add(entity);
 
-    const store = arc.stores.filter(StoreInfo.isCollectionEntityStore).find(s => s.entityHasName('TestSchema'));
-    const collection = await handleForStoreInfo(store, arc);
+    const store = arcInfo.stores.filter(StoreInfo.isCollectionEntityStore).find(s => s.entityHasName('TestSchema'));
+    const collection = await runtime.host.handleForStoreInfo(store, arcInfo);
     const list = await collection.toList();
     const clone = list[0];
     assert.isDefined(clone);

--- a/src/runtime/tests/description-test.ts
+++ b/src/runtime/tests/description-test.ts
@@ -9,7 +9,6 @@
  */
 
 import {assert} from '../../platform/chai-web.js';
-import {Arc} from '../arc.js';
 import {Description} from '../description.js';
 import {Loader} from '../../platform/loader.js';
 import {Manifest} from '../manifest.js';
@@ -20,29 +19,22 @@ import {EntityType, SingletonType, InterfaceType} from '../../types/lib-types.js
 import {Entity} from '../entity.js';
 import {ArcId} from '../id.js';
 import {ConCap} from '../../testing/test-util.js';
-import {handleType, handleForStoreInfo} from '../storage/storage.js';
+import {SingletonEntityHandle} from '../storage/storage.js';
 import {Runtime} from '../runtime.js';
 import {CRDTTypeRecord} from '../../crdt/lib-crdt.js';
 import {StoreInfo} from '../storage/store-info.js';
 import {newRecipe} from '../recipe/internal/recipe-constructor.js';
 import {VolatileStorageKey} from '../storage/drivers/volatile.js';
-
-async function createTestArc(recipe: Recipe, manifest: Manifest) {
-  const runtime = new Runtime({context: manifest, loader: new Loader()});
-  const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
-  // TODO(lindner) stop messing with arc internal state, or provide a way to supply in constructor..
-  arc.arcInfo['activeRecipe'] = recipe;
-  arc.arcInfo['recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
-  return arc;
-}
+import {ArcInfo} from '../arc-info.js';
 
 type VerifySuggestionOptions = {
-  arc: Arc;
+  arcInfo: ArcInfo;
+  runtime: Runtime;
   relevance?: Relevance;
 };
 
-async function verifySuggestion({arc, relevance}: VerifySuggestionOptions, expectedSuggestion) {
-  const description = await Description.create(arc, relevance);
+async function verifySuggestion({arcInfo, runtime, relevance}: VerifySuggestionOptions, expectedSuggestion) {
+  const description = await Description.create(runtime.getArcById(arcInfo.id), runtime, relevance);
   assert.strictEqual(description.getArcDescription(), expectedSuggestion);
   return description;
 }
@@ -81,68 +73,68 @@ recipe
     assert.lengthOf(manifest.recipes, 1);
     const recipe = manifest.recipes[0];
     const fooType = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null).type;
-    recipe.handles[0].mapToStorage(new StoreInfo({id: 'test:1', type: fooType}));
+
+    const runtime = new Runtime({context: manifest});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'testArc'});
+
+    const fooStore = await arcInfo.createStoreInfo(new SingletonType(fooType), {id: 'test:1'});
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
+    const foosStore = await arcInfo.createStoreInfo(fooType.collectionOf(), {id: 'test:2'});
+    const foosHandle = await runtime.host.handleForStoreInfo(foosStore, arcInfo);
+
+    recipe.handles[0].mapToStorage(fooStore);
     if (recipe.handles.length > 1) {
-      recipe.handles[1].mapToStorage(new StoreInfo({id: 'test:2', type: fooType.collectionOf()}));
+      recipe.handles[1].mapToStorage(foosStore);
     }
     if (recipe.handles.length > 2) {
-      recipe.handles[2].mapToStorage(new StoreInfo({id: 'test:3', type: fooType}));
+      const foo3Store = await arcInfo.createStoreInfo(new SingletonType(fooType), {id: 'test:3'});
+      recipe.handles[2].mapToStorage(foo3Store);
     }
-    recipe.normalize();
-    assert.isTrue(recipe.isResolved());
 
-    // TODO(shans): This clone is required because for some bizarre reason we're stuffing
-    // the recipe into activeRecipes here instead of simply instantiating it. That makes
-    // the activeRecipe frozen if we don't clone, as we just normalized. A frozen active
-    // recipe is A Bad Thing.
-    const newRecipe = recipe.clone();
+    assert(recipe.tryResolve(), `cannot resolve: ${recipe.toString({showUnresolved: true})}`);
+    await arcInfo.instantiate(recipe);
 
-    const ifooHandleConn = newRecipe.handleConnections.find(hc => hc.particle.name === 'A' && hc.name === 'ifoo');
+    const ifooHandleConn = arcInfo.activeRecipe.handleConnections.find(hc => hc.particle.name === 'A' && hc.name === 'ifoo');
     const ifooHandle = ifooHandleConn ? ifooHandleConn.handle : null;
-    const ofoosHandleConn = newRecipe.handleConnections.find(hc => hc.particle.name === 'A' && hc.name === 'ofoos');
+    const ofoosHandleConn = arcInfo.activeRecipe.handleConnections.find(hc => hc.particle.name === 'A' && hc.name === 'ofoos');
     const ofoosHandle = ofoosHandleConn ? ofoosHandleConn.handle : null;
 
-    const arc = await createTestArc(newRecipe, manifest);
-
-    const fooStore = await arc.createStore(new SingletonType(fooType), undefined, 'test:1');
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
-    const foosStore = await arc.createStore(fooType.collectionOf(), undefined, 'test:2');
-    const foosHandle = await handleForStoreInfo(foosStore, arc);
-    return {arc, recipe: newRecipe, ifooHandle, ofoosHandle, fooHandle, foosHandle};
+    const arc = runtime.getArcById(arcInfo.id);
+    return {runtime, arc, recipe: arcInfo.activeRecipe, ifooHandle, ofoosHandle, fooHandle, foosHandle};
   }
 
   it('one particle description', async () => {
-    const {arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
   description \`read from \${ifoo} and populate \${ofoos}\`
 ${recipeManifest}
     `));
 
-    let description = await verifySuggestion({arc}, 'Read from foo and populate foo list.');
+    let description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from foo and populate foo list.');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'foo list');
 
     // Add value to a singleton handle.
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
-    description = await verifySuggestion({arc}, 'Read from foo-name and populate foo list.');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from foo-name and populate foo list.');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'foo list');
 
     // Add values to a collection handle.
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
-    description = await verifySuggestion({arc}, 'Read from foo-name and populate foo list (foo-1, foo-2).');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from foo-name and populate foo list (foo-1, foo-2).');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'foo list');
 
     // Add more values to the collection handle.
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-name', fooValue: 'foo-3'}));
-    await verifySuggestion({arc}, 'Read from foo-name and populate foo list (foo-1 plus 2 other items).');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from foo-name and populate foo list (foo-1 plus 2 other items).');
   });
 
   it('one particle and connections descriptions', async () => {
-    const {arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
   description \`read from \${ifoo} and populate \${ofoos}\`
@@ -151,29 +143,29 @@ ${aParticleManifest}
 ${recipeManifest}
     `));
 
-    let description = await verifySuggestion({arc}, 'Read from my-in-foo and populate my-out-foos.');
+    let description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from my-in-foo and populate my-out-foos.');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'my-in-foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'my-out-foos');
 
     // Add value to a singleton handle.
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
-    description = await verifySuggestion({arc}, 'Read from my-in-foo (foo-name) and populate my-out-foos.');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from my-in-foo (foo-name) and populate my-out-foos.');
 
     // Add values to a collection handle.
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
-    description = await verifySuggestion({arc}, 'Read from my-in-foo (foo-name) and populate my-out-foos (foo-1, foo-2).');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from my-in-foo (foo-name) and populate my-out-foos (foo-1, foo-2).');
 
     // Add more values to the collection handle.
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-name', fooValue: 'foo-3'}));
-    description = await verifySuggestion({arc},
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime},
         'Read from my-in-foo (foo-name) and populate my-out-foos (foo-1 plus 2 other items).');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'my-in-foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'my-out-foos');
   });
 
   it('one particle and connections descriptions references', async () => {
-    const {arc, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
   description \`read from \${ifoo} and populate \${ofoos}\`
@@ -182,21 +174,21 @@ ${aParticleManifest}
 ${recipeManifest}
     `));
 
-    let description = await verifySuggestion({arc}, 'Read from my-in-foo and populate The Foos from my-in-foo.');
+    let description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from my-in-foo and populate The Foos from my-in-foo.');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'my-in-foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'The Foos from my-in-foo');
 
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
-    description = await verifySuggestion({arc},
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime},
         'Read from my-in-foo (foo-name) and populate The Foos from my-in-foo (foo-1, foo-2).');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'my-in-foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'The Foos from my-in-foo');
   });
 
   it('one particle and connections descriptions references no pattern', async () => {
-    const {arc, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
   description \`read from \${ifoo} and populate \${ofoos}\`
@@ -204,21 +196,21 @@ ${aParticleManifest}
 ${recipeManifest}
     `));
 
-    let description = await verifySuggestion({arc}, 'Read from foo and populate The Foos from foo.');
+    let description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from foo and populate The Foos from foo.');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'The Foos from foo');
 
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
-    description = await verifySuggestion({arc},
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime},
         'Read from foo-name and populate The Foos from foo-name (foo-1, foo-2).');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'The Foos from foo');
   });
 
   it('one particle and connections descriptions with extras', async () => {
-    const {arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
   description \`read from \${ifoo} and populate \${ofoos}._name_\`
@@ -231,7 +223,7 @@ ${recipeManifest}
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
 
-    const description = await verifySuggestion({arc},
+    const description = await verifySuggestion({arcInfo: arc.arcInfo, runtime},
         'Read from [fooValue: the-FOO] (foo-name) and populate [A list of foo with values: foo-1, foo-2].');
 
     assert.strictEqual(description.getHandleDescription(ifooHandle), '[fooValue: the-FOO]');
@@ -240,7 +232,7 @@ ${recipeManifest}
   });
 
   it('connection description from another particle', async () => {
-    const {arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe, ifooHandle, ofoosHandle, fooHandle, foosHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
   description \`read from \${ifoo} and populate \${ofoos}\`
@@ -253,7 +245,7 @@ ${recipeManifest}
     ofoo: writes fooHandle
     `));
 
-    let description = await verifySuggestion({arc}, 'Read from best-new-foo and populate my-foos.');
+    let description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from best-new-foo and populate my-foos.');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'best-new-foo');
     const oBFooHandle = recipe.handleConnections.find(hc => hc.particle.name === 'B' && hc.name === 'ofoo').handle;
     assert.strictEqual(description.getHandleDescription(oBFooHandle), 'best-new-foo');
@@ -262,14 +254,14 @@ ${recipeManifest}
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await foosHandle.add(new foosHandle.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
-    description = await verifySuggestion({arc}, 'Read from best-new-foo (foo-name) and populate my-foos (foo-1, foo-2).');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Read from best-new-foo (foo-name) and populate my-foos (foo-1, foo-2).');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'best-new-foo');
     assert.strictEqual(description.getHandleDescription(oBFooHandle), 'best-new-foo');
     assert.strictEqual(description.getHandleDescription(ofoosHandle), 'my-foos');
   });
 
   it('multiple particles', async () => {
-    const {arc, recipe} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 particle X1
   ofoo: writes Foo
@@ -305,7 +297,7 @@ recipe
     const aFooHandle = recipe.handleConnections.find(hc => hc.particle.name === 'A' && hc.name === 'ifoo').handle;
 
     let description = await verifySuggestion(
-        {arc}, 'Display X1-foo, create X1::X1-foo, and create X2::X2-foo.');
+        {arcInfo: arc.arcInfo, runtime}, 'Display X1-foo, create X1::X1-foo, and create X2::X2-foo.');
     assert.strictEqual(description.getHandleDescription(aFooHandle), 'X1-foo');
 
     // Rank X2 higher than X2
@@ -316,7 +308,7 @@ recipe
     relevance.relevanceMap.set(recipe.particles.find(p => p.name === 'X2'), [10]);
 
     description = await verifySuggestion(
-        {arc, relevance}, 'Display X2-foo, create X2::X2-foo, and create X1::X1-foo.');
+        {arcInfo: arc.arcInfo, runtime, relevance}, 'Display X2-foo, create X2::X2-foo, and create X1::X1-foo.');
     assert.strictEqual(description.getHandleDescription(aFooHandle), 'X2-foo');
   });
 
@@ -344,39 +336,42 @@ recipe
     assert.lengthOf(manifest.recipes, 1);
     let recipe = manifest.recipes[0];
     const fooType = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null).type;
-    recipe.handles[0].mapToStorage(new StoreInfo({id: 'test:1', type: fooType.collectionOf()}));
-    recipe.handles[1].mapToStorage(new StoreInfo({id: 'test:2', type: fooType.collectionOf()}));
-    recipe.normalize();
-    assert.isTrue(recipe.isResolved());
-    recipe = recipe.clone();
 
-    const arc = await createTestArc(recipe, manifest);
-    const fooStore1 = await arc.createStore(fooType.collectionOf(), undefined, 'test:1');
-    const fooStore2 = await arc.createStore(fooType.collectionOf(), undefined, 'test:2');
-    const fooHandle1 = await handleForStoreInfo(fooStore1, arc);
-    const fooHandle2 = await handleForStoreInfo(fooStore2, arc);
+    const runtime = new Runtime({context: manifest});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
+    const fooStore1 = await arcInfo.createStoreInfo(fooType.collectionOf(), {id: 'test:1'});
+    const fooStore2 = await arcInfo.createStoreInfo(fooType.collectionOf(), {id: 'test:2'});
+    recipe.handles[0].mapToStorage(fooStore1);
+    recipe.handles[1].mapToStorage(fooStore2);
+    assert(recipe.tryResolve());
+    await arcInfo.instantiate(recipe);
+    recipe = arcInfo.activeRecipe;
 
-    let description = await verifySuggestion({arc}, 'Write to X-foo and write to X-foo.');
+    const arc = runtime.getArcById(arcInfo.id);
+    let description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Write to X-foo and write to X-foo.');
     assert.strictEqual(description.getHandleDescription(recipe.handles[0]), 'X-foo');
     assert.strictEqual(description.getHandleDescription(recipe.handles[1]), 'X-foo');
+
+    const fooHandle1 = await runtime.host.handleForStoreInfo(fooStore1, arcInfo);
+    const fooHandle2 = await runtime.host.handleForStoreInfo(fooStore2, arcInfo);
 
     // Add values to the second handle.
     await fooHandle2.add(new fooHandle2.entityClass({name: 'foo-1', fooValue: 'foo-value-1'}));
     await fooHandle2.add(new fooHandle2.entityClass({name: 'foo-2', fooValue: 'foo-value-2'}));
-    description = await verifySuggestion({arc}, 'Write to X-foo and write to X-foo (foo-1, foo-2).');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Write to X-foo and write to X-foo (foo-1, foo-2).');
     assert.strictEqual(description.getHandleDescription(recipe.handles[0]), 'X-foo');
     assert.strictEqual(description.getHandleDescription(recipe.handles[1]), 'X-foo');
 
     // Add values to the first handle also.
     await fooHandle1.add(new fooHandle1.entityClass({name: 'foo-3', fooValue: 'foo-value-3'}));
     await fooHandle1.add(new fooHandle1.entityClass({name: 'foo-4', fooValue: 'foo-value-4'}));
-    description = await verifySuggestion({arc}, 'Write to X-foo (foo-3, foo-4) and write to X-foo (foo-1, foo-2).');
+    description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Write to X-foo (foo-3, foo-4) and write to X-foo (foo-1, foo-2).');
     assert.strictEqual(description.getHandleDescription(recipe.handles[0]), 'X-foo');
     assert.strictEqual(description.getHandleDescription(recipe.handles[1]), 'X-foo');
   });
 
   it('duplicate particles', async () => {
-    const {arc, recipe, ifooHandle, fooHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe, ifooHandle, fooHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${aParticleManifest}
     action: provides Slot
@@ -407,10 +402,10 @@ recipe
 
     // Add values to both Foo handles
     await fooHandle.setFromData({name: 'the-FOO'});
-    const fooStore2 = await arc.createStore(handleType(fooHandle), undefined, 'test:3');
-    const fooHandle2 = await handleForStoreInfo(fooStore2, arc);
+    const fooStore2 = arc.arcInfo.findStoreById('test:3');
+    const fooHandle2 = await runtime.host.handleForStoreInfo(fooStore2, arc.arcInfo) as SingletonEntityHandle;
     await fooHandle2.setFromData({name: 'another-FOO'});
-    const description = await verifySuggestion({arc},
+    const description = await verifySuggestion({arcInfo: arc.arcInfo, runtime},
         'Do A with b-foo (the-FOO), output B to b-foo, and output B to b-foo (another-FOO).');
     assert.strictEqual(description.getHandleDescription(ifooHandle), 'b-foo');
 
@@ -420,12 +415,12 @@ recipe
     relevance.relevanceMap.set(recipe.particles.filter(p => p.name === 'B')[0], [1]);
     relevance.relevanceMap.set(recipe.particles.filter(p => p.name === 'B')[1], [10]);
 
-    await verifySuggestion({arc, relevance},
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime, relevance},
         'Do A with b-foo (the-FOO), output B to b-foo (another-FOO), and output B to b-foo.');
   });
 
   it('sanitize description', async () => {
-    const {arc, recipe} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 particle A
   ofoo: writes Foo
@@ -441,7 +436,7 @@ recipe
     root: consumes slot0
     `));
 
-    const description = await verifySuggestion({arc}, 'Create &lt;new> &lt;&lt;my-foo>>.');
+    const description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Create &lt;new> &lt;&lt;my-foo>>.');
     const handle = recipe.handleConnections.find(hc => hc.particle.name === 'A' && hc.name === 'ofoo').handle;
     assert.strictEqual(description.getHandleDescription(handle), '&lt;my-foo>');
   });
@@ -462,19 +457,22 @@ recipe
           root: consumes slot0
       `;
     const manifest = (await Manifest.parse(manifestStr));
-    let recipe = manifest.recipes[0];
-    const scriptDateType = Entity.createEntityClass(manifest.findSchemaByName('ScriptDate'), null).type;
-    recipe.handles[0].mapToStorage(new StoreInfo({id: 'test:1', type: scriptDateType}));
-    assert.isTrue(recipe.normalize());
-    assert.isTrue(recipe.isResolved());
-    recipe = recipe.clone();
-    const arc = await createTestArc(recipe, manifest);
-    const store = await arc.createStore(new SingletonType(scriptDateType), undefined, 'test:1');
-    const handle = await handleForStoreInfo(store, arc);
-    await verifySuggestion({arc}, 'Stardate .');
+    const recipe = manifest.recipes[0];
 
+    const runtime = new Runtime({context: manifest});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
+    const scriptDateType = Entity.createEntityClass(manifest.findSchemaByName('ScriptDate'), null).type;
+    const storeInfo = await arcInfo.createStoreInfo(new SingletonType(scriptDateType), {id: 'test:1'});
+    recipe.handles[0].mapToStorage(storeInfo);
+    assert(recipe.tryResolve());
+    await arcInfo.instantiate(recipe);
+
+    const arc = runtime.getArcById(arcInfo.id);
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Stardate .');
+
+    const handle = await runtime.host.handleForStoreInfo(storeInfo, arcInfo) as SingletonEntityHandle;
     await handle.set(new handle.entityClass({date: 'June 31'}));
-    await verifySuggestion({arc}, 'Stardate June 31.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Stardate June 31.');
   });
 
   it('multiword type and no name property in description', async () => {
@@ -496,21 +494,24 @@ recipe
            root: consumes slot0`;
     const manifest = (await Manifest.parse(manifestStr));
     assert.lengthOf(manifest.recipes, 1);
-    let recipe = manifest.recipes[0];
+    const recipe = manifest.recipes[0];
+
+    const runtime = new Runtime({context: manifest});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
     const myBESTType = Entity.createEntityClass(manifest.findSchemaByName('MyBESTType'), null).type;
-    recipe.handles[0].mapToStorage(new StoreInfo({id: 'test:1', type: myBESTType}));
-    recipe.handles[1].mapToStorage(new StoreInfo({id: 'test:2', type: myBESTType.collectionOf()}));
-    recipe.normalize();
-    assert.isTrue(recipe.isResolved());
-    recipe = recipe.clone();
+    const tStore = await arcInfo.createStoreInfo(new SingletonType(myBESTType), {id: 'test:1'});
+    const tsStore = await arcInfo.createStoreInfo(myBESTType.collectionOf(), {id: 'test:2'});
+    recipe.handles[0].mapToStorage(tStore);
+    recipe.handles[1].mapToStorage(tsStore);
 
-    const arc = await createTestArc(recipe, manifest);
-    const tStore = await arc.createStore(new SingletonType(myBESTType), undefined, 'test:1');
-    const tsStore = await arc.createStore(myBESTType.collectionOf(), undefined, 'test:2');
-    const tHandle = await handleForStoreInfo(tStore, arc);
-    const tsHandle = await handleForStoreInfo(tsStore, arc);
+    assert(recipe.tryResolve());
+    await arcInfo.instantiate(recipe);
 
-    const description = await verifySuggestion({arc}, 'Make my best type list from my best type.');
+    const tHandle = await runtime.host.handleForStoreInfo(tStore, arcInfo);
+    const tsHandle = await runtime.host.handleForStoreInfo(tsStore, arcInfo);
+
+    const arc = runtime.getArcById(arcInfo.id);
+    const description = await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Make my best type list from my best type.');
     const tRecipeHandle = recipe.handleConnections.find(hc => hc.particle.name === 'P' && hc.name === 't').handle;
     const tsRecipeHandle = recipe.handleConnections.find(hc => hc.particle.name === 'P' && hc.name === 'ts').handle;
     assert.strictEqual(description.getHandleDescription(tRecipeHandle), 'my best type');
@@ -519,11 +520,11 @@ recipe
     // Add values to handles.
     await tHandle.set(new tHandle.entityClass({property: 'value1'}));
     await tsHandle.add(new tsHandle.entityClass({property: 'value2'}));
-    await verifySuggestion({arc}, 'Make my best type list (1 items) from my best type.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Make my best type list (1 items) from my best type.');
 
     await tsHandle.add(new tsHandle.entityClass({property: 'value3'}));
     await tsHandle.add(new tsHandle.entityClass({property: 'value4'}));
-    await verifySuggestion({arc}, 'Make my best type list (3 items) from my best type.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Make my best type list (3 items) from my best type.');
   });
 
   it('particle slots description', async () => {
@@ -568,16 +569,19 @@ recipe
 `;
     const manifest = (await Manifest.parse(manifestStr));
     assert.lengthOf(manifest.recipes, 1);
-    const recipe = manifest.recipes[0];
-    recipe.normalize();
-    assert.isTrue(recipe.isResolved());
-    const arc = await createTestArc(recipe, manifest);
+    let recipe = manifest.recipes[0];
+    const runtime = new Runtime({context: manifest});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
 
-    await verifySuggestion({arc}, 'Hello first b and second b, see you at only c.');
+    assert(recipe.tryResolve());
+    recipe = await runtime.allocator.assignStorageKeys(arcInfo.id, recipe);
+    await arcInfo.instantiate(recipe);
+
+    await verifySuggestion({arcInfo, runtime}, 'Hello first b and second b, see you at only c.');
   });
 
   it('particle without UI description', async () => {
-    const {arc, recipe, fooHandle} = (await prepareRecipeAndArc(`
+    const {runtime, arc, recipe, fooHandle} = (await prepareRecipeAndArc(`
 ${schemaManifest}
 ${bParticleManifest}
   description \`Populate \${ofoo}\`
@@ -587,11 +591,11 @@ recipe
     ofoo: writes fooHandle
     `));
 
-    await verifySuggestion({arc}, 'Populate foo.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Populate foo.');
 
     // Add value to a singleton handle.
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
-    await verifySuggestion({arc}, 'Populate foo-name.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Populate foo-name.');
   });
 
   it('capitalizes when some particles do not have descriptions', async () => {
@@ -618,33 +622,33 @@ recipe
     myslot: consumes slot1
       `));
     const recipe = manifest.recipes[0];
-    // Cannot use createTestArc here, because capabilities-resolver cannot be set to null,
-    // and interface returns a null schema, and cannot generate hash.
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
-    arc.arcInfo['activeRecipe'] = recipe;
-    arc.arcInfo['recipeDeltas'].push({particles: recipe.particles, handles: recipe.handles, slots: recipe.slots, patterns: recipe.patterns});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
 
     const hostedParticle = manifest.findParticleByName('NoDescription');
     const hostedType = manifest.findParticleByName('NoDescMuxer').handleConnections[0].type as InterfaceType;
-
     const hostedStoreId = 'hosted-particle-handle';
-    const hostedStorageKey = new VolatileStorageKey(arc.id, '').childKeyForHandle(hostedStoreId);
-    const newStore = await arc.createStore(new SingletonType(hostedType), /* name= */ null, hostedStoreId, /* tags= */ [], hostedStorageKey);
-    const newHandle = await handleForStoreInfo(newStore, arc);
+    const hostedStore = await arcInfo.createStoreInfo(new SingletonType(hostedType), {
+      id: hostedStoreId,
+      storageKey: new VolatileStorageKey(arcInfo.id, '').childKeyForHandle(hostedStoreId)
+    });
+    recipe.handles[0].mapToStorage(hostedStore);
+
+    await arcInfo.instantiate(recipe);
+    const newHandle = await runtime.host.handleForStoreInfo(hostedStore, arcInfo);
     await newHandle.set(hostedParticle.clone());
 
-    await verifySuggestion({arc}, 'Start with capital letter.');
+    await verifySuggestion({arcInfo, runtime}, 'Start with capital letter.');
   });
 
   it('has no particles description', async () => {
     const verify = async (manifestStr: string, expectedDescription: string) => {
       const manifest = await Manifest.parse(manifestStr);
       const recipe = manifest.recipes[0];
-      recipe.normalize();
-      assert.isTrue(recipe.isResolved());
-      const arc = await createTestArc(recipe, manifest);
-      const description = await Description.create(arc);
+      const runtime = new Runtime({context: manifest});
+      const arcInfo = await runtime.allocator.startArc({arcName: 'testArc'});
+      await arcInfo.instantiate(recipe);
 
+      const description = await Description.create(runtime.getArcById(arcInfo.id), runtime);
       const recipeDescription = description.getRecipeSuggestion();
       assert.strictEqual(recipeDescription, expectedDescription);
     };
@@ -669,11 +673,11 @@ schema GitHubDash`));
     const verifyNoAssert = async (manifestStr, expectedSuggestion, expectedWarning) => {
       const manifest = (await Manifest.parse(manifestStr));
       assert.lengthOf(manifest.recipes, 1);
-      const recipe = manifest.recipes[0];
-      recipe.normalize();
-      assert.isTrue(recipe.isResolved());
-      const arc = await createTestArc(recipe, manifest);
-      const description = await Description.create(arc);
+      const runtime = new Runtime({context: manifest});
+      const arcInfo = await runtime.allocator.startArc({arcName: 'testArc'});
+      await arcInfo.instantiate(manifest.recipes[0]);
+
+      const description = await Description.create(runtime.getArcById(arcInfo.id), runtime);
       const arcDesc = ConCap.capture(() => description.getArcDescription());
       assert.strictEqual(arcDesc.result, expectedSuggestion);
       assert.match(arcDesc.warn[0][0], expectedWarning);
@@ -743,60 +747,62 @@ recipe
     let recipe = manifest.recipes[0];
     const fooType = Entity.createEntityClass(manifest.findSchemaByName('Foo'), null).type;
     const descriptionType = Entity.createEntityClass(manifest.findSchemaByName('Description'), null).type;
-    recipe.handles[0].mapToStorage(new StoreInfo({id: 'test:1', type: fooType}));
-    recipe.handles[1].mapToStorage(new StoreInfo({id: 'test:2', type: descriptionType.collectionOf()}));
-    recipe.normalize();
-    assert.isTrue(recipe.isResolved());
-    recipe = recipe.clone();
-    const arc = await createTestArc(recipe, manifest);
-    const fooStore = await arc.createStore(new SingletonType(fooType), undefined, 'test:1');
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
-    const descriptionStore = await arc.createStore(descriptionType.collectionOf(), undefined, 'test:2');
+    const runtime = new Runtime({context: manifest});
+    const arcInfo = await runtime.allocator.startArc({arcName: 'testArc'});
+    const fooStore = await arcInfo.createStoreInfo(new SingletonType(fooType), {id: 'test:1'});
+    recipe.handles[0].mapToStorage(fooStore);
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
+    const descriptionStore = await arcInfo.createStoreInfo(descriptionType.collectionOf(), {id: 'test:2'});
+    recipe.handles[1].mapToStorage(descriptionStore);
+    await arcInfo.instantiate(recipe);
+    recipe = arcInfo.activeRecipe;
+    const arc = runtime.getArcById(arcInfo.id);
 
     return {
+      runtime,
       arc,
       recipe,
       fooHandle,
       DescriptionType: Entity.createEntityClass((descriptionStore.type.getContainedType() as EntityType).entitySchema, null),
-      descriptionHandle: await handleForStoreInfo(descriptionStore, arc),
+      descriptionHandle: await runtime.host.handleForStoreInfo(descriptionStore, arcInfo),
     };
   }
 
   it('particle dynamic description', async () => {
-    const {arc, recipe, fooHandle, DescriptionType, descriptionHandle} = await prepareRecipeAndArc();
+    const {runtime, arc, recipe, fooHandle, DescriptionType, descriptionHandle} = await prepareRecipeAndArc();
 
-    const description = await Description.create(arc);
+    const description = await Description.create(arc, runtime);
     assert.isUndefined(description.getArcDescription());
 
     // Particle (static) spec pattern.
     recipe.particles[0].spec.pattern = 'hello world';
-    await verifySuggestion({arc}, 'Hello world.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Hello world.');
 
     // Particle (dynamic) description handle (override static description).
     await descriptionHandle.add(new DescriptionType({key: 'pattern', value: 'Return my foo'}));
-    await verifySuggestion({arc}, 'Return my foo.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Return my foo.');
 
     // Particle description handle with handle connections.
     await descriptionHandle.add(new DescriptionType({key: 'pattern', value: 'Return my temporary foo'}));
     await descriptionHandle.add(new DescriptionType({key: 'pattern', value: 'Return my ${ofoo}'}));
     const ofooDesc = new DescriptionType({key: 'ofoo', value: 'best-foo'});
     await descriptionHandle.add(ofooDesc);
-    await verifySuggestion({arc}, 'Return my best-foo.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Return my best-foo.');
 
     // Add value to connection's handle.
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FO4'}));
-    await verifySuggestion({arc}, 'Return my best-foo (foo-name).');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Return my best-foo (foo-name).');
 
     // Remove connection's description.
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name', fooValue: 'the-FOO'}));
     await descriptionHandle.remove(ofooDesc);
-    await verifySuggestion({arc}, 'Return my foo-name.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Return my foo-name.');
   });
 
   it('particle recipe description', async () => {
-    const {arc, recipe, fooHandle, DescriptionType, descriptionHandle} = await prepareRecipeAndArc();
+    const {runtime, arc, recipe, fooHandle, DescriptionType, descriptionHandle} = await prepareRecipeAndArc();
 
-    const description = await Description.create(arc);
+    const description = await Description.create(arc, runtime);
     assert.isUndefined(description.getArcDescription());
 
     const recipeClone = recipe.clone();
@@ -806,24 +812,24 @@ recipe
 
     // Particle (static) spec pattern.
     recipeClone.particles[0].spec.pattern = 'hello world';
-    await verifySuggestion({arc}, 'Hello world.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Hello world.');
 
     recipeClone.patterns = [`Here it is: \${B}`];
-    await verifySuggestion({arc}, 'Here it is: hello world.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Here it is: hello world.');
 
     // Particle (dynamic) description handle (override static description).
     await descriptionHandle.add(new DescriptionType({key: 'pattern', value: 'dynamic B description'}));
-    await verifySuggestion({arc}, 'Here it is: dynamic B description.');
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, 'Here it is: dynamic B description.');
   });
 
   it('particle dynamic dom description', async () => {
-    const {arc, recipe, fooHandle, DescriptionType, descriptionHandle} = await prepareRecipeAndArc();
+    const {runtime, arc, recipe, fooHandle, DescriptionType, descriptionHandle} = await prepareRecipeAndArc();
     await descriptionHandle.add(new DescriptionType({key: 'pattern', value: 'return my ${ofoo} (text)'}));
     await descriptionHandle.add(new DescriptionType({key: '_template_', value: 'Return my <span>{{ofoo}}</span> (dom)'}));
     await descriptionHandle.add(new DescriptionType({key: '_model_', value: JSON.stringify({'ofoo': '${ofoo}'})}));
-    await verifySuggestion({arc}, `Return my foo (text).`);
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, `Return my foo (text).`);
 
     await fooHandle.set(new fooHandle.entityClass({name: 'foo-name'}));
-    await verifySuggestion({arc}, `Return my foo-name (text).`);
+    await verifySuggestion({arcInfo: arc.arcInfo, runtime}, `Return my foo-name (text).`);
   });
 });

--- a/src/runtime/tests/manifest-test.ts
+++ b/src/runtime/tests/manifest-test.ts
@@ -30,7 +30,7 @@ import {mockFirebaseStorageKeyOptions} from '../storage/testing/mock-firebase.js
 import {Flags} from '../flags.js';
 import {TupleType, CollectionType, EntityType, TypeVariable, Schema, BinaryExpression,
         FieldNamePrimitive, NumberPrimitive, PrimitiveField} from '../../types/lib-types.js';
-import {handleForStoreInfo, CollectionEntityType} from '../storage/storage.js';
+import {CollectionEntityType} from '../storage/storage.js';
 import {Ttl} from '../capabilities.js';
 import {StoreInfo} from '../storage/store-info.js';
 import {deleteFieldRecursively} from '../../utils/lib-utils.js';
@@ -1986,7 +1986,8 @@ recipe SomeRecipe
     const manifest = await runtime.parseFile('./the.manifest', {loader});
     const storageStub = manifest.findStoreByName('Store0') as StoreInfo<CollectionEntityType>;
     assert(storageStub);
-    const handle = await handleForStoreInfo(storageStub, {...manifest, storageService});
+    await runtime.storageService.getActiveStore(storageStub);
+    const handle = await runtime.storageService.handleForStoreInfo(storageStub, manifest.generateID(), manifest.idGenerator);
 
     assert.deepEqual((await handle.toList()).map(Entity.serialize), [
       {
@@ -2041,7 +2042,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     `);
     const storeInfo = manifest.findStoreByName('Store0') as StoreInfo<CollectionEntityType>;
     assert(storeInfo);
-    const handle = await handleForStoreInfo(storeInfo, {...manifest, storageService});
+    const handle = await runtime.storageService.handleForStoreInfo(storeInfo, manifest.generateID(), manifest.idGenerator);
 
     // TODO(shans): address as part of storage refactor
     assert.deepEqual((await handle.toList()).map(Entity.serialize), [
@@ -2065,7 +2066,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       }
     `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
-    const handle = await handleForStoreInfo(store, {...manifest, storageService});
+    const handle = await runtime.storageService.handleForStoreInfo(store, manifest.generateID(), manifest.idGenerator);
     const entities = (await handle.toList()).map(Entity.serialize);
     assert.lengthOf(entities, 2);
 
@@ -2098,7 +2099,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       }
     `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
-    const handle = await handleForStoreInfo(store, {...manifest, storageService});
+    const handle = await runtime.storageService.handleForStoreInfo(store, manifest.generateID(), manifest.idGenerator);
     const entities = (await handle.toList()).map(Entity.serialize);
     assert.lengthOf(entities, 2);
 
@@ -2134,7 +2135,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       }
     `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
-    const handle = await handleForStoreInfo(store, {...manifest, storageService});
+    const handle = await runtime.storageService.handleForStoreInfo(store, manifest.generateID(), manifest.idGenerator);
     const entities = (await handle.toList()).map(Entity.serialize);
     assert.lengthOf(entities, 2);
 
@@ -2160,7 +2161,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
       }
     `);
     const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
-    const handle = await handleForStoreInfo(store, {...manifest, storageService});
+    const handle = await runtime.storageService.handleForStoreInfo(store, manifest.generateID(), manifest.idGenerator);
     const entities = (await handle.toList()).map(e => Entity.serialize(e).rawData);
 
     assert.deepStrictEqual(entities, [
@@ -2175,7 +2176,7 @@ Error parsing JSON from 'EntityList' (Unexpected token h in JSON at position 1)'
     const check = async (manifestStr, msg) => {
       const manifest = await runtime.parse(manifestStr);
       const store = manifest.findStoreByName('X') as StoreInfo<CollectionEntityType>;
-      const handle = await handleForStoreInfo(store, {...manifest, storageService});
+      const handle = await runtime.storageService.handleForStoreInfo(store, manifest.generateID(), manifest.idGenerator);
       await assertThrowsAsync(async () => handle.toList(), msg);
     };
 

--- a/src/runtime/tests/particle-api-test.ts
+++ b/src/runtime/tests/particle-api-test.ts
@@ -20,24 +20,21 @@ import {Runtime} from '../runtime.js';
 import {Speculator} from '../../planning/speculator.js';
 import {RamDiskStorageDriverProvider} from '../storage/drivers/ramdisk.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
-import {handleForStoreInfo, CollectionEntityType} from '../storage/storage.js';
+import {CollectionEntityType, SingletonEntityHandle} from '../storage/storage.js';
 import {StoreInfo} from '../storage/store-info.js';
+import {ArcInfo} from '../arc-info.js';
 
 class ResultInspector {
-  private readonly _arc: Arc;
-  private readonly _store: StoreInfo<CollectionEntityType>;
-  private readonly _field;
-
   /**
    * @param arc the arc being tested; used to detect when all messages have been processed.
    * @param store a Collection-based store that should be connected as an output for the particle.
    * @param field the field within store's contained Entity type that this inspector should observe.
    */
-  constructor(arc: Arc, store: StoreInfo<CollectionEntityType>, field: string) {
+  constructor(private readonly runtime,
+              private readonly arc: Arc,
+              private readonly store: StoreInfo<CollectionEntityType>,
+              private readonly field: string) {
     assert(store.type instanceof CollectionType, `ResultInspector given non-Collection store: ${store}`);
-    this._arc = arc;
-    this._store = store;
-    this._field = field;
   }
 
   /**
@@ -46,12 +43,12 @@ class ResultInspector {
    * checks in the same test. The order of expectations is not significant.
    */
   async verify(...expectations) {
-    await this._arc.idle;
-    const handle = await handleForStoreInfo(this._store, this._arc); //{idGenerator: null, generateID: () => Id.fromString('id')});
+    await this.arc.idle;
+    const handle = await this.runtime.host.handleForStoreInfo(this.store, this.arc.arcInfo);
     const received = await handle.toList();
     const misses = [];
 
-    for (const item of received.map(r => r[this._field])) {
+    for (const item of received.map(r => r[this.field])) {
       const i = expectations.indexOf(item);
       if (i >= 0) {
         expectations.splice(i, 1);
@@ -82,14 +79,14 @@ class ResultInspector {
 describe('particle-api', () => {
   let runtime = null;
 
-  async function loadFilesIntoNewArc(fileMap: {[index:string]: string, manifest: string}): Promise<Arc> {
+  async function loadFilesIntoNewArc(fileMap: {[index:string]: string, manifest: string}): Promise<ArcInfo> {
     const manifest = await Manifest.parse(fileMap.manifest);
     runtime = new Runtime({loader: new Loader(null, fileMap), context: manifest});
-    return runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo'}));
+    return runtime.allocator.startArc({arcName: 'demo'});
   }
 
   it('StorageProxy integration test', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Data
           value: Text
@@ -135,16 +132,17 @@ describe('particle-api', () => {
       `
     });
 
-    const data = Entity.createEntityClass(arc.context.findSchemaByName('Data'), null);
-    const fooStore = await arc.createStore(new SingletonType(data.type), 'foo', 'test:0');
-    const fooHandle = await handleForStoreInfo(fooStore, arc);
-    const resStore = await arc.createStore(data.type.collectionOf(), 'res', 'test:1');
-    const inspector = new ResultInspector(arc, resStore, 'value');
-    const recipe = arc.context.recipes[0];
+    const data = Entity.createEntityClass(arcInfo.context.findSchemaByName('Data'), null);
+    const fooStore = await arcInfo.createStoreInfo(new SingletonType(data.type), {name: 'foo', id: 'test:0'});
+    const fooHandle = await runtime.host.handleForStoreInfo(fooStore, arcInfo);
+    const resStore = await arcInfo.createStoreInfo(data.type.collectionOf(), {name: 'res', id: 'test:1'});
+    const arc = runtime.getArcById(arcInfo.id);
+    const inspector = new ResultInspector(runtime, arc, resStore, 'value');
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(fooStore);
     recipe.handles[1].mapToStorage(resStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
     await inspector.verify('sync:null');
 
     // Drop event 2; desync is triggered by v3.
@@ -170,7 +168,7 @@ describe('particle-api', () => {
   });
 
   it('can sync/update and store/remove with collections', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -203,18 +201,18 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const resultStore = await arc.createStore(result.type.collectionOf(), undefined, 'result-handle');
-    const resultHandle = await handleForStoreInfo(resultStore, arc);
-    const recipe = arc.context.recipes[0];
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const resultStore = await arcInfo.createStoreInfo(result.type.collectionOf(), {id: 'result-handle'});
+    const resultHandle = await runtime.host.handleForStoreInfo(resultStore, arcInfo);
+    const recipe = arcInfo.context.recipes[0];
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    await runtime.getArcById(arcInfo.id).idle;
     const values = await resultHandle.toList();
     assert.deepStrictEqual(values as {}[], [{value: 'two'}]);
   });
 
   it('contains a constructInnerArc call', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -244,26 +242,27 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const resultStore = await arc.createStore(new SingletonType(result.type), undefined, 'test:1');
-    const resultHandle = await handleForStoreInfo(resultStore, arc);
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const resultStore = await arcInfo.createStoreInfo(new SingletonType(result.type), {id: 'test:1'});
+    const resultHandle = await runtime.host.handleForStoreInfo(resultStore, arcInfo);
 
-    const recipe = arc.context.recipes[0];
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
-    const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
+    const [innerArc] = arc.findInnerArcs(arcInfo.activeRecipe.particles[0]);
     const newStore = innerArc.findStoresByType(new SingletonType(result.type))[0];
     assert.strictEqual(newStore.name, 'hello');
 
-    const newHandle = await handleForStoreInfo(newStore, arc);
+    const newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'success'});
   });
 
   it('can load a recipe', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -327,28 +326,29 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const resultStore = await arc.createStore(new SingletonType(result.type), undefined, 'test:1');
-    const resultHandle = await handleForStoreInfo(resultStore, arc);
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const resultStore = await arcInfo.createStoreInfo(new SingletonType(result.type), {id: 'test:1'});
+    const resultHandle = await runtime.host.handleForStoreInfo(resultStore, arcInfo);
 
-    const recipe = arc.context.recipes[0];
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
-    const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
+    const [innerArc] = arc.findInnerArcs(arcInfo.activeRecipe.particles[0]);
     const newStore = innerArc.findStoresByType(new SingletonType(result.type))[1];
     assert.strictEqual(newStore.name, 'the-out');
 
-    const newHandle = await handleForStoreInfo(newStore, arc);
+    const newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'success'});
   });
 
   // TODO(cypher1): Disabling this for now. The resolution seems to depend on order.
   // It is likely that this usage was depending on behavior that may not be intended.
   it.skip('can load a recipe referencing a manifest store', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -424,26 +424,27 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const resultStore = await arc.createStore(new SingletonType(result.type), undefined, 'test:1');
-    const resultHandle = await handleForStoreInfo(resultStore, arc);
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const resultStore = await arcInfo.createStoreInfo(new SingletonType(result.type), {id: 'test:1'});
+    const resultHandle = await runtime.host.handleForStoreInfo(resultStore, arcInfo);
 
-    const recipe = arc.context.recipes[0];
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
-    const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
+    const [innerArc] = arc.findInnerArcs(arcInfo.activeRecipe.particles[0]);
     const newStore = innerArc.findStoresByType(new SingletonType(result.type))[1];
     assert.strictEqual(newStore.name, 'the-out');
 
-    const newHandle = await handleForStoreInfo(newStore, arc);
+    const newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'success'});
   });
 
   it('can load a recipe referencing a tagged handle in containing arc', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -522,22 +523,23 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const resultStore = await arc.createStore(new SingletonType(result.type), undefined, 'test:1');
-    const resultHandle = await handleForStoreInfo(resultStore, arc);
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const resultStore = await arcInfo.createStoreInfo(new SingletonType(result.type), {id: 'test:1'});
+    const resultHandle = await runtime.host.handleForStoreInfo(resultStore, arcInfo);
 
-    const recipe = arc.context.recipes[0];
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
     recipe.normalize();
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
-    const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
+    const [innerArc] = arc.findInnerArcs(arcInfo.activeRecipe.particles[0]);
     const newStore = innerArc.findStoresByType(new SingletonType(result.type))[1];
     assert.strictEqual(newStore.name, 'the-out');
 
-    const newHandle = await handleForStoreInfo(newStore, arc);
+    const newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'success'});
   });
 
@@ -549,7 +551,7 @@ describe('particle-api', () => {
   // execution host's strategizer or adding such fallback to
   // `arc.findStoresByType`.
   it.skip('can load a recipe referencing a tagged handle in manifest', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -625,26 +627,27 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const resultStore = await arc.createStore(new SingletonType(result.type), undefined, 'test:1');
-    const resultHandle = await handleForStoreInfo(resultStore, arc);
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const resultStore = await arcInfo.createStoreInfo(new SingletonType(result.type), {id: 'test:1'});
+    const resultHandle = await runtime.host.handleForStoreInfo(resultStore, arcInfo);
 
-    const recipe = arc.context.recipes[0];
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(resultStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
     assert.deepStrictEqual(await resultHandle.fetch() as {}, {value: 'done'});
-    const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
+    const [innerArc] = arc.findInnerArcs(arcInfo.activeRecipe.particles[0]);
     const newStore = innerArc.findStoresByType(new SingletonType(result.type))[1];
     assert.strictEqual(newStore.name, 'the-out');
 
-    const newHandle = await handleForStoreInfo(newStore, arc);
+    const newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'success'});
   });
 
   it('multiplexing', async () => {
-    const arc = await loadFilesIntoNewArc({
+    const arcInfo = await loadFilesIntoNewArc({
       manifest: `
         schema Result
           value: Text
@@ -724,33 +727,34 @@ describe('particle-api', () => {
       `
     });
 
-    const result = Entity.createEntityClass(arc.context.findSchemaByName('Result'), null);
-    const inputsStore = await arc.createStore(result.type.collectionOf(), undefined, 'test:1');
-    const inputsHandle = await handleForStoreInfo(inputsStore, arc);
+    const result = Entity.createEntityClass(arcInfo.context.findSchemaByName('Result'), null);
+    const inputsStore = await arcInfo.createStoreInfo(result.type.collectionOf(), {id: 'test:1'});
+    const inputsHandle = await runtime.host.handleForStoreInfo(inputsStore, arcInfo);
     await inputsHandle.add(new inputsHandle.entityClass({value: 'hello'}));
     await inputsHandle.add(new inputsHandle.entityClass({value: 'world'}));
-    const resultsStore = await arc.createStore(result.type.collectionOf(), undefined, 'test:2');
-    const resultsHandle = await handleForStoreInfo(resultsStore, arc);
-    const inspector = new ResultInspector(arc, resultsStore, 'value');
-    const recipe = arc.context.recipes[0];
+    const resultsStore = await arcInfo.createStoreInfo(result.type.collectionOf(), {id: 'test:2'});
+    const resultsHandle = await runtime.host.handleForStoreInfo(resultsStore, arcInfo);
+    const arc = runtime.getArcById(arcInfo.id);
+    const inspector = new ResultInspector(runtime, arc, resultsStore, 'value');
+    const recipe = arcInfo.context.recipes[0];
     recipe.handles[0].mapToStorage(inputsStore);
     recipe.handles[1].mapToStorage(resultsStore);
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
     await arc.idle;
     assert.sameMembers((await resultsHandle.toList()).map(item => item.value), ['done', 'done', 'HELLO', 'WORLD']);
     await inspector.verify('done', 'done', 'HELLO', 'WORLD');
 
-    const [innerArc] = arc.findInnerArcs(arc.activeRecipe.particles[0]);
+    const [innerArc] = arc.findInnerArcs(arcInfo.activeRecipe.particles[0]);
     const innerArcStores = innerArc.findStoresByType(new SingletonType(result.type));
 
     let newStore = innerArcStores[1];
     assert.strictEqual(innerArcStores[1].name, 'the-out', `Unexpected newStore name: ${newStore.name}`);
-    let newHandle = await handleForStoreInfo(newStore, arc);
+    let newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'HELLO'});
 
     newStore = innerArcStores[3];
     assert.strictEqual(newStore.name, 'the-out', `Unexpected newStore name: ${newStore.name}`);
-    newHandle = await handleForStoreInfo(newStore, arc);
+    newHandle = await runtime.host.handleForStoreInfo(newStore, arcInfo) as SingletonEntityHandle;
     assert.deepStrictEqual(await newHandle.fetch() as {}, {value: 'WORLD'});
   });
 
@@ -788,24 +792,24 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
-    const inStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {}))), 'foo', 'test:1');
-    const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'faz', 'test:2');
+    const inStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {}))), {name: 'foo', id: 'test:1'});
+    const outStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), {name: 'faz', id: 'test:2'});
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
 
-    const inHandle = await handleForStoreInfo(inStore, arc);
+    const inHandle = await runtime.host.handleForStoreInfo(inStore, arcInfo);
     const entityType = Entity.createEntityClass(inStore.type.getEntitySchema(), null);
     const entity = new entityType({}, '1');
     await inHandle.set(entity);
 
-    await arc.idle;
-    const outHandle = await handleForStoreInfo(outStore, arc);
+    await runtime.getArcById(arcInfo.id).idle;
+    const outHandle = await runtime.host.handleForStoreInfo(outStore, arcInfo);
     assert.deepStrictEqual(await outHandle.fetch() as {}, {result: 'hi'});
   });
 
@@ -844,24 +848,24 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({loader, context: new Manifest({id})});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
-    const inStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {}))), 'foo', 'test:1');
-    const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'faz', 'test:2');
+    const inStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {}))), {name: 'foo', id: 'test:1'});
+    const outStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), {name: 'faz', id: 'test:2'});
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
 
-    const inHandle = await handleForStoreInfo(inStore, arc);
+    const inHandle = await runtime.host.handleForStoreInfo(inStore, arcInfo);
     const entityType = Entity.createEntityClass(inStore.type.getEntitySchema(), null);
     const entity = new entityType({}, '1');
     await inHandle.set(entity);
 
-    await arc.idle;
-    const outHandle = await handleForStoreInfo(outStore, arc);
+    await runtime.getArcById(arcInfo.id).idle;
+    const outHandle = await runtime.host.handleForStoreInfo(outStore, arcInfo);
     assert.deepStrictEqual(await outHandle.fetch() as {}, {result: 'hi'});
   });
 
@@ -900,22 +904,23 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
-    const inStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {}))), 'foo', 'test:1');
-    const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'faz', 'test:2');
+    const inStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {}))), {name: 'foo', id: 'test:1'});
+    const outStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), {name: 'faz', id: 'test:2'});
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arcInfo, recipe);
 
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
-    const inHandle = await handleForStoreInfo(inStore, arc);
+    const inHandle = await runtime.host.handleForStoreInfo(inStore, arcInfo);
     await inHandle.set(new inHandle.entityClass({}));
     await arc.idle;
-    const outHandle = await handleForStoreInfo(outStore, arc);
+    const outHandle = await runtime.host.handleForStoreInfo(outStore, arcInfo);
     assert.deepStrictEqual(await outHandle.fetch() as {}, {result: 'hi'});
   });
 
@@ -953,18 +958,18 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test'});
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
 
-    const inStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {}))), 'h0', 'test:0');
-    const outStore = await arc.createStore(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), 'h1', 'test:1');
+    const inStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {}))), {name: 'h0', id: 'test:0'});
+    const outStore = await arcInfo.createStoreInfo(new SingletonType(new EntityType(new Schema([], {result: 'Text'}))), {name: 'h1', id: 'test:1'});
     recipe.handles[0].mapToStorage(inStore);
     recipe.handles[1].mapToStorage(outStore);
     recipe.normalize();
 
-    const {speculativeArc, relevance} = await (new Speculator(runtime)).speculate(arc, recipe, 'recipe-hash');
-    const description = await Description.create(speculativeArc, relevance);
+    const {speculativeArc, relevance} = await (new Speculator(runtime)).speculate(runtime.getArcById(arcInfo.id), recipe, 'recipe-hash');
+    const description = await Description.create(speculativeArc, runtime, relevance);
     assert.strictEqual(description.getRecipeSuggestion(), 'Out is hi!');
   });
 
@@ -1016,13 +1021,13 @@ describe('particle-api', () => {
 
     const id = IdGenerator.createWithSessionIdForTesting('session').newArcId('test');
     const runtime = new Runtime({context: new Manifest({id}), loader});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'test'})).id);
     const manifest = await Manifest.load('./manifest', loader);
     const recipe = manifest.recipes[0];
     assert.isTrue(recipe.normalize());
 
     const {speculativeArc, relevance} = await (new Speculator(runtime)).speculate(arc, recipe, 'recipe-hash');
-    const description = await Description.create(speculativeArc, relevance);
+    const description = await Description.create(speculativeArc, runtime, relevance);
     assert.strictEqual(description.getRecipeSuggestion(), 'Out is hi!');
   });
 
@@ -1075,13 +1080,14 @@ describe('particle-api', () => {
     });
     // TODO(lindner): add strict rendering
     const runtime = new Runtime({loader, context});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', planName: 'DemoPlan'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', planName: 'DemoPlan'});
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
-    assert.lengthOf(arc.activeRecipe.particles, 1);
-    const [transformationParticle] = arc.activeRecipe.particles;
+    assert.lengthOf(arcInfo.activeRecipe.particles, 1);
+    const [transformationParticle] = arcInfo.activeRecipe.particles;
 
-    assert.lengthOf(arc.recipeDeltas, 1);
+    assert.lengthOf(arcInfo.recipeDeltas, 1);
     const [innerArc] = arc.findInnerArcs(transformationParticle);
 
     const sessionId = innerArc.idGenerator.currentSessionIdForTesting;

--- a/src/runtime/tests/recipe-resolver-test.ts
+++ b/src/runtime/tests/recipe-resolver-test.ts
@@ -26,7 +26,7 @@ describe('RecipeResolver', () => {
 
   const createArc = async (manifest) => {
     const runtime = new Runtime({loader: new Loader(), context: manifest});
-    return runtime.getArcById(await runtime.allocator.startArc({arcName: 'test'}));
+    return runtime.getArcById((await runtime.allocator.startArc({arcName: 'test'})).id);
   };
 
   it('resolves a recipe', async () => {

--- a/src/runtime/tests/reference-test.ts
+++ b/src/runtime/tests/reference-test.ts
@@ -19,7 +19,6 @@ import {ReferenceModeStorageKey} from '../storage/reference-mode-storage-key.js'
 import {Reference} from '../reference.js';
 import {TestVolatileMemoryProvider} from '../testing/test-volatile-memory-provider.js';
 import {Runtime} from '../runtime.js';
-import {handleForStoreInfo} from '../storage/storage.js';
 
 describe('reference', () => {
   it('can parse & validate a recipe containing references', async () => {
@@ -94,45 +93,36 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
-    const refModeStore = await arc.createStore(
-      new SingletonType(result.type),
-      undefined,
-      'test:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
-    const refStore = await arc.createStore(
-      new SingletonType(new ReferenceType(result.type)),
-      undefined,
-      'input:1',
-      undefined,
-      new VolatileStorageKey(arc.id, 'refStore')
-    );
-    const outStore = await arc.createStore(
-      new SingletonType(result.type),
-      undefined,
-      'output:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
-    );
+    const refModeStore = await arc.createStoreInfo(new SingletonType(result.type), {
+      id: 'test:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
+    const refStore = await arc.createStoreInfo(new SingletonType(new ReferenceType(result.type)), {
+      id: 'input:1',
+      storageKey: new VolatileStorageKey(arc.id, 'refStore')
+    });
+    const outStore = await arc.createStoreInfo(new SingletonType(result.type), {
+      id: 'output:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
+    });
 
     recipe.handles[0].mapToStorage(refStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
 
-    const inHandle = await handleForStoreInfo(refModeStore, arc);
+    const inHandle = await runtime.host.handleForStoreInfo(refModeStore, arc);
     const entity = await inHandle.setFromData({value: 'val1'});
-    const refHandle = await handleForStoreInfo(refStore, arc);
+    const refHandle = await runtime.host.handleForStoreInfo(refStore, arc);
     await refHandle.set(new Reference({id: Entity.id(entity), entityStorageKey: refModeStore.storageKey.toString()}, refStore.type.getContainedType(), refHandle.storageFrontend));
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
 
-    const outHandle = await handleForStoreInfo(outStore, arc);
+    const outHandle = await runtime.host.handleForStoreInfo(outStore, arc);
     const value = await outHandle.fetch();
     assert.deepStrictEqual(value as {}, {value: 'val1'});
   });
@@ -178,58 +168,46 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
-    const refModeStore1 = await arc.createStore(
-      new SingletonType(result.type),
-      undefined,
-      'test:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
-    const refModeStore2 = await arc.createStore(
-      new SingletonType(result.type),
-      undefined,
-      'test:2',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
-    );
-    const inputStore = await arc.createStore(
-      new CollectionType(new ReferenceType(result.type)),
-      undefined,
-      'input:1',
-      undefined,
-      new VolatileStorageKey(arc.id, 'inputStore')
-    );
-    const outputStore = await arc.createStore(
-      new CollectionType(result.type),
-      undefined,
-      'output:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
-    );
+    const refModeStore1 = await arc.createStoreInfo(new SingletonType(result.type), {
+      id: 'test:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
+    const refModeStore2 = await arc.createStoreInfo(new SingletonType(result.type), {
+      id: 'test:2',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
+    });
+    const inputStore = await arc.createStoreInfo(new CollectionType(new ReferenceType(result.type)), {
+      id: 'input:1',
+      storageKey: new VolatileStorageKey(arc.id, 'inputStore')
+    });
+    const outputStore = await arc.createStoreInfo(new CollectionType(result.type), {
+      id: 'output:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
+    });
 
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(outputStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
 
-    const handle1 = await handleForStoreInfo(refModeStore1, arc);
-    const handle2 = await handleForStoreInfo(refModeStore2, arc);
+    const handle1 = await runtime.host.handleForStoreInfo(refModeStore1, arc);
+    const handle2 = await runtime.host.handleForStoreInfo(refModeStore2, arc);
     const entity1 = await handle1.setFromData({value: 'val1'});
     const entity2 = await handle2.setFromData({value: 'val2'});
 
-    const refHandle = await handleForStoreInfo(inputStore, arc);
+    const refHandle = await runtime.host.handleForStoreInfo(inputStore, arc);
     const storageFrontend = refHandle.storageFrontend;
     await refHandle.add(new Reference({id: Entity.id(entity1), entityStorageKey: refModeStore1.storageKey.toString()}, inputStore.type.getContainedType(), storageFrontend));
     await refHandle.add(new Reference({id: Entity.id(entity2), entityStorageKey: refModeStore2.storageKey.toString()}, inputStore.type.getContainedType(), storageFrontend));
 
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
 
-    const outHandle = await handleForStoreInfo(outputStore, arc);
+    const outHandle = await runtime.host.handleForStoreInfo(outputStore, arc);
     const values = await outHandle.toList();
     assert.deepStrictEqual(values as {}[], [{value: 'val1'}, {value: 'val2'}]);
   });
@@ -275,37 +253,31 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
-    const inputStore = await arc.createStore(
-      new SingletonType(result.type),
-      undefined,
-      'test:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
+    const inputStore = await arc.createStoreInfo(new SingletonType(result.type), {
+      id: 'test:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
 
-    const refStore = await arc.createStore(
-      new SingletonType(new ReferenceType(result.type)),
-      undefined,
-      'test:2',
-      undefined,
-      new VolatileStorageKey(arc.id, 'refStore')
-    );
+    const refStore = await arc.createStoreInfo(new SingletonType(new ReferenceType(result.type)), {
+      id: 'test:2',
+      storageKey: new VolatileStorageKey(arc.id, 'refStore')
+    });
 
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(refStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
+    await runtime.allocator.runPlanInArc(arc, recipe);
 
-    const handle = await handleForStoreInfo(inputStore, arc);
+    const handle = await runtime.host.handleForStoreInfo(inputStore, arc);
     const entity = await handle.setFromData({value: 'what a result!'});
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
 
     const storageKey = Entity.storageKey(entity);
-    const refHandle = await handleForStoreInfo(refStore, arc);
+    const refHandle = await runtime.host.handleForStoreInfo(refStore, arc);
     const reference = await refHandle.fetch();
     assert.equal(reference['id'], Entity.id(entity));
     assert.equal(reference['entityStorageKey'], storageKey);
@@ -354,49 +326,40 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const resultEntity = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
 
-    const entityStore = await arc.createStore(
-      new SingletonType(resultEntity.type),
-      undefined,
-      'test:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
+    const entityStore = await arc.createStoreInfo(new SingletonType(resultEntity.type), {
+      id: 'test:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
 
     const referenceIn = manifest.particles[0].handleConnectionMap.get('referenceIn');
     const refType = referenceIn.type as EntityType;
-    const inputStore = await arc.createStore(
-      new SingletonType(refType),
-      undefined,
-      'input:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
-    );
+    const inputStore = await arc.createStoreInfo(new SingletonType(refType), {
+      id: 'input:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
+    });
 
-    const outStore = await arc.createStore(
-      new SingletonType(resultEntity.type),
-      undefined,
-      'output:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
-    );
+    const outStore = await arc.createStoreInfo(new SingletonType(resultEntity.type), {
+      id: 'output:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
+    });
 
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(outStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
 
-    const entityHandle = await handleForStoreInfo(entityStore, arc);
+    const entityHandle = await runtime.host.handleForStoreInfo(entityStore, arc);
     const entity = await entityHandle.setFromData({value: 'what a result!'});
-    const inHandle = await handleForStoreInfo(inputStore, arc);
+    const inHandle = await runtime.host.handleForStoreInfo(inputStore, arc);
     await inHandle.setFromData({result: new Reference({id: Entity.id(entity), entityStorageKey: entityStore.storageKey.toString()}, new ReferenceType(resultEntity.type), inHandle.storageFrontend)});
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
 
-    const outHandle = await handleForStoreInfo(outStore, arc);
+    const outHandle = await runtime.host.handleForStoreInfo(outStore, arc);
     assert.strictEqual(outHandle.type.getContainedType().getEntitySchema().name, 'Result');
     const out = await outHandle.fetch();
     assert.equal(out.value, 'what a result!');
@@ -493,50 +456,41 @@ describe('reference', () => {
     const memoryProvider = new TestVolatileMemoryProvider();
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
 
     // create 'input:1' store to hold [Result]
     const resultType = Entity.createEntityClass(manifest.findSchemaByName('Result'), null).type;
-    const resultInputStore = await arc.createStore(
-      new CollectionType(resultType),
-      undefined,
-      'input:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
+    const resultInputStore = await arc.createStoreInfo(new CollectionType(resultType), {
+      id: 'input:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
 
     const fooType = manifest.particles[0].handleConnectionMap.get('inFoo').type as EntityType;
-    const fooInputStore = await arc.createStore(
-      new SingletonType(fooType),
-      undefined,
-      'input:2',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
-    );
+    const fooInputStore = await arc.createStoreInfo(new SingletonType(fooType), {
+      id: 'input:2',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
+    });
 
-    const fooOutputStore = await arc.createStore(
-      new CollectionType(fooType),
-      undefined,
-      'output:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
-    );
+    const fooOutputStore = await arc.createStoreInfo(new CollectionType(fooType), {
+      id: 'output:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
+    });
 
     recipe.handles[0].mapToStorage(resultInputStore);
     recipe.handles[1].mapToStorage(fooInputStore);
     recipe.handles[2].mapToStorage(fooOutputStore);
 
-    const fooInHandle = await handleForStoreInfo(fooInputStore, arc);
+    const fooInHandle = await runtime.host.handleForStoreInfo(fooInputStore, arc);
     await fooInHandle.setFromData({result: null, shortForm: 'a'});
 
-    const resultInHandle = await handleForStoreInfo(resultInputStore, arc);
+    const resultInHandle = await runtime.host.handleForStoreInfo(resultInputStore, arc);
     const resultInEntities = await resultInHandle.addMultipleFromData([{value: 'this is an a'}, {value: 'this is a b'}]);
 
-    const fooOutHandle = await handleForStoreInfo(fooOutputStore, arc);
+    const fooOutHandle = await runtime.host.handleForStoreInfo(fooOutputStore, arc);
     await fooOutHandle.addFromData({result: null, shortForm: 'b'});
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
 
     const values = await fooOutHandle.toList();
     assert.strictEqual(values.length, 2);
@@ -615,40 +569,35 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
     const result = Entity.createEntityClass(manifest.findSchemaByName('Result'), null);
     const referenceOut = manifest.particles[0].handleConnectionMap.get('referenceOut');
     const refType = referenceOut.type as EntityType;
 
-    const inputStore = await arc.createStore(
-      new CollectionType(result.type),
-      undefined,
-      'input:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
-    const refStore = await arc.createStore(
-      new SingletonType(refType),
-      undefined,
-      'output:1',
-      undefined,
-      new VolatileStorageKey(arc.id, 'refStore')
-    );
+    const inputStore = await arc.createStoreInfo(new CollectionType(result.type), {
+      id: 'input:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
+    const refStore = await arc.createStoreInfo(new SingletonType(refType), {
+      id: 'output:1',
+      storageKey: new VolatileStorageKey(arc.id, 'refStore')
+    });
 
     recipe.handles[0].mapToStorage(inputStore);
     recipe.handles[1].mapToStorage(refStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-
-    const handle = await handleForStoreInfo(inputStore, arc);
+    const handle = await runtime.host.handleForStoreInfo(inputStore, arc);
     assert.strictEqual((handle.type.getContainedType() as EntityType).entitySchema.name, 'Result');
+
+    await runtime.allocator.runPlanInArc(arc, recipe);
+
     const now = new Date().getTime();
     await handle.add(Entity.identify(new handle.entityClass({value: 'what a result!'}), 'id:1', null, now));
     await handle.add(Entity.identify(new handle.entityClass({value: 'what another result!'}), 'id:2', null, now));
 
-    await arc.idle;
-    const outputHandle = await handleForStoreInfo(refStore, arc);
+    await runtime.getArcById(arc.id).idle;
+    const outputHandle = await runtime.host.handleForStoreInfo(refStore, arc);
     assert.strictEqual(outputHandle.type.getContainedType().getEntitySchema().name, 'Foo');
     const outputRefs = await outputHandle.fetch();
     const ids = [...outputRefs.result].map(ref => ref.id);
@@ -699,53 +648,44 @@ describe('reference', () => {
 
     const manifest = await Manifest.load('./manifest', loader, {memoryProvider});
     const runtime = new Runtime({loader, context: manifest, memoryProvider});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix}));
+    const arc = await runtime.allocator.startArc({arcName: 'test', storageKeyPrefix});
     const recipe = manifest.recipes[0];
 
     const resultType = Entity.createEntityClass(manifest.findSchemaByName('Result'), null).type;
-    const resultInputStore = await arc.createStore(
-      new CollectionType(resultType),
-      undefined,
-      'test:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
-    );
+    const resultInputStore = await arc.createStoreInfo(new CollectionType(resultType), {
+      id: 'test:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'a'), new VolatileStorageKey(arc.id, 'b'))
+    });
 
     const fooType = manifest.particles[0].handleConnectionMap.get('referenceIn').type as EntityType;
-    const fooInputStore = await arc.createStore(
-      new SingletonType(fooType),
-      undefined,
-      'input:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
-    );
+    const fooInputStore = await arc.createStoreInfo(new SingletonType(fooType), {
+      id: 'input:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'c'), new VolatileStorageKey(arc.id, 'd'))
+    });
 
-    const resultOutputStore = await arc.createStore(
-      new CollectionType(resultType),
-      undefined,
-      'output:1',
-      undefined,
-      new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
-    );
+    const resultOutputStore = await arc.createStoreInfo(new CollectionType(resultType), {
+      id: 'output:1',
+      storageKey: new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, 'e'), new VolatileStorageKey(arc.id, 'f'))
+    });
 
     recipe.handles[0].mapToStorage(fooInputStore);
     recipe.handles[1].mapToStorage(resultOutputStore);
 
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
 
-    const handle = await handleForStoreInfo(resultInputStore, arc);
+    const handle = await runtime.host.handleForStoreInfo(resultInputStore, arc);
     const resultEntities = await handle.addMultipleFromData([{value: 'what a result!'}, {value: 'what another result!'}]);
 
-    const fooInHandle = await handleForStoreInfo(fooInputStore, arc);
+    const fooInHandle = await runtime.host.handleForStoreInfo(fooInputStore, arc);
     await fooInHandle.setFromData({result: [
       {id: Entity.id(resultEntities[0]), creationTimestamp: Entity.creationTimestamp(resultEntities[0]), entityStorageKey: Entity.storageKey(resultEntities[0])},
       {id: Entity.id(resultEntities[1]), creationTimestamp: Entity.creationTimestamp(resultEntities[1]), entityStorageKey: Entity.storageKey(resultEntities[1])},
     ]});
 
-    await arc.idle;
+    await runtime.getArcById(arc.id).idle;
 
-    const outputHandle = await handleForStoreInfo(resultOutputStore, arc);
+    const outputHandle = await runtime.host.handleForStoreInfo(resultOutputStore, arc);
     assert.strictEqual((outputHandle.type.getContainedType() as EntityType).entitySchema.name, 'Result');
     const values = await outputHandle.toList();
     assert.strictEqual(values.length, 2);

--- a/src/runtime/tests/runtime-manifest-integration-test.ts
+++ b/src/runtime/tests/runtime-manifest-integration-test.ts
@@ -10,18 +10,18 @@
 
 import {assert} from '../../platform/chai-web.js';
 import {manifestTestSetup} from '../testing/manifest-integration-test-setup.js';
-import {handleForStoreInfo, SingletonEntityType} from '../storage/storage.js';
+import {SingletonEntityType} from '../storage/storage.js';
 import {StoreInfo} from '../storage/store-info.js';
 
 describe('runtime manifest integration', () => {
   it('can produce a recipe that can be instantiated in an arc', async () => {
     const {runtime, arc, recipe} = await manifestTestSetup();
-    await runtime.allocator.runPlanInArc(arc.id, recipe);
-    await arc.idle;
+    await runtime.allocator.runPlanInArc(arc, recipe);
+    await runtime.getArcById(arc.id).idle;
     const type = recipe.handles[0].type;
     const storeInfo = arc.findStoresByType(type)[0] as StoreInfo<SingletonEntityType>;
 
-    const handle = await handleForStoreInfo(storeInfo, arc);
+    const handle = await runtime.host.handleForStoreInfo(storeInfo, arc);
     const result = await handle.fetch();
     assert.strictEqual(result['value'], 'Hello, world!');
   });

--- a/src/runtime/tests/runtime-test.ts
+++ b/src/runtime/tests/runtime-test.ts
@@ -47,10 +47,10 @@ function assertManifestsEqual(actual: Manifest, expected: Manifest) {
 describe('Runtime', () => {
   it('gets an arc description for an arc', async () => {
     const runtime = new Runtime();
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcId: ArcId.newForTest('test')}));
-    const description = await Description.create(arc);
+    const arcInfo = await runtime.allocator.startArc({arcId: ArcId.newForTest('test')});
+    const description = await Description.create(runtime.getArcById(arcInfo.id), runtime);
     const expected = await description.getArcDescription();
-    const actual = await runtime.getArcDescription(arc);
+    const actual = await runtime.getArcDescription(arcInfo.id);
     assert.strictEqual(expected, actual);
   });
   it('parses a Manifest', async () => {
@@ -83,14 +83,16 @@ describe('Runtime', () => {
     const runtime = new Runtime();
     const arcById = runtime => (runtime.host as ArcHostImpl).arcById;
     assert.equal(arcById(runtime).size, 0);
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    assert.isNotNull(arc);
-    assert(arc.id.toString().includes('test-arc'));
-    assert.hasAllKeys(arcById(runtime), [arc.id]);
-    runtime.getArcById(await runtime.allocator.startArc({storageKeyPrefix: volatileStorageKeyPrefixForTest(), arcId: arc.id}));
-    assert.hasAllKeys(arcById(runtime), [arc.id]);
-    const otherArc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'other-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    assert.hasAllKeys(arcById(runtime), [arc.id, otherArc.id]);
+    const arcInfo = await runtime.allocator.startArc({arcName: 'test-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    assert.isNotNull(arcInfo);
+    assert(arcInfo.id.toString().includes('test-arc'));
+    assert.hasAllKeys(arcById(runtime), [arcInfo.id]);
+    assert.isNotNull(runtime.getArcById(arcInfo.id));
+    await runtime.allocator.startArc({storageKeyPrefix: volatileStorageKeyPrefixForTest(), arcId: arcInfo.id});
+    assert.hasAllKeys(arcById(runtime), [arcInfo.id]);
+    const otherArcInfo = await runtime.allocator.startArc({arcName: 'other-arc', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    assert.hasAllKeys(arcById(runtime), [arcInfo.id, otherArcInfo.id]);
+    assert.isNotNull(runtime.getArcById(otherArcInfo.id));
   });
   it('registers and unregisters stores', Flags.withDefaultReferenceMode(async () => {
     const loader = new Loader(null, {
@@ -120,33 +122,33 @@ describe('Runtime', () => {
     const runtime = new Runtime({loader});
     const manifest = await runtime.parseFile('manifest');
     manifest.recipes[0].normalize();
-    const volatileArc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc-1', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    const ramdiskArc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc-2', storageKeyPrefix: ramDiskStorageKeyPrefixForTest()}));
+    const volatileArc = await runtime.allocator.startArc({arcName: 'test-arc-1', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    const ramdiskArc = await runtime.allocator.startArc({arcName: 'test-arc-2', storageKeyPrefix: ramDiskStorageKeyPrefixForTest()});
     assert.equal(runtime.context, ramdiskArc.context);
     assert.equal(runtime.context, volatileArc.context);
 
-    await runtime.allocator.runPlanInArc(volatileArc.id, manifest.recipes[0]);
+    await runtime.allocator.runPlanInArc(volatileArc, manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 3);
 
-    await runtime.allocator.runPlanInArc(ramdiskArc.id, manifest.recipes[0]);
+    await runtime.allocator.runPlanInArc(ramdiskArc, manifest.recipes[0]);
     assert.lengthOf(runtime.context.stores, 6);
 
-    const volatileArc1 = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc-v1', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    const plan1 = await runtime.resolveRecipe(volatileArc1, manifest.recipes[1]);
-    await runtime.allocator.runPlanInArc(volatileArc1.id, plan1);
+    const volatileArc1 = await runtime.allocator.startArc({arcName: 'test-arc-v1', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    const plan1 = await runtime.resolveRecipe(runtime.getArcById(volatileArc1.id), manifest.recipes[1]);
+    await runtime.allocator.runPlanInArc(volatileArc1, plan1);
     assert.lengthOf(runtime.context.stores, 6);
-    volatileArc1.dispose();
-    assert.lengthOf(runtime.context.stores, 6);
-
-    volatileArc.dispose();
+    runtime.allocator.stopArc(volatileArc1.id);
     assert.lengthOf(runtime.context.stores, 6);
 
-    ramdiskArc.dispose();
+    runtime.allocator.stopArc(volatileArc.id);
     assert.lengthOf(runtime.context.stores, 6);
 
-    const volatileArc2 = runtime.getArcById(await runtime.allocator.startArc({arcName: 'test-arc-v2', storageKeyPrefix: volatileStorageKeyPrefixForTest()}));
-    const plan2 = await runtime.resolveRecipe(volatileArc2, manifest.recipes[1]);
-    await runtime.allocator.runPlanInArc(volatileArc2.id, plan2);
+    runtime.allocator.stopArc(ramdiskArc.id);
+    assert.lengthOf(runtime.context.stores, 6);
+
+    const volatileArc2 = await runtime.allocator.startArc({arcName: 'test-arc-v2', storageKeyPrefix: volatileStorageKeyPrefixForTest()});
+    const plan2 = await runtime.resolveRecipe(runtime.getArcById(volatileArc2.id), manifest.recipes[1]);
+    await runtime.allocator.runPlanInArc(volatileArc2, plan2);
     assert.lengthOf(runtime.context.stores, 6);
     assert.isTrue(runtime.context.stores.map(s => s.storageKey).includes(
         volatileArc2.activeRecipe.handles[0].storageKey));

--- a/src/tests/arc-integration-test.ts
+++ b/src/tests/arc-integration-test.ts
@@ -43,11 +43,12 @@ describe('Arc integration', () => {
     `);
     runtime.context = manifest;
 
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', planName: 'ThingPlan'}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', planName: 'ThingPlan'});
+    const arc = runtime.getArcById(arcInfo.id);
     await arc.idle;
 
-    assert.lengthOf(arc.stores, 1);
+    assert.lengthOf(arcInfo.stores, 1);
     assert.lengthOf(Object.keys(arc.storeTagsById), 1);
-    assert.deepEqual(['best'], [...arc.storeTagsById[arc.stores[0].id]]);
+    assert.deepEqual(['best'], [...arcInfo.storeTagsById[arcInfo.stores[0].id]]);
   });
 });

--- a/src/tests/particles/common-test.ts
+++ b/src/tests/particles/common-test.ts
@@ -16,7 +16,7 @@ import {Loader} from '../../platform/loader.js';
 import {StrategyTestHelper} from '../../planning/testing/strategy-test-helper.js';
 import {RamDiskStorageDriverProvider} from '../../runtime/storage/drivers/ramdisk.js';
 import {storageKeyPrefixForTest} from '../../runtime/testing/handle-for-test.js';
-import {handleForActiveStore, CollectionEntityType} from '../../runtime/storage/storage.js';
+import {CollectionEntityType} from '../../runtime/storage/storage.js';
 import {StoreInfo} from '../../runtime/storage/store-info.js';
 
 describe('common particles test', () => {
@@ -75,20 +75,21 @@ describe('common particles test', () => {
   it('copy handle test', async () => {
     const runtime = new Runtime();
     runtime.context = await runtime.parseFile('./src/tests/particles/artifacts/copy-collection-test.recipes');
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
+    const arcInfo = await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()});
+    const arc = runtime.getArcById(arcInfo.id);
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
     const suggestion = suggestions[0];
     assert.equal(suggestion.descriptionText, 'Copy all things!');
 
-    assert.isEmpty(arc.stores);
+    assert.isEmpty(arcInfo.stores);
 
-    await runtime.allocator.runPlanInArc(arc.id, suggestion.plan);
+    await runtime.allocator.runPlanInArc(arcInfo, suggestion.plan);
     await arc.idle;
 
     const storeInfo = arc.findStoreById(arc.stores[2].id) as StoreInfo<CollectionEntityType>;
-    const handle = handleForActiveStore(storeInfo, arc);
+    const handle = await runtime.host.handleForStoreInfo(storeInfo, arcInfo);
     assert.strictEqual((await handle.toList()).length, 5);
   });
 });

--- a/src/tests/recipe-descriptions-test.ts
+++ b/src/tests/recipe-descriptions-test.ts
@@ -116,7 +116,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
       {fileName: 'foo.js'}
     );
     const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix})).id);
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions, 1);
@@ -184,7 +184,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
             foo: writes fooHandle
           description \`cannot show duplicate \${ShowFoo.foo}\`
       `, {fileName: ''});
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix: storageKeyPrefixForTest()})).id);
 
     await StrategyTestHelper.planForArc(runtime, arc).then(() => assert('expected exception for duplicate particles'))
       .catch((err) => assert.strictEqual(
@@ -234,14 +234,14 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         description \`show \${ShowFoo.foo} with dummy\`
     `, {fileName: ''});
     const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix})).id);
     // Plan for arc
     const suggestions0 = await StrategyTestHelper.planForArc(runtime, arc);
     assert.lengthOf(suggestions0, 2);
     assert.strictEqual('Show foo.', suggestions0[0].descriptionText);
 
     // Instantiate suggestion
-    await runtime.allocator.runPlanInArc(arc.id, await suggestions0[0].getResolvedPlan(arc));
+    await runtime.allocator.runPlanInArc(arc.arcInfo, await suggestions0[0].getResolvedPlan(arc));
     await arc.idle;
 
     // Plan again.
@@ -268,7 +268,7 @@ store BoxesStore of [Box] 'allboxes' in AllBoxes` : ''}
         description \`do C\`
     `, {fileName: ''});
     const storageKeyPrefix = (id: ArcId) => new VolatileStorageKey(id, '');
-    const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix}));
+    const arc = runtime.getArcById((await runtime.allocator.startArc({arcName: 'demo', storageKeyPrefix})).id);
 
     const suggestions = await StrategyTestHelper.planForArc(runtime, arc);
 

--- a/src/wasm/tests/wasm-api-test.ts
+++ b/src/wasm/tests/wasm-api-test.ts
@@ -20,9 +20,10 @@ import {VolatileStorageKey} from '../../runtime/storage/drivers/volatile.js';
 import {Exists} from '../../runtime/storage/drivers/driver.js';
 import {Reference} from '../../runtime/reference.js';
 import {Arc} from '../../runtime/arc.js';
-import {handleForStoreInfo, CollectionEntityType, SingletonEntityType, SingletonReferenceType, CollectionReferenceType} from '../../runtime/storage/storage.js';
+import {CollectionEntityType, SingletonEntityType, SingletonReferenceType, CollectionReferenceType} from '../../runtime/storage/storage.js';
 import {ReferenceModeStorageKey} from '../../runtime/storage/reference-mode-storage-key.js';
 import {StoreInfo} from '../../runtime/storage/store-info.js';
+import {ArcInfo} from '../../runtime/arc-info.js';
 import {MockStorageFrontend} from '../../runtime/storage/testing/test-storage.js';
 
 // Import some service definition files for their side-effects (the services get
@@ -54,7 +55,7 @@ const testMap = {
   'Kotlin': '../../javatests/arcs/sdk/wasm',
 };
 
-async function createBackingEntity(arc: Arc, referenceType: ReferenceType<EntityType>, id: string, entityData: {}): Promise<[string, Reference]> {
+async function createBackingEntity(arc: ArcInfo, referenceType: ReferenceType<EntityType>, id: string, entityData: {}, runtime: Runtime): Promise<[string, Reference]> {
   const referenceModeStorageKey = new ReferenceModeStorageKey(new VolatileStorageKey(arc.id, id+'a'), new VolatileStorageKey(arc.id, id+'b'));
   const baseType = referenceType.getContainedType();
   const referenceModeStore = new StoreInfo({
@@ -64,7 +65,7 @@ async function createBackingEntity(arc: Arc, referenceType: ReferenceType<Entity
     exists: Exists.MayExist
   });
 
-  const backingHandle1 = await handleForStoreInfo(referenceModeStore, arc);
+  const backingHandle1 = await runtime.host.handleForStoreInfo(referenceModeStore, arc);
   const entity = await backingHandle1.setFromData(entityData);
   const entityId = Entity.id(entity);
   const reference = new Reference({id: entityId, entityStorageKey: referenceModeStorageKey.toString()}, referenceType, new MockStorageFrontend());
@@ -96,23 +97,24 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     async function setup(planName) {
       const runtime = new Runtime({loader, context: await manifestPromise});
       const slotObserver = new SlotTestObserver();
-      const arc = runtime.getArcById(await runtime.allocator.startArc({
+      const arcInfo = await runtime.allocator.startArc({
         arcName: 'wasm-test',
         storageKeyPrefix: storageKeyPrefixForTest(),
         planName,
         slotObserver
-      }));
+      });
+      const arc = runtime.getArcById(arcInfo.id);
       await arc.idle;
       const [info] = arc.loadedParticleInfo.values();
 
-      return {arc, stores: info.stores, slotObserver, runtime};
+      return {arcInfo, stores: info.stores, slotObserver, runtime};
     }
 
     it('onHandleSync / onHandleUpdate', async () => {
-      const {arc, stores} = await setup('HandleSyncUpdateTest');
-      const sng = await handleForStoreInfo(stores.get('sng') as StoreInfo<SingletonEntityType>, arc);
-      const col = await handleForStoreInfo(stores.get('col') as StoreInfo<CollectionEntityType>, arc);
-      const res = await handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('HandleSyncUpdateTest');
+      const sng = await runtime.host.handleForStoreInfo(stores.get('sng') as StoreInfo<SingletonEntityType>, arcInfo);
+      const col = await runtime.host.handleForStoreInfo(stores.get('col') as StoreInfo<CollectionEntityType>, arcInfo);
+      const res = await runtime.host.handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arcInfo);
 
       // onHandleSync: txt = 'sync:<handle-name>:<all-synced>'
       // The order in which handles are synchronized isn't guaranteed, so allow for either result.
@@ -129,11 +131,11 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       await sng.set(new sng.entityClass({num: 3}));
       const e = new col.entityClass({num: 7});
       await col.add(e);
-      await arc.idle;
+      await runtime.getArcById(arcInfo.id).idle;
 
       await sng.clear();
       await col.remove(e);
-      await arc.idle;
+      await runtime.getArcById(arcInfo.id).idle;
 
       assert.deepStrictEqual(await res.toList() as {}[], [
         {txt: 'update:sng', num: 3},
@@ -145,9 +147,10 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
 
     // TODO(sjmiles, #4762): Enable this test.
     it.skip('getTemplate / populateModel / renderSlot', async () => {
-      const {arc, stores, slotObserver} = await setup('RenderTest');
-      const flags = await handleForStoreInfo(stores.get('flags') as StoreInfo<SingletonEntityType>, arc);
+      const {arcInfo, stores, slotObserver, runtime} = await setup('RenderTest');
+      const flags = await runtime.host.handleForStoreInfo(stores.get('flags') as StoreInfo<SingletonEntityType>, arcInfo);
 
+      const arc = runtime.getArcById(arcInfo.id);
       await flags.setFromData({template: false, model: true});
       await arc.idle;
 
@@ -170,11 +173,11 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
 
     // TODO(sjmiles, #4762): Enable this test.
     it.skip('autoRender', async () => {
-      const {arc, stores, slotObserver} = await setup('AutoRenderTest');
-      const data = await handleForStoreInfo(stores.get('data') as StoreInfo<SingletonEntityType>, arc);
+      const {arcInfo, stores, slotObserver, runtime} = await setup('AutoRenderTest');
+      const data = await runtime.host.handleForStoreInfo(stores.get('data') as StoreInfo<SingletonEntityType>, arcInfo);
 
       await data.setFromData({txt: 'update'});
-      await arc.idle;
+      await runtime.getArcById(arcInfo.id).idle;
 
       // TODO(sjmiles): modify slotTestObserver to capture similar information
       // First renderSlot call is initiated by the runtime, before handles are synced.
@@ -187,10 +190,11 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     it('fireEvent', async () => {
-      const {arc, stores} = await setup('EventsTest');
-      const output = await handleForStoreInfo(stores.get('output') as StoreInfo<SingletonEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('EventsTest');
+      const output = await runtime.host.handleForStoreInfo(stores.get('output') as StoreInfo<SingletonEntityType>, arcInfo);
 
-      const particle = arc.activeRecipe.particles[0];
+      const particle = arcInfo.activeRecipe.particles[0];
+      const arc = runtime.getArcById(arcInfo.id);
       arc.peh.sendEvent(particle, 'root', {handler: 'icanhazclick', data: {info: 'fooBar'}});
       await arc.idle;
 
@@ -198,8 +202,8 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     it('serviceRequest / serviceResponse / resolveUrl', async () => {
-      const {arc, stores} = await setup('ServicesTest');
-      const output = await handleForStoreInfo(stores.get('output') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('ServicesTest');
+      const output = await runtime.host.handleForStoreInfo(stores.get('output') as StoreInfo<CollectionEntityType>, arcInfo);
 
       const results = await output.toList();
       assert.lengthOf(results, 4);
@@ -232,8 +236,8 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     }
 
     prefix('entity class API', async () => {
-      const {arc, stores} = await setup('EntityClassApiTest');
-      const errHandle = await handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('EntityClassApiTest');
+      const errHandle = await runtime.host.handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arcInfo);
       const errors = (await errHandle.toList()).map(e => e.msg);
       if (errors.length > 0) {
         assert.fail(`${errors.length} errors found:\n${errors.join('\n')}`);
@@ -241,8 +245,8 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     prefix('special schema fields', async () => {
-      const {arc, stores} = await setup('SpecialSchemaFieldsTest');
-      const errHandle = await handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('SpecialSchemaFieldsTest');
+      const errHandle = await runtime.host.handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arcInfo);
       const errors = (await errHandle.toList()).map(e => e.msg);
       if (errors.length > 0) {
         assert.fail(`${errors.length} errors found:\n${errors.join('\n')}`);
@@ -254,8 +258,8 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
         // TODO(alxr, #4763): Enable this test.
         return;
       }
-      const {arc, stores} = await setup('ReferenceClassApiTest');
-      const errHandle = await handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('ReferenceClassApiTest');
+      const errHandle = await runtime.host.handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arcInfo);
       const errors = (await errHandle.toList()).map(e => e.msg);
       if (errors.length > 0) {
         assert.fail(`${errors.length} errors found:\n${errors.join('\n')}`);
@@ -264,15 +268,16 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
 
     // TODO - check that writing to read-only handles throws and vice versa
     it('singleton storage API', async () => {
-      const {arc, stores} = await setup('SingletonApiTest');
-      const inHandle = await handleForStoreInfo(stores.get('inHandle') as StoreInfo<SingletonEntityType>, arc);
-      const outHandle = await handleForStoreInfo(stores.get('outHandle') as StoreInfo<SingletonEntityType>, arc);
-      const ioHandle = await handleForStoreInfo(stores.get('ioHandle') as StoreInfo<SingletonEntityType>, arc);
-      const errors = await handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('SingletonApiTest');
+      const inHandle = await runtime.host.handleForStoreInfo(stores.get('inHandle') as StoreInfo<SingletonEntityType>, arcInfo);
+      const outHandle = await runtime.host.handleForStoreInfo(stores.get('outHandle') as StoreInfo<SingletonEntityType>, arcInfo);
+      const ioHandle = await runtime.host.handleForStoreInfo(stores.get('ioHandle') as StoreInfo<SingletonEntityType>, arcInfo);
+      const errors = await runtime.host.handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arcInfo);
 
+      const arc = runtime.getArcById(arcInfo.id);
       const sendEvent = async handler => {
         await arc.idle;
-        arc.peh.sendEvent(arc.activeRecipe.particles[0], 'root', {handler});
+        arc.peh.sendEvent(arcInfo.activeRecipe.particles[0], 'root', {handler});
         await arc.idle;
       };
 
@@ -305,14 +310,15 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     it('collection storage API', async () => {
-      const {arc, stores} = await setup('CollectionApiTest');
-      const inHandle = await handleForStoreInfo(stores.get('inHandle') as StoreInfo<CollectionEntityType>, arc);
-      const outHandle = await handleForStoreInfo(stores.get('outHandle') as StoreInfo<CollectionEntityType>, arc);
-      const ioHandle = await handleForStoreInfo(stores.get('ioHandle') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('CollectionApiTest');
+      const inHandle = await runtime.host.handleForStoreInfo(stores.get('inHandle') as StoreInfo<CollectionEntityType>, arcInfo);
+      const outHandle = await runtime.host.handleForStoreInfo(stores.get('outHandle') as StoreInfo<CollectionEntityType>, arcInfo);
+      const ioHandle = await runtime.host.handleForStoreInfo(stores.get('ioHandle') as StoreInfo<CollectionEntityType>, arcInfo);
 
+      const arc = runtime.getArcById(arcInfo.id);
       const sendEvent = async handler => {
         await arc.idle;
-        arc.peh.sendEvent(arc.activeRecipe.particles[0], 'root', {handler});
+        arc.peh.sendEvent(arcInfo.activeRecipe.particles[0], 'root', {handler});
         await arc.idle;
       };
 
@@ -363,10 +369,10 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
         // TODO(alxr, #4763): Enable this test.
         this.skip();
       }
-      const {arc, stores} = await setup('ReferenceHandlesTest');
-      const sng = await handleForStoreInfo(stores.get('sng') as StoreInfo<SingletonReferenceType>, arc);
-      const col = await handleForStoreInfo(stores.get('col') as StoreInfo<CollectionReferenceType>, arc);
-      const res = await handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('ReferenceHandlesTest');
+      const sng = await runtime.host.handleForStoreInfo(stores.get('sng') as StoreInfo<SingletonReferenceType>, arcInfo);
+      const col = await runtime.host.handleForStoreInfo(stores.get('col') as StoreInfo<CollectionReferenceType>, arcInfo);
+      const res = await runtime.host.handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arcInfo);
 
       assert.instanceOf(sng.type, SingletonType);
       assert.instanceOf(sng.type.getContainedType(), ReferenceType);
@@ -380,10 +386,11 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
 
       // onHandleUpdate tests populated references handles.
       const referenceType = sng.type.getContainedType() as ReferenceType<EntityType>;
-      const [entityId1, reference1] = await createBackingEntity(arc, referenceType, 'id1', {num: 6, txt: 'ok'});
-      const [entityId2, reference2] = await createBackingEntity(arc, referenceType, 'id2', {num: 7, txt: 'ko'});
+      const [entityId1, reference1] = await createBackingEntity(arcInfo, referenceType, 'id1', {num: 6, txt: 'ok'}, runtime);
+      const [entityId2, reference2] = await createBackingEntity(arcInfo, referenceType, 'id2', {num: 7, txt: 'ko'}, runtime);
 
       // Singleton
+      const arc = runtime.getArcById(arcInfo.id);
       await sng.set(reference1);
       await arc.idle;
       assert.sameMembers((await res.toList()).map(e => e.txt), [
@@ -417,14 +424,14 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
         // TODO(alxr, #4763): Enable this test.
         this.skip();
       }
-      const {arc, stores} = await setup('SchemaReferenceFieldsTest');
-      const input = await handleForStoreInfo(stores.get('input') as StoreInfo<SingletonEntityType>, arc);
-      const output = await handleForStoreInfo(stores.get('output') as StoreInfo<SingletonEntityType>, arc);
-      const res = await handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('SchemaReferenceFieldsTest');
+      const input = await runtime.host.handleForStoreInfo(stores.get('input') as StoreInfo<SingletonEntityType>, arcInfo);
+      const output = await runtime.host.handleForStoreInfo(stores.get('output') as StoreInfo<SingletonEntityType>, arcInfo);
+      const res = await runtime.host.handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arcInfo);
 
       // Uninitialised reference fields.
       await input.set(new input.entityClass({num: 5}));
-      await arc.idle;
+      await runtime.getArcById(arcInfo.id).idle;
 
       assert.sameMembers((await res.toList()).map(e => e.txt), [
         'before <> !{}',  // no id or entity data; dereference is a no-op (no 'after' output)
@@ -434,11 +441,11 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       // Populated reference fields.
       const entityType = input.type.getEntitySchema().fields.ref.getEntityType();  // yikes
       const refType = new ReferenceType(entityType);
-      const [childEntityId, childRef] = await createBackingEntity(arc, refType, 'id1', {val: 'v1'});
+      const [childEntityId, childRef] = await createBackingEntity(arcInfo, refType, 'id1', {val: 'v1'}, runtime);
 
       const parentEntity = new input.entityClass({num: 12, ref: childRef});
       await input.set(parentEntity);
-      await arc.idle;
+      await runtime.getArcById(arcInfo.id).idle;
 
       assert.sameMembers((await res.toList()).map(e => e.txt), [
         `before <${childEntityId}> !{}`,            // before dereferencing: contained entity is empty
@@ -456,16 +463,16 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
     });
 
     it('unicode strings', async () => {
-      const {arc, stores} = await setup('UnicodeTest');
-      const sng = await handleForStoreInfo(stores.get('sng') as StoreInfo<SingletonEntityType>, arc);
-      const col = await handleForStoreInfo(stores.get('col') as StoreInfo<CollectionEntityType>, arc);
-      const res = await handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('UnicodeTest');
+      const sng = await runtime.host.handleForStoreInfo(stores.get('sng') as StoreInfo<SingletonEntityType>, arcInfo);
+      const col = await runtime.host.handleForStoreInfo(stores.get('col') as StoreInfo<CollectionEntityType>, arcInfo);
+      const res = await runtime.host.handleForStoreInfo(stores.get('res') as StoreInfo<CollectionEntityType>, arcInfo);
 
       // 'pass' tests passthrough of unicode data in entities.
       const pass = 'A:₤⛲ℜ|あ表⏳:Z';
       await sng.set(new sng.entityClass({pass}));
       await col.add(new col.entityClass({pass}));
-      await arc.idle;
+      await runtime.getArcById(arcInfo.id).idle;
 
       // 'src' is set directly by the particle.
       const val = {pass, src: 'åŗċş 🌈'};
@@ -479,19 +486,19 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       // extra fields are correctly ignored.
       const manifest = await manifestPromise;
       const runtime = new Runtime({loader, context: manifest});
-      const arc = runtime.getArcById(await runtime.allocator.startArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest()}));
+      const arc = await runtime.allocator.startArc({arcName: 'wasm-test', storageKeyPrefix: storageKeyPrefixForTest()});
 
       const sliceClass = Entity.createEntityClass(manifest.findSchemaByName('Slice'), null);
-      const sngStore = await arc.createStore(new SingletonType(sliceClass.type), undefined, 'test:0');
-      const colStore = await arc.createStore(sliceClass.type.collectionOf(), undefined, 'test:1');
+      const sngStore = await arc.createStoreInfo(new SingletonType(sliceClass.type), {id: 'test:0'});
+      const colStore = await arc.createStoreInfo(sliceClass.type.collectionOf(), {id: 'test:1'});
 
       const resType = manifest.findParticleByName('EntitySlicingTest').getConnectionByName('res').type as CollectionType<EntityType>;
-      const resStore = await arc.createStore(resType, undefined, 'test:2');
+      const resStore = await arc.createStoreInfo(resType, {id: 'test:2'});
 
-      const sng = await handleForStoreInfo(sngStore, arc);
+      const sng = await runtime.host.handleForStoreInfo(sngStore, arc);
       await sng.set(new sng.entityClass({num: 159, txt: 'Charlie', flg: true}));
 
-      const col = await handleForStoreInfo(colStore, arc);
+      const col = await runtime.host.handleForStoreInfo(colStore, arc);
       await col.add(new col.entityClass({num: 30, txt: 'Moe', flg: false}));
       await col.add(new col.entityClass({num: 60, txt: 'Larry', flg: false}));
       await col.add(new col.entityClass({num: 90, txt: 'Curly', flg: true}));
@@ -500,10 +507,10 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       recipe.handles[0].mapToStorage(sngStore);
       recipe.handles[1].mapToStorage(colStore);
       recipe.handles[2].mapToStorage(resStore);
-      await runtime.allocator.runPlanInArc(arc.id, recipe);
-      await arc.idle;
+      await runtime.allocator.runPlanInArc(arc, recipe);
+      await runtime.getArcById(arc.id).idle;
 
-      const res = await handleForStoreInfo(resStore, arc);
+      const res = await runtime.host.handleForStoreInfo(resStore, arc);
       assert.sameMembers((await res.toList()).map(e => e.val), [
         's1:159',
         's2:159,Charlie',
@@ -526,22 +533,22 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
         this.skip();
       }
 
-      const {arc, stores, runtime} = await setup('OnFirstStartTest');
-      const fooHandle = await handleForStoreInfo(stores.get('fooHandle') as StoreInfo<SingletonEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('OnFirstStartTest');
+      const fooHandle = await runtime.host.handleForStoreInfo(stores.get('fooHandle') as StoreInfo<SingletonEntityType>, arcInfo);
 
       assert.deepStrictEqual(await fooHandle.fetch() as {}, {txt: 'Created!'});
 
-      const serialization = await arc.serialize();
-      arc.dispose();
+      const serialization = await runtime.getArcById(arcInfo.id).serialize();
+      runtime.allocator.stopArc(arcInfo.id);
 
       const manifest = await manifestPromise;
 
       const {driverFactory, storageService, storageKeyParser} = runtime;
-      const arc2 = runtime.getArcById(await runtime.allocator.deserialize({serialization, fileName: ''}));
-      await arc2.idle;
+      const arc2 = await runtime.allocator.deserialize({serialization, fileName: ''});
+      await runtime.getArcById(arc2.id).idle;
 
       const fooClass = Entity.createEntityClass(manifest.findSchemaByName('FooHandle'), null);
-      const fooHandle2 = await handleForStoreInfo(arc2.stores.find(StoreInfo.isSingletonEntityStore), arc);
+      const fooHandle2 = await runtime.host.handleForStoreInfo(arc2.stores.find(StoreInfo.isSingletonEntityStore), arcInfo);
       assert.deepStrictEqual(await fooHandle2.fetch(), new fooClass({txt: 'Not created!'}));
 
     });
@@ -550,17 +557,17 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       if (isCpp) {
         this.skip();
       }
-      const {arc, stores} = await setup('CombineUpdatesTest');
-      const handle1 = await handleForStoreInfo(stores.get('handle1') as StoreInfo<SingletonEntityType>, arc);
-      const handle2 = await handleForStoreInfo(stores.get('handle2') as StoreInfo<CollectionEntityType>, arc);
-      const handle3 = await handleForStoreInfo(stores.get('handle3') as StoreInfo<SingletonEntityType>, arc);
-      const handle4 = await handleForStoreInfo(stores.get('handle4') as StoreInfo<SingletonEntityType>, arc);
-      const handle5 = await handleForStoreInfo(stores.get('handle5') as StoreInfo<SingletonEntityType>, arc);
-      const handle6 = await handleForStoreInfo(stores.get('handle6') as StoreInfo<SingletonEntityType>, arc);
-      const handle7 = await handleForStoreInfo(stores.get('handle7') as StoreInfo<SingletonEntityType>, arc);
-      const handle8 = await handleForStoreInfo(stores.get('handle8') as StoreInfo<SingletonEntityType>, arc);
-      const handle9 = await handleForStoreInfo(stores.get('handle9') as StoreInfo<SingletonEntityType>, arc);
-      const handle10 = await handleForStoreInfo(stores.get('handle10') as StoreInfo<SingletonEntityType>, arc);
+      const {arcInfo, stores, runtime} = await setup('CombineUpdatesTest');
+      const handle1 = await runtime.host.handleForStoreInfo(stores.get('handle1') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle2 = await runtime.host.handleForStoreInfo(stores.get('handle2') as StoreInfo<CollectionEntityType>, arcInfo);
+      const handle3 = await runtime.host.handleForStoreInfo(stores.get('handle3') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle4 = await runtime.host.handleForStoreInfo(stores.get('handle4') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle5 = await runtime.host.handleForStoreInfo(stores.get('handle5') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle6 = await runtime.host.handleForStoreInfo(stores.get('handle6') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle7 = await runtime.host.handleForStoreInfo(stores.get('handle7') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle8 = await runtime.host.handleForStoreInfo(stores.get('handle8') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle9 = await runtime.host.handleForStoreInfo(stores.get('handle9') as StoreInfo<SingletonEntityType>, arcInfo);
+      const handle10 = await runtime.host.handleForStoreInfo(stores.get('handle10') as StoreInfo<SingletonEntityType>, arcInfo);
 
       await handle1.set(new handle1.entityClass({num: 1.0}));
       await handle2.add(new handle2.entityClass({num: 1.0}));
@@ -573,11 +580,12 @@ Object.entries(testMap).forEach(([testLabel, testDir]) => {
       await handle9.set(new handle9.entityClass({num9: 1.0}));
       await handle10.set(new handle10.entityClass({num10: 1.0}));
 
-      const errHandle = await handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arc);
+      const errHandle = await runtime.host.handleForStoreInfo(stores.get('errors') as StoreInfo<CollectionEntityType>, arcInfo);
 
+      const arc = runtime.getArcById(arcInfo.id);
       const sendEvent = async handler => {
         await arc.idle;
-        arc.peh.sendEvent(arc.activeRecipe.particles[0], 'root', {handler});
+        arc.peh.sendEvent(arcInfo.activeRecipe.particles[0], 'root', {handler});
         await arc.idle;
       };
 


### PR DESCRIPTION
- Use ArcInfo instead of Arc, where possible
- Remove `createStore` method from Arc and update handleForX methods to take ArcInfo
- Update Allocator.startArc to return ArcInfo and update all callers.
- runtime.getArcDescription takes ArcId as parameter
- unify handleForStoreInfo and handleForActiveStore and move to ArcHost

Next step:
- move innerArcs from Arc to ArcInfo and manage them via Allocator (will allow to further reduce usage of `Arc` class
- move `arc.idle` call inside ArcHost's startArc method.