### PR TITLE
Implemented a TTL Policy / Ingress restriction test.

### DIFF
--- a/javatests/arcs/android/integration/policy/BUILD
+++ b/javatests/arcs/android/integration/policy/BUILD
@@ -51,6 +51,7 @@ arcs_kt_android_test_suite(
         "//javatests/arcs/core/host:pure-particles-jvm",
         "//third_party/android/androidx_test/ext/junit",
         "//third_party/java/junit:junit-android",
+        "//third_party/java/robolectric:annotations",
         "//third_party/java/truth:truth-android",
         "//third_party/kotlin/kotlinx_coroutines",
     ],

--- a/javatests/arcs/android/integration/policy/Particles.kt
+++ b/javatests/arcs/android/integration/policy/Particles.kt
@@ -41,3 +41,15 @@ class EgressAB : AbstractEgressAB() {
 
   fun fetchThings(): Set<Thing> = handles.output.fetchAll()
 }
+
+/** Egresses Thing { b, c }. */
+class EgressBC : AbstractEgressBC() {
+  val handleRegistered = Job()
+
+  override fun onReady() {
+    fetchThings()
+    handleRegistered.complete()
+  }
+
+  fun fetchThings(): Set<Thing> = handles.output.fetchAll()
+}

--- a/javatests/arcs/android/integration/policy/Particles.kt
+++ b/javatests/arcs/android/integration/policy/Particles.kt
@@ -39,5 +39,5 @@ class EgressAB : AbstractEgressAB() {
     handleRegistered.complete()
   }
 
-  fun triggerRead(): Set<Thing> = handles.output.fetchAll()
+  fun fetchThings(): Set<Thing> = handles.output.fetchAll()
 }

--- a/javatests/arcs/android/integration/policy/Particles.kt
+++ b/javatests/arcs/android/integration/policy/Particles.kt
@@ -15,25 +15,29 @@ import kotlinx.coroutines.Job
 /** Ingresses Things. */
 class IngressThing : AbstractIngressThing() {
   lateinit var storeFinished: Job
-  override fun onFirstStart() {
-    storeFinished = handles.input.storeAll(listOf(
-      Thing("Once", "upon", "a", "midnight"),
-      Thing("dreary", "while", "I", "pondered"),
-      Thing("weak", "and", "weary", "over"),
-      Thing("many", "a", "quaint", "and"),
-      Thing("curious", "volumes", "of", "forgotten"),
-      Thing("lore", "while", "I", "nodded")
-    ))
+  override fun onFirstStart() = triggerWrite()
+  fun triggerWrite() {
+    storeFinished = handles.input.storeAll(
+      listOf(
+        Thing("Once", "upon", "a", "midnight"),
+        Thing("dreary", "while", "I", "pondered"),
+        Thing("weak", "and", "weary", "over"),
+        Thing("many", "a", "quaint", "and"),
+        Thing("curious", "volumes", "of", "forgotten"),
+        Thing("lore", "while", "I", "nodded")
+      )
+    )
   }
 }
 
 /** Egresses Thing { a, b }. */
 class EgressAB : AbstractEgressAB() {
   val handleRegistered = Job()
-  val outputForTest = mutableSetOf<Thing>()
 
   override fun onReady() {
-    outputForTest.addAll(handles.output.fetchAll())
+    triggerRead()
     handleRegistered.complete()
   }
+
+  fun triggerRead(): Set<Thing> = handles.output.fetchAll()
 }

--- a/javatests/arcs/android/integration/policy/Particles.kt
+++ b/javatests/arcs/android/integration/policy/Particles.kt
@@ -15,8 +15,8 @@ import kotlinx.coroutines.Job
 /** Ingresses Things. */
 class IngressThing : AbstractIngressThing() {
   lateinit var storeFinished: Job
-  override fun onFirstStart() = triggerWrite()
-  fun triggerWrite() {
+  override fun onFirstStart() = writeThings()
+  fun writeThings() {
     storeFinished = handles.input.storeAll(
       listOf(
         Thing("Once", "upon", "a", "midnight"),
@@ -35,7 +35,7 @@ class EgressAB : AbstractEgressAB() {
   val handleRegistered = Job()
 
   override fun onReady() {
-    triggerRead()
+    fetchThings()
     handleRegistered.complete()
   }
 

--- a/javatests/arcs/android/integration/policy/PolicyTest.kt
+++ b/javatests/arcs/android/integration/policy/PolicyTest.kt
@@ -158,6 +158,7 @@ class PolicyTest {
 
       // And Thing {a, b} data will be deleted at Arcs' runtime end
       env.stopRuntime()
+      env.triggerCleanupWork()
       assertThat(env.getDatabaseEntities(keyAB, AbstractIngressThing.Thing.SCHEMA)).isEmpty()
     }
 

--- a/javatests/arcs/android/integration/policy/PolicyTest.kt
+++ b/javatests/arcs/android/integration/policy/PolicyTest.kt
@@ -121,8 +121,8 @@ class PolicyTest {
         .storageKey
 
       // And Thing {a, b, c} is written to storage (RAM)
-      assertStorageContains(keyAB, setOf("a", "b"))
-      assertStorageContains(keyBC, setOf("b", "c"))
+      assertStorageContains(keyAB, singletons = setOf("a", "b"))
+      assertStorageContains(keyBC, singletons = setOf("b", "c"))
 
       // And the egress data with fields Thing {a, b} will be exfiltrated (filtered with no
       // output read) after 2 hours have passed.
@@ -154,7 +154,7 @@ class PolicyTest {
 
       // Then Thing {a, b} data persists after the arc is finished
       env.stopArc(arc)
-      assertStorageContains(keyAB, setOf("a", "b"))
+      assertStorageContains(keyAB, singletons = setOf("a", "b"))
 
       // And Thing {a, b} data will be deleted at Arcs' runtime end
       env.stopRuntime()

--- a/javatests/arcs/android/integration/policy/particles.arcs
+++ b/javatests/arcs/android/integration/policy/particles.arcs
@@ -24,3 +24,6 @@ particle IngressThing in '.IngressThing'
 particle EgressAB in '.EgressAB'
   output: reads [Thing {a, b}]
 
+@egress('GeneralEgress')
+particle EgressBC in '.EgressBC'
+  output: reads [Thing {b, c}]

--- a/javatests/arcs/android/integration/policy/scenarios.arcs
+++ b/javatests/arcs/android/integration/policy/scenarios.arcs
@@ -67,14 +67,12 @@ recipe TtlEgresses
   // And the recipe ingresses a schema Thing {a, b, c, d}
   IngressThing
     input: handle1
+  IngressThing
+    input: handle2
 
   // And the recipe egresses Thing {a, b}
   EgressAB
     output: handle1
-
-  // And the recipe ingresses a schema Thing {a, b, c, d}
-  IngressThing
-    input: handle2
 
   // And the recipe egresses Thing {b, c}
   EgressBC

--- a/javatests/arcs/android/integration/policy/scenarios.arcs
+++ b/javatests/arcs/android/integration/policy/scenarios.arcs
@@ -38,3 +38,31 @@ recipe PersistsEgresses
   // And the recipe egresses Thing {a, b}
   EgressAB
     output: handle1
+
+/// Scenario: A policy-compliant recipe with @ttl handles egresses data and
+/// stores ingress-restricted values to RAM that are deleted when the TTL expires
+/// and at the runtime’s end.
+
+@egressType('GeneralEgress')
+policy SimpleTtlPolicy {
+  @allowedRetention(medium: 'Ram', encryption: false)
+  from Thing access {
+    a,
+    b
+  }
+}
+
+// Given a recipe is compliant with a policy
+@policy('SimplePersistencePolicy')
+recipe TtlEgresses
+  // And the recipe's store is marked @ttl('2h')
+  handle1: create @ttl('2h')
+
+  // And the recipe ingresses a schema Thing {a, b, c, d}
+  IngressThing
+    input: handle1
+
+  // And the recipe egresses Thing {a, b}
+  EgressAB
+    output: handle1
+

--- a/javatests/arcs/android/integration/policy/scenarios.arcs
+++ b/javatests/arcs/android/integration/policy/scenarios.arcs
@@ -60,8 +60,9 @@ policy SimpleTtlPolicy {
 // Given a recipe is compliant with a policy
 @policy('SimplePersistencePolicy')
 recipe TtlEgresses
-  // And the recipe's store is marked @ttl('2h')
+  // And the recipe's stores are marked @ttl('2h') and @ttl('5d')
   handle1: create @ttl('2h')
+  handle2: create @ttl('5d')
 
   // And the recipe ingresses a schema Thing {a, b, c, d}
   IngressThing
@@ -71,3 +72,10 @@ recipe TtlEgresses
   EgressAB
     output: handle1
 
+  // And the recipe ingresses a schema Thing {a, b, c, d}
+  IngressThing
+    input: handle2
+
+  // And the recipe egresses Thing {b, c}
+  EgressBC
+    output: handle2

--- a/javatests/arcs/android/integration/policy/scenarios.arcs
+++ b/javatests/arcs/android/integration/policy/scenarios.arcs
@@ -7,6 +7,11 @@
 // grant found at
 // http://polymer.github.io/PATENTS.txt
 
+/// !!!
+/// TODO(b/183554828): Update these tests to make use of compile-time policy
+///   checking when ready!
+/// !!!
+
 meta
   namespace: arcs.android.integration.policy
 


### PR DESCRIPTION
- Refactored the particles to make it easier to trigger reads and writes.
- Added a TTL policy tests that exercises data expiring, egress exfiltration, and data being stored in RAM Disk. 