### PR TITLE
Action checks that all sources & build files include copyright notice.

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -12,6 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check Source code
-        run: git diff $default-branch | grep -iL "copyright" || exit 1
+      - name: Check Kotlin & Typescript source
+        # Get all files that are different from the default branch (excluding
+        # deleted files), if they are either Typescript or Kotlin files,
+        # output the list of files who do not contain "copyright" (case
+        # insensitive).
+        # In this case, we want to exit the check with an error.
+        run: git diff $default-branch --diff-filter=d --name-only | xargs grep --include=\*.{ts,kt} -iL "copyright" || exit 1
+
+      - name: Check build files
+        run: git diff $default-branch --diff-filter=d --name-only | xargs grep --include=BUILD -iL "licenses" || exit 1
 

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,12 +1,12 @@
-# An action to check that all new sources include a copyright notice
-name: copyright check
+# An action to check that all new sources include a copyright notice.
+name: copyright-check
 
 on:
   push:
-    branches [ $default-branch ]
+    branches: [ $default-branch ]
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,0 +1,17 @@
+# An action to check that all new sources include a copyright notice
+name: copyright check
+
+on:
+  push:
+    branches [ $default-branch ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check Source code
+        run: git diff $default-branch | grep -iL "copyright" || exit 1
+


### PR DESCRIPTION
Added a github action where, for every PR into the default branch: 
- Search all the modified files (excluding deleted ones). If they are *.ts or *.kt files, check that "copyright" appears in the file.
- The same search logic, but checks that BUILD files contain the term "licenses". 