### PR TITLE
Update codegen to output correct type slicing interfaces.

### DIFF
--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -1,15 +1,20 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
     "arcs_kt_jvm_test_suite",
+    "arcs_kt_gen",
 )
 
 licenses(["notice"])
 
 arcs_kt_jvm_test_suite(
     name = "entity",
-    srcs = glob(["*.kt"]),
+    srcs = glob(
+        ["*.kt"],
+        exclude = ["TypeSlicingTest.kt"]
+    ),
     package = "arcs.core.entity",
     deps = [
+        "//java/arcs/core/allocator",
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
@@ -36,7 +41,9 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/flags:flags-kt",
         "//java/arcs/flags:unit_test_build_flags",
         "//java/arcs/flags/testing:testing-kt",
+        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
+        "//javatests/arcs/core/host:testhost",
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito",
         "//third_party/java/truth:truth-android",
@@ -44,5 +51,34 @@ arcs_kt_jvm_test_suite(
         "//third_party/kotlin/kotlinx_coroutines",
         "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
         "//third_party/kotlin/mockito_kotlin",
+    ],
+)
+
+# TODO(b/182330900): fold back into the 'entity' rule once type slicing has been fully launched.
+arcs_kt_jvm_test_suite(
+    name = "type_slicing",
+    srcs = ["TypeSlicingTest.kt"],
+    package = "arcs.core.entity",
+    build_flag = "particle_type_slicing",
+    deps = [
+        ":codegen",
+        "//java/arcs/core/allocator",
+        "//java/arcs/core/entity/testutil",
+        "//java/arcs/core/host",
+        "//java/arcs/core/storage/api",
+        "//java/arcs/core/storage/driver:ramdisk",
+        "//java/arcs/jvm/host",
+        "//third_party/java/junit:junit-android",
+        "//third_party/java/truth:truth-android",
+        "//third_party/kotlin/kotlin:kotlin_test",
+        "//third_party/kotlin/kotlinx_coroutines",
+        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
+    ],
+)
+
+arcs_kt_gen(
+    name = "codegen",
+    srcs = [
+        "type_slicing.arcs",
     ],
 )

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -14,7 +14,6 @@ arcs_kt_jvm_test_suite(
     ),
     package = "arcs.core.entity",
     deps = [
-        "//java/arcs/core/allocator",
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
@@ -41,9 +40,7 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/flags:flags-kt",
         "//java/arcs/flags:unit_test_build_flags",
         "//java/arcs/flags/testing:testing-kt",
-        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
-        "//javatests/arcs/core/host:testhost",
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito",
         "//third_party/java/truth:truth-android",

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -8,12 +8,11 @@ licenses(["notice"])
 
 arcs_kt_jvm_test_suite(
     name = "entity",
-    srcs = glob(
-        ["*.kt"],
-        exclude = ["TypeSlicingTest.kt"]
-    ),
+    srcs = glob(["*.kt"]),
     package = "arcs.core.entity",
     deps = [
+        ":codegen",
+        "//java/arcs/core/allocator",
         "//java/arcs/core/common",
         "//java/arcs/core/crdt",
         "//java/arcs/core/data",
@@ -40,7 +39,9 @@ arcs_kt_jvm_test_suite(
         "//java/arcs/flags:flags-kt",
         "//java/arcs/flags:unit_test_build_flags",
         "//java/arcs/flags/testing:testing-kt",
+        "//java/arcs/jvm/host",
         "//java/arcs/jvm/util/testutil",
+        "//javatests/arcs/core/host:testhost",
         "//third_party/java/junit:junit-android",
         "//third_party/java/mockito",
         "//third_party/java/truth:truth-android",
@@ -51,31 +52,9 @@ arcs_kt_jvm_test_suite(
     ],
 )
 
-# TODO(b/182330900): fold back into the 'entity' rule once type slicing has been fully launched.
-arcs_kt_jvm_test_suite(
-    name = "type_slicing",
-    srcs = ["TypeSlicingTest.kt"],
-    package = "arcs.core.entity",
-    build_flag = "particle_type_slicing",
-    deps = [
-        ":codegen",
-        "//java/arcs/core/allocator",
-        "//java/arcs/core/entity/testutil",
-        "//java/arcs/core/host",
-        "//java/arcs/core/storage/api",
-        "//java/arcs/core/storage/driver:ramdisk",
-        "//java/arcs/jvm/host",
-        "//third_party/java/junit:junit-android",
-        "//third_party/java/truth:truth-android",
-        "//third_party/kotlin/kotlin:kotlin_test",
-        "//third_party/kotlin/kotlinx_coroutines",
-        "//third_party/kotlin/kotlinx_coroutines:kotlinx_coroutines_test",
-    ],
-)
-
 arcs_kt_gen(
     name = "codegen",
-    srcs = [
-        "type_slicing.arcs",
-    ],
+    srcs = ["type_slicing.arcs"],
+    # TODO(b/182330900): remove once type slicing has been fully launched.
+    force_enable_type_slicing = True,
 )

--- a/javatests/arcs/core/entity/BUILD
+++ b/javatests/arcs/core/entity/BUILD
@@ -1,7 +1,7 @@
 load(
     "//third_party/java/arcs/build_defs:build_defs.bzl",
-    "arcs_kt_jvm_test_suite",
     "arcs_kt_gen",
+    "arcs_kt_jvm_test_suite",
 )
 
 licenses(["notice"])

--- a/javatests/arcs/core/entity/TypeSlicingTest.kt
+++ b/javatests/arcs/core/entity/TypeSlicingTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2021 Google LLC.
+ *
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ *
+ * Code distributed by Google as part of this project is also subject to an additional IP rights
+ * grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+package arcs.core.entity
+
+import arcs.core.allocator.Allocator
+import arcs.core.host.SimpleSchedulerProvider
+import arcs.core.host.TestHost
+import arcs.core.host.toRegistration
+import arcs.core.storage.api.DriverAndKeyConfigurator
+import arcs.core.storage.driver.RamDisk
+import arcs.core.testutil.runTest
+import arcs.jvm.host.ExplicitHostRegistry
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+
+// Writer feeds entities into the middle and bottom layer of Slicer's handle lattice.
+class Writer : AbstractWriter() {
+  override fun onFirstStart() {
+    handles.l.store(Writer_L("left", 2.3))
+    handles.r.store(Writer_R("right", setOf()))
+    handles.b.store(Writer_B("bottom", 8.0, setOf(5, 9), true))
+  }
+}
+
+// Slicer has handles with types arranged in a diamond lattice (casting is allowed upwards):
+//     T
+//    / \
+//   L   R
+//    \ /
+//     B
+class Slicer : AbstractSlicer() {
+  override fun onReady() {
+    // Read the input from Writer as concrete entities.
+    val left = requireNotNull(handles.l.fetch())
+    val right = requireNotNull(handles.r.fetch())
+    val bottom = requireNotNull(handles.b.fetch())
+
+    assertThat(left).isInstanceOf(Slicer_L::class.java)
+    assertThat(right).isInstanceOf(Slicer_R::class.java)
+    assertThat(bottom).isInstanceOf(Slicer_B::class.java)
+
+    // Write the input entities to all handles that should accept them (via slice interfaces).
+    Reader.expected = 7
+
+    // Top handle can accept all types from the diamond.
+    handles.t.store(left)
+    handles.t.store(right)
+    handles.t.store(bottom)
+
+    // Left and right handles can accept the bottom type in addition to their own.
+    handles.l.store(left)
+    handles.l.store(bottom)
+    handles.r.store(right)
+    handles.r.store(bottom)
+  }
+}
+
+// Reader collectes the sliced writes from Slicer for verification in the unit test.
+class Reader : AbstractReader() {
+  override fun onStart() {
+    handles.t.onUpdate { topReceived.add(requireNotNull(it.new)) }
+    handles.l.onUpdate { leftReceived.add(requireNotNull(it.new)) }
+    handles.r.onUpdate { rightReceived.add(requireNotNull(it.new)) }
+  }
+
+  override fun onUpdate() {
+    if (--expected == 0) latch.complete()
+  }
+
+  companion object {
+    var expected = 0
+    val latch = Job() // Single job works since only one test requires it.
+    val topReceived = mutableListOf<Reader_T>()
+    val leftReceived = mutableListOf<Reader_L>()
+    val rightReceived = mutableListOf<Reader_R>()
+  }
+}
+
+@RunWith(JUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class TypeSlicingTest {
+
+  @Test
+  fun particlesCanWriteToSliceInterfaces() = runTest {
+    RamDisk.clear()
+    DriverAndKeyConfigurator.configure(null)
+    val schedulerProvider = SimpleSchedulerProvider(coroutineContext)
+    val host = TestHost(
+      schedulerProvider,
+      ::Reader.toRegistration(),
+      ::Slicer.toRegistration(),
+      ::Writer.toRegistration()
+    )
+    val hostRegistry = ExplicitHostRegistry().apply { registerHost(host) }
+    val allocator = Allocator.createNonSerializing(hostRegistry, TestCoroutineScope())
+    val arc = allocator.startArcForPlan(TypeSlicingTestPlan).waitForStart()
+
+    Reader.latch.join()
+
+    assertThat(Reader.topReceived.map { it.a }).isEqualTo(listOf("left", "right", "bottom"))
+
+    assertThat(Reader.leftReceived.map { "${it.a}:${it.b}" })
+      .isEqualTo(listOf("left:2.3", "bottom:8.0"))
+
+    assertThat(Reader.rightReceived.map { "${it.a}:${it.c}" })
+      .isEqualTo(listOf("right:[]", "bottom:[5, 9]"))
+
+    arc.stop()
+    arc.waitForStop()
+    schedulerProvider.cancelAll()
+  }
+
+  @Test
+  fun castingBetweenRelatedSchemas() {
+    // Re-use the type lattice from Reader to check direct casts across the entire lattice.
+    checkCasts(Reader_T("abc"), true, false, false, false)
+    checkCasts(Reader_L("abc", 5.7), true, true, false, false)
+    checkCasts(Reader_R("abc", setOf(4, 6)), true, false, true, false)
+    checkCasts(Reader_B("abc", 5.7, setOf(4, 6), true), true, true, true, true)
+
+    // An unrelated type should fail all casts.
+    checkCasts(Reader_X(5.7), false, false, false, false)
+  }
+
+  fun checkCasts(x: Any, isTop: Boolean, isLeft: Boolean, isRight: Boolean, isBottom: Boolean) {
+    try {
+      (x as Reader_T_Slice).let {
+        assertThat(it.a).isEqualTo("abc")
+      }
+      assertWithMessage("Cast of $x to Reader_T_Slice succeeded but should have failed")
+        .that(isTop).isTrue()
+    } catch (e: ClassCastException) {
+      assertWithMessage("Cast of $x to Reader_T_Slice failed but should have succeeded")
+        .that(isTop).isFalse()
+    }
+
+    try {
+      (x as Reader_L_Slice).let {
+        assertThat(it.a).isEqualTo("abc")
+        assertThat(it.b).isEqualTo(5.7)
+      }
+      assertWithMessage("Cast of $x to Reader_L_Slice succeeded but should have failed")
+        .that(isLeft).isTrue()
+    } catch (e: ClassCastException) {
+      assertWithMessage("Cast of $x to Reader_L_Slice failed but should have succeeded")
+        .that(isLeft).isFalse()
+    }
+
+    try {
+      (x as Reader_R_Slice).let {
+        assertThat(it.a).isEqualTo("abc")
+        assertThat(it.c).isEqualTo(setOf(4, 6))
+      }
+      assertWithMessage("Cast of $x to Reader_R_Slice succeeded but should have failed")
+        .that(isRight).isTrue()
+    } catch (e: ClassCastException) {
+      assertWithMessage("Cast of $x to Reader_R_Slice failed but should have succeeded")
+        .that(isRight).isFalse()
+    }
+
+    try {
+      (x as Reader_B_Slice).let {
+        assertThat(it.a).isEqualTo("abc")
+        assertThat(it.b).isEqualTo(5.7)
+        assertThat(it.c).isEqualTo(setOf(4, 6))
+        assertThat(it.d).isEqualTo(true)
+      }
+      assertWithMessage("Cast of $x to Reader_B_Slice succeeded but should have failed")
+        .that(isBottom).isTrue()
+    } catch (e: ClassCastException) {
+      assertWithMessage("Cast of $x to Reader_B_Slice failed but should have succeeded")
+        .that(isBottom).isFalse()
+    }
+  }
+}

--- a/javatests/arcs/core/entity/TypeSlicingTest.kt
+++ b/javatests/arcs/core/entity/TypeSlicingTest.kt
@@ -19,7 +19,7 @@ import arcs.core.storage.driver.RamDisk
 import arcs.core.testutil.runTest
 import arcs.jvm.host.ExplicitHostRegistry
 import com.google.common.truth.Truth.assertThat
-import com.google.common.truth.Truth.assertWithMessage
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -137,53 +137,41 @@ class TypeSlicingTest {
   }
 
   fun checkCasts(x: Any, isTop: Boolean, isLeft: Boolean, isRight: Boolean, isBottom: Boolean) {
-    try {
+    if (isTop) {
       (x as Reader_T_Slice).let {
         assertThat(it.a).isEqualTo("abc")
       }
-      assertWithMessage("Cast of $x to Reader_T_Slice succeeded but should have failed")
-        .that(isTop).isTrue()
-    } catch (e: ClassCastException) {
-      assertWithMessage("Cast of $x to Reader_T_Slice failed but should have succeeded")
-        .that(isTop).isFalse()
+    } else {
+      assertFailsWith<ClassCastException> { x as Reader_T_Slice }
     }
 
-    try {
+    if (isLeft) {
       (x as Reader_L_Slice).let {
         assertThat(it.a).isEqualTo("abc")
         assertThat(it.b).isEqualTo(5.7)
       }
-      assertWithMessage("Cast of $x to Reader_L_Slice succeeded but should have failed")
-        .that(isLeft).isTrue()
-    } catch (e: ClassCastException) {
-      assertWithMessage("Cast of $x to Reader_L_Slice failed but should have succeeded")
-        .that(isLeft).isFalse()
+    } else {
+      assertFailsWith<ClassCastException> { x as Reader_L_Slice }
     }
 
-    try {
+    if (isRight) {
       (x as Reader_R_Slice).let {
         assertThat(it.a).isEqualTo("abc")
         assertThat(it.c).isEqualTo(setOf(4, 6))
       }
-      assertWithMessage("Cast of $x to Reader_R_Slice succeeded but should have failed")
-        .that(isRight).isTrue()
-    } catch (e: ClassCastException) {
-      assertWithMessage("Cast of $x to Reader_R_Slice failed but should have succeeded")
-        .that(isRight).isFalse()
+    } else {
+      assertFailsWith<ClassCastException> { x as Reader_R_Slice }
     }
 
-    try {
+    if (isBottom) {
       (x as Reader_B_Slice).let {
         assertThat(it.a).isEqualTo("abc")
         assertThat(it.b).isEqualTo(5.7)
         assertThat(it.c).isEqualTo(setOf(4, 6))
         assertThat(it.d).isEqualTo(true)
       }
-      assertWithMessage("Cast of $x to Reader_B_Slice succeeded but should have failed")
-        .that(isBottom).isTrue()
-    } catch (e: ClassCastException) {
-      assertWithMessage("Cast of $x to Reader_B_Slice failed but should have succeeded")
-        .that(isBottom).isFalse()
+    } else {
+      assertFailsWith<ClassCastException> { x as Reader_B_Slice }
     }
   }
 }

--- a/javatests/arcs/core/entity/type_slicing.arcs
+++ b/javatests/arcs/core/entity/type_slicing.arcs
@@ -1,0 +1,37 @@
+meta
+  namespace: arcs.core.entity
+
+particle Writer in '.Writer'
+  l: writes {a: Text, b: Number}
+  r: writes {a: Text, c: [Int]}
+  b: writes {a: Text, b: Number, c: [Int], d: Boolean}
+
+particle Slicer in '.Slicer'
+  t: writes {a: Text}
+  l: reads writes {a: Text, b: Number}
+  r: reads writes {a: Text, c: [Int]}
+  b: reads {a: Text, b: Number, c: [Int], d: Boolean}
+
+particle Reader in '.Reader'
+  t: reads {a: Text}
+  l: reads {a: Text, b: Number}
+  r: reads {a: Text, c: [Int]}
+  b: reads {a: Text, b: Number, c: [Int], d: Boolean}
+  x: reads {a: Number}  // for casting test
+
+recipe TypeSlicingTest
+  Writer
+    l: writes h2
+    r: writes h3
+    b: writes h4
+  Slicer
+    t: writes h1
+    l: reads writes h2
+    r: reads writes h3
+    b: reads h4
+  Reader
+    t: reads h1
+    l: reads h2
+    r: reads h3
+    b: reads h4
+    x: reads unused

--- a/src/tools/kotlin-entity-generator.ts
+++ b/src/tools/kotlin-entity-generator.ts
@@ -45,6 +45,8 @@ export class KotlinEntityGenerator implements EntityGenerator {
   async generateClasses(): Promise<string> {
     return `\
 
+    ${this.generateInterfaceDefinition()}
+
     ${this.generateClassDefinition()} {
         ${this.generateFieldsDefinitions()}
         ${this.generateCopyMethods()}
@@ -66,10 +68,32 @@ export class KotlinEntityGenerator implements EntityGenerator {
     const res = [];
     for (const s of this.node.sources) {
       res.push(`typealias ${s.fullName} = Abstract${particleName}.${this.className}`);
-      // TODO(b/182330900): temporary state; will be changed to alias the actual slice interface
-      res.push(`typealias ${interfaceName(s.fullName)} = Abstract${particleName}.${this.className}`);
+      // TODO(b/182330900): hard-code to interfaceName() once type slicing has fully launched
+      const sliceName = this.opts.type_slicing ? interfaceName(this.className) : this.className;
+      res.push(`typealias ${interfaceName(s.fullName)} = Abstract${particleName}.${sliceName}`);
     }
     return res;
+  }
+
+  generateInterfaceDefinition(): string {
+    // TODO(b/182330900): remove once type slicing has fully launched
+    if (!this.opts.type_slicing) return '';
+
+    let bases: string;
+    if (this.node.parents.length > 0) {
+      bases = this.node.parents.map(p => interfaceName(p.entityClassName)).join(', ');
+    } else {
+      bases = this.opts.wasm ? 'WasmEntity' : 'arcs.sdk.Entity';
+    }
+
+    const fields: string[] = [];
+    for (const added of this.node.addedFields) {
+      const field = this.fields.filter(f => f.name === added)[0];
+      fields.push(`val ${field.escaped}: ${field.type.kotlinType}`);
+    }
+    return `interface ${interfaceName(this.className)} : ${bases} {
+        ${ktUtils.indentFollowing(fields, 2)}
+    }`;
   }
 
   generateClassDefinition(): string {
@@ -98,8 +122,9 @@ export class KotlinEntityGenerator implements EntityGenerator {
         'expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP',
       ]);
     }
-
-    const classInterface = `) : ${baseClass}`;
+    // TODO(b/182330900): hard-code to include the extra base once type slicing has fully launched
+    const sliceBase = this.opts.type_slicing ? (', ' + interfaceName(this.className)) : '';
+    const classInterface = `) : ${baseClass}${sliceBase}`;
 
     const constructorArguments = ktUtils.joinWithIndents(constructorFields, {
       startIndent: classDecl.length + classInterface.length,
@@ -159,13 +184,16 @@ export class KotlinEntityGenerator implements EntityGenerator {
     const fieldCount = Object.keys(this.node.schema.fields).length;
     const blocks: string[] = [];
 
+    // TODO(b/182330900): hard-code to override once type slicing has fully launched
+    const override = this.opts.type_slicing ? 'override ' : '';
+
     const fieldVals: string[] = [];
     for (const {name, type, escaped, nullableType} of this.fields) {
       if (this.opts.wasm) {
         // TODO: Add support for collections in wasm.
         assert(!type.isCollection, 'Collection fields not supported in Kotlin wasm yet.');
         fieldVals.push(`\
-var ${escaped} = ${escaped}
+${override}var ${escaped} = ${escaped}
     get() = field
     private set(_value) {
         field = _value
@@ -173,14 +201,14 @@ var ${escaped} = ${escaped}
         );
       } else if (type.isCollection) {
         fieldVals.push(`\
-var ${escaped}: ${type.kotlinType}
+${override}var ${escaped}: ${type.kotlinType}
     get() = super.getCollectionValue("${name}") as ${type.kotlinType}
     private set(_value) = super.setCollectionValue("${name}", _value)`
         );
       } else {
         const defaultFallback = type.defaultVal === 'null' ? '' : ` ?: ${type.defaultVal}`;
         fieldVals.push(`\
-var ${escaped}: ${type.kotlinType}
+${override}var ${escaped}: ${type.kotlinType}
     get() = super.getSingletonValue("${name}") as ${nullableType}${defaultFallback}
     private set(_value) = super.setSingletonValue("${name}", _value)`
         );

--- a/src/tools/schema2wasm.ts
+++ b/src/tools/schema2wasm.ts
@@ -13,7 +13,7 @@ import {Schema2Kotlin} from './schema2kotlin.js';
 import {Schema2Dot} from './schema2dot.js';
 
 const opts = minimist(process.argv.slice(2), {
-  boolean: ['cpp', 'kotlin', 'graph', 'update', 'wasm', 'test_harness', 'help'],
+  boolean: ['cpp', 'kotlin', 'graph', 'update', 'wasm', 'test_harness', 'type_slicing', 'help'],
   string: ['outdir', 'outfile'],
   alias: {c: 'cpp', k: 'kotlin', g: 'graph', u: 'update', d: 'outdir', f: 'outfile'},
   default: {outdir: '.'}
@@ -28,15 +28,17 @@ Description
   Generates entity class code from schemas for use in wasm particles.
 
 Options
-  --cpp, -c      generate C++ code
-  --kotlin, -k   generate Kotlin code
-  --graph, -g    generate a Graphviz (.dot) file for the type lattice
-  --wasm         whether to output wasm-specific code (applies to Kotlin only)
-  --test_harness whether to output a particle test harness only (applies to Kotlin only)
-  --outdir, -d   output directory; defaults to '.'
-  --outfile, -f  output filename; if omitted, generated from the manifest name
-  --update, -u   only generate if the source file is newer than the destination
-  --help         usage info
+  --cpp, -c       generate C++ code
+  --kotlin, -k    generate Kotlin code
+  --graph, -g     generate a Graphviz (.dot) file for the type lattice
+  --outdir, -d    output directory; defaults to '.'
+  --outfile, -f   output filename; if omitted, generated from the manifest name
+  --update, -u    only generate if the source file is newer than the destination
+  --help          usage info
+Kotlin-specific options
+  --wasm          whether to output wasm-specific code
+  --test_harness  whether to output particle test harnesses only
+  --type_slicing  whether to enable type slicing interfaces
 `);
   process.exit(0);
 }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -20,26 +20,24 @@ import arcs.sdk.toBigInt
 import javax.annotation.Generated
 
 typealias Gold_Data_Ref = AbstractGold.GoldInternal1
-typealias Gold_Data_Ref_Slice = AbstractGold.GoldInternal1Slice
+typealias Gold_Data_Ref_Slice = AbstractGold.GoldInternal1
 typealias Gold_Alias = AbstractGold.GoldInternal1
-typealias Gold_Alias_Slice = AbstractGold.GoldInternal1Slice
+typealias Gold_Alias_Slice = AbstractGold.GoldInternal1
 typealias Gold_AllPeople = AbstractGold.Gold_AllPeople
-typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople_Slice
+typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople
 typealias Gold_Collection = AbstractGold.Foo
-typealias Gold_Collection_Slice = AbstractGold.FooSlice
+typealias Gold_Collection_Slice = AbstractGold.Foo
 typealias Gold_Data = AbstractGold.Gold_Data
-typealias Gold_Data_Slice = AbstractGold.Gold_Data_Slice
+typealias Gold_Data_Slice = AbstractGold.Gold_Data
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
-typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection_Slice
+typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection
 
 @Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractGold : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 
 
-    interface GoldInternal1Slice : arcs.sdk.Entity {
-        val val_: String
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class GoldInternal1(
@@ -54,9 +52,9 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ), GoldInternal1Slice {
+    ) {
 
-        override var val_: String
+        var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
             private set(_value) = super.setSingletonValue("val", _value)
 
@@ -107,15 +105,7 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface Gold_AllPeople_Slice : arcs.sdk.Entity {
-        val name: String
-        val age: Double
-        val lastCall: Double
-        val address: String
-        val favoriteColor: String
-        val birthDayMonth: Double
-        val birthDayDOM: Double
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Gold_AllPeople(
@@ -136,27 +126,27 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ), Gold_AllPeople_Slice {
+    ) {
 
-        override var name: String
+        var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
-        override var age: Double
+        var age: Double
             get() = super.getSingletonValue("age") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("age", _value)
-        override var lastCall: Double
+        var lastCall: Double
             get() = super.getSingletonValue("lastCall") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("lastCall", _value)
-        override var address: String
+        var address: String
             get() = super.getSingletonValue("address") as String? ?: ""
             private set(_value) = super.setSingletonValue("address", _value)
-        override var favoriteColor: String
+        var favoriteColor: String
             get() = super.getSingletonValue("favoriteColor") as String? ?: ""
             private set(_value) = super.setSingletonValue("favoriteColor", _value)
-        override var birthDayMonth: Double
+        var birthDayMonth: Double
             get() = super.getSingletonValue("birthDayMonth") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayMonth", _value)
-        override var birthDayDOM: Double
+        var birthDayDOM: Double
             get() = super.getSingletonValue("birthDayDOM") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayDOM", _value)
 
@@ -251,9 +241,7 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface FooSlice : arcs.sdk.Entity {
-        val num: Double
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Foo(
@@ -261,9 +249,9 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Foo", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), FooSlice {
+    ) : arcs.sdk.EntityBase("Foo", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
-        override var num: Double
+        var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
 
@@ -314,13 +302,7 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface Gold_Data_Slice : arcs.sdk.Entity {
-        val num: Double
-        val txt: String
-        val lnk: String
-        val flg: Boolean
-        val ref: arcs.sdk.Reference<GoldInternal1>?
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Gold_Data(
@@ -332,21 +314,21 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), Gold_Data_Slice {
+    ) : arcs.sdk.EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
-        override var num: Double
+        var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
-        override var txt: String
+        var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        override var lnk: String
+        var lnk: String
             get() = super.getSingletonValue("lnk") as String? ?: ""
             private set(_value) = super.setSingletonValue("lnk", _value)
-        override var flg: Boolean
+        var flg: Boolean
             get() = super.getSingletonValue("flg") as Boolean? ?: false
             private set(_value) = super.setSingletonValue("flg", _value)
-        override var ref: arcs.sdk.Reference<GoldInternal1>?
+        var ref: arcs.sdk.Reference<GoldInternal1>?
             get() = super.getSingletonValue("ref") as arcs.sdk.Reference<GoldInternal1>?
             private set(_value) = super.setSingletonValue("ref", _value)
 
@@ -423,9 +405,7 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface Gold_QCollection_Slice : Gold_AllPeople_Slice {
 
-    }
 
     @Suppress("UNCHECKED_CAST")
     class Gold_QCollection(
@@ -446,27 +426,27 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ), Gold_QCollection_Slice {
+    ) {
 
-        override var name: String
+        var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
-        override var age: Double
+        var age: Double
             get() = super.getSingletonValue("age") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("age", _value)
-        override var lastCall: Double
+        var lastCall: Double
             get() = super.getSingletonValue("lastCall") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("lastCall", _value)
-        override var address: String
+        var address: String
             get() = super.getSingletonValue("address") as String? ?: ""
             private set(_value) = super.setSingletonValue("address", _value)
-        override var favoriteColor: String
+        var favoriteColor: String
             get() = super.getSingletonValue("favoriteColor") as String? ?: ""
             private set(_value) = super.setSingletonValue("favoriteColor", _value)
-        override var birthDayMonth: Double
+        var birthDayMonth: Double
             get() = super.getSingletonValue("birthDayMonth") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayMonth", _value)
-        override var birthDayDOM: Double
+        var birthDayDOM: Double
             get() = super.getSingletonValue("birthDayDOM") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayDOM", _value)
 
@@ -574,7 +554,7 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         val data: arcs.sdk.ReadSingletonHandle<Gold_Data> by handles
         val allPeople: arcs.sdk.ReadCollectionHandle<Gold_AllPeople> by handles
         val qCollection: arcs.sdk.ReadQueryCollectionHandle<Gold_QCollection, String> by handles
-        val alias: arcs.sdk.WriteSingletonHandle<Gold_Alias_Slice> by handles
+        val alias: arcs.sdk.WriteSingletonHandle<Gold_Alias> by handles
         val collection: arcs.sdk.ReadCollectionHandle<Foo> by handles
     }
 }

--- a/src/tools/tests/goldens/generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/generated-schemas.jvm.kt
@@ -20,22 +20,26 @@ import arcs.sdk.toBigInt
 import javax.annotation.Generated
 
 typealias Gold_Data_Ref = AbstractGold.GoldInternal1
-typealias Gold_Data_Ref_Slice = AbstractGold.GoldInternal1
+typealias Gold_Data_Ref_Slice = AbstractGold.GoldInternal1Slice
 typealias Gold_Alias = AbstractGold.GoldInternal1
-typealias Gold_Alias_Slice = AbstractGold.GoldInternal1
+typealias Gold_Alias_Slice = AbstractGold.GoldInternal1Slice
 typealias Gold_AllPeople = AbstractGold.Gold_AllPeople
-typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople
+typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople_Slice
 typealias Gold_Collection = AbstractGold.Foo
-typealias Gold_Collection_Slice = AbstractGold.Foo
+typealias Gold_Collection_Slice = AbstractGold.FooSlice
 typealias Gold_Data = AbstractGold.Gold_Data
-typealias Gold_Data_Slice = AbstractGold.Gold_Data
+typealias Gold_Data_Slice = AbstractGold.Gold_Data_Slice
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
-typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection
+typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection_Slice
 
 @Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractGold : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 
+
+    interface GoldInternal1Slice : arcs.sdk.Entity {
+        val val_: String
+    }
 
     @Suppress("UNCHECKED_CAST")
     class GoldInternal1(
@@ -50,9 +54,9 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ) {
+    ), GoldInternal1Slice {
 
-        var val_: String
+        override var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
             private set(_value) = super.setSingletonValue("val", _value)
 
@@ -103,6 +107,16 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface Gold_AllPeople_Slice : arcs.sdk.Entity {
+        val name: String
+        val age: Double
+        val lastCall: Double
+        val address: String
+        val favoriteColor: String
+        val birthDayMonth: Double
+        val birthDayDOM: Double
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Gold_AllPeople(
         name: String = "",
@@ -122,27 +136,27 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ) {
+    ), Gold_AllPeople_Slice {
 
-        var name: String
+        override var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
-        var age: Double
+        override var age: Double
             get() = super.getSingletonValue("age") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("age", _value)
-        var lastCall: Double
+        override var lastCall: Double
             get() = super.getSingletonValue("lastCall") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("lastCall", _value)
-        var address: String
+        override var address: String
             get() = super.getSingletonValue("address") as String? ?: ""
             private set(_value) = super.setSingletonValue("address", _value)
-        var favoriteColor: String
+        override var favoriteColor: String
             get() = super.getSingletonValue("favoriteColor") as String? ?: ""
             private set(_value) = super.setSingletonValue("favoriteColor", _value)
-        var birthDayMonth: Double
+        override var birthDayMonth: Double
             get() = super.getSingletonValue("birthDayMonth") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayMonth", _value)
-        var birthDayDOM: Double
+        override var birthDayDOM: Double
             get() = super.getSingletonValue("birthDayDOM") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayDOM", _value)
 
@@ -237,15 +251,19 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface FooSlice : arcs.sdk.Entity {
+        val num: Double
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Foo(
         num: Double = 0.0,
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Foo", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+    ) : arcs.sdk.EntityBase("Foo", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), FooSlice {
 
-        var num: Double
+        override var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
 
@@ -296,6 +314,14 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface Gold_Data_Slice : arcs.sdk.Entity {
+        val num: Double
+        val txt: String
+        val lnk: String
+        val flg: Boolean
+        val ref: arcs.sdk.Reference<GoldInternal1>?
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Gold_Data(
         num: Double = 0.0,
@@ -306,21 +332,21 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+    ) : arcs.sdk.EntityBase("Gold_Data", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), Gold_Data_Slice {
 
-        var num: Double
+        override var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
-        var txt: String
+        override var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        var lnk: String
+        override var lnk: String
             get() = super.getSingletonValue("lnk") as String? ?: ""
             private set(_value) = super.setSingletonValue("lnk", _value)
-        var flg: Boolean
+        override var flg: Boolean
             get() = super.getSingletonValue("flg") as Boolean? ?: false
             private set(_value) = super.setSingletonValue("flg", _value)
-        var ref: arcs.sdk.Reference<GoldInternal1>?
+        override var ref: arcs.sdk.Reference<GoldInternal1>?
             get() = super.getSingletonValue("ref") as arcs.sdk.Reference<GoldInternal1>?
             private set(_value) = super.setSingletonValue("ref", _value)
 
@@ -397,6 +423,10 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface Gold_QCollection_Slice : Gold_AllPeople_Slice {
+
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Gold_QCollection(
         name: String = "",
@@ -416,27 +446,27 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ) {
+    ), Gold_QCollection_Slice {
 
-        var name: String
+        override var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
-        var age: Double
+        override var age: Double
             get() = super.getSingletonValue("age") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("age", _value)
-        var lastCall: Double
+        override var lastCall: Double
             get() = super.getSingletonValue("lastCall") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("lastCall", _value)
-        var address: String
+        override var address: String
             get() = super.getSingletonValue("address") as String? ?: ""
             private set(_value) = super.setSingletonValue("address", _value)
-        var favoriteColor: String
+        override var favoriteColor: String
             get() = super.getSingletonValue("favoriteColor") as String? ?: ""
             private set(_value) = super.setSingletonValue("favoriteColor", _value)
-        var birthDayMonth: Double
+        override var birthDayMonth: Double
             get() = super.getSingletonValue("birthDayMonth") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayMonth", _value)
-        var birthDayDOM: Double
+        override var birthDayDOM: Double
             get() = super.getSingletonValue("birthDayDOM") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("birthDayDOM", _value)
 
@@ -544,7 +574,7 @@ abstract class AbstractGold : arcs.sdk.BaseParticle() {
         val data: arcs.sdk.ReadSingletonHandle<Gold_Data> by handles
         val allPeople: arcs.sdk.ReadCollectionHandle<Gold_AllPeople> by handles
         val qCollection: arcs.sdk.ReadQueryCollectionHandle<Gold_QCollection, String> by handles
-        val alias: arcs.sdk.WriteSingletonHandle<Gold_Alias> by handles
+        val alias: arcs.sdk.WriteSingletonHandle<Gold_Alias_Slice> by handles
         val collection: arcs.sdk.ReadCollectionHandle<Foo> by handles
     }
 }

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -10,27 +10,22 @@ package arcs.golden
 import arcs.sdk.wasm.*
 
 typealias Gold_Data = AbstractGold.Gold_Data
-typealias Gold_Data_Slice = AbstractGold.Gold_Data_Slice
+typealias Gold_Data_Slice = AbstractGold.Gold_Data
 typealias Gold_AllPeople = AbstractGold.Gold_AllPeople
-typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople_Slice
+typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople
 typealias Gold_Alias = AbstractGold.Gold_Alias
-typealias Gold_Alias_Slice = AbstractGold.Gold_Alias_Slice
+typealias Gold_Alias_Slice = AbstractGold.Gold_Alias
 typealias Gold_Collection = AbstractGold.Foo
-typealias Gold_Collection_Slice = AbstractGold.FooSlice
+typealias Gold_Collection_Slice = AbstractGold.Foo
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
-typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection_Slice
+typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection
 
 @Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractGold : WasmParticleImpl() {
     val handles: Handles = Handles(this)
 
 
-    interface Gold_Data_Slice : WasmEntity {
-        val num: Double
-        val txt: String
-        val lnk: String
-        val flg: Boolean
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Gold_Data(
@@ -38,24 +33,24 @@ abstract class AbstractGold : WasmParticleImpl() {
         txt: String = "",
         lnk: String = "",
         flg: Boolean = false
-    ) : WasmEntity, Gold_Data_Slice {
+    ) : WasmEntity {
 
-        override var num = num
+        var num = num
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var txt = txt
+        var txt = txt
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var lnk = lnk
+        var lnk = lnk
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var flg = flg
+        var flg = flg
             get() = field
             private set(_value) {
                 field = _value
@@ -148,15 +143,7 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
-    interface Gold_AllPeople_Slice : WasmEntity {
-        val name: String
-        val age: Double
-        val lastCall: Double
-        val address: String
-        val favoriteColor: String
-        val birthDayMonth: Double
-        val birthDayDOM: Double
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Gold_AllPeople(
@@ -167,39 +154,39 @@ abstract class AbstractGold : WasmParticleImpl() {
         favoriteColor: String = "",
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0
-    ) : WasmEntity, Gold_AllPeople_Slice {
+    ) : WasmEntity {
 
-        override var name = name
+        var name = name
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var age = age
+        var age = age
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var lastCall = lastCall
+        var lastCall = lastCall
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var address = address
+        var address = address
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var favoriteColor = favoriteColor
+        var favoriteColor = favoriteColor
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var birthDayMonth = birthDayMonth
+        var birthDayMonth = birthDayMonth
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var birthDayDOM = birthDayDOM
+        var birthDayDOM = birthDayDOM
             get() = field
             private set(_value) {
                 field = _value
@@ -332,14 +319,12 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
-    interface Gold_Alias_Slice : WasmEntity {
-        val val_: String
-    }
+
 
     @Suppress("UNCHECKED_CAST")
-    class Gold_Alias(val_: String = "") : WasmEntity, Gold_Alias_Slice {
+    class Gold_Alias(val_: String = "") : WasmEntity {
 
-        override var val_ = val_
+        var val_ = val_
             get() = field
             private set(_value) {
                 field = _value
@@ -406,14 +391,12 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
-    interface FooSlice : WasmEntity {
-        val num: Double
-    }
+
 
     @Suppress("UNCHECKED_CAST")
-    class Foo(num: Double = 0.0) : WasmEntity, FooSlice {
+    class Foo(num: Double = 0.0) : WasmEntity {
 
-        override var num = num
+        var num = num
             get() = field
             private set(_value) {
                 field = _value
@@ -480,9 +463,7 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
-    interface Gold_QCollection_Slice : Gold_AllPeople_Slice {
 
-    }
 
     @Suppress("UNCHECKED_CAST")
     class Gold_QCollection(
@@ -493,39 +474,39 @@ abstract class AbstractGold : WasmParticleImpl() {
         favoriteColor: String = "",
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0
-    ) : WasmEntity, Gold_QCollection_Slice {
+    ) : WasmEntity {
 
-        override var name = name
+        var name = name
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var age = age
+        var age = age
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var lastCall = lastCall
+        var lastCall = lastCall
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var address = address
+        var address = address
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var favoriteColor = favoriteColor
+        var favoriteColor = favoriteColor
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var birthDayMonth = birthDayMonth
+        var birthDayMonth = birthDayMonth
             get() = field
             private set(_value) {
                 field = _value
             }
-        override var birthDayDOM = birthDayDOM
+        var birthDayDOM = birthDayDOM
             get() = field
             private set(_value) {
                 field = _value

--- a/src/tools/tests/goldens/generated-schemas.wasm.kt
+++ b/src/tools/tests/goldens/generated-schemas.wasm.kt
@@ -10,20 +10,27 @@ package arcs.golden
 import arcs.sdk.wasm.*
 
 typealias Gold_Data = AbstractGold.Gold_Data
-typealias Gold_Data_Slice = AbstractGold.Gold_Data
+typealias Gold_Data_Slice = AbstractGold.Gold_Data_Slice
 typealias Gold_AllPeople = AbstractGold.Gold_AllPeople
-typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople
+typealias Gold_AllPeople_Slice = AbstractGold.Gold_AllPeople_Slice
 typealias Gold_Alias = AbstractGold.Gold_Alias
-typealias Gold_Alias_Slice = AbstractGold.Gold_Alias
+typealias Gold_Alias_Slice = AbstractGold.Gold_Alias_Slice
 typealias Gold_Collection = AbstractGold.Foo
-typealias Gold_Collection_Slice = AbstractGold.Foo
+typealias Gold_Collection_Slice = AbstractGold.FooSlice
 typealias Gold_QCollection = AbstractGold.Gold_QCollection
-typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection
+typealias Gold_QCollection_Slice = AbstractGold.Gold_QCollection_Slice
 
 @Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractGold : WasmParticleImpl() {
     val handles: Handles = Handles(this)
 
+
+    interface Gold_Data_Slice : WasmEntity {
+        val num: Double
+        val txt: String
+        val lnk: String
+        val flg: Boolean
+    }
 
     @Suppress("UNCHECKED_CAST")
     class Gold_Data(
@@ -31,24 +38,24 @@ abstract class AbstractGold : WasmParticleImpl() {
         txt: String = "",
         lnk: String = "",
         flg: Boolean = false
-    ) : WasmEntity {
+    ) : WasmEntity, Gold_Data_Slice {
 
-        var num = num
+        override var num = num
             get() = field
             private set(_value) {
                 field = _value
             }
-        var txt = txt
+        override var txt = txt
             get() = field
             private set(_value) {
                 field = _value
             }
-        var lnk = lnk
+        override var lnk = lnk
             get() = field
             private set(_value) {
                 field = _value
             }
-        var flg = flg
+        override var flg = flg
             get() = field
             private set(_value) {
                 field = _value
@@ -141,6 +148,16 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
+    interface Gold_AllPeople_Slice : WasmEntity {
+        val name: String
+        val age: Double
+        val lastCall: Double
+        val address: String
+        val favoriteColor: String
+        val birthDayMonth: Double
+        val birthDayDOM: Double
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Gold_AllPeople(
         name: String = "",
@@ -150,39 +167,39 @@ abstract class AbstractGold : WasmParticleImpl() {
         favoriteColor: String = "",
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0
-    ) : WasmEntity {
+    ) : WasmEntity, Gold_AllPeople_Slice {
 
-        var name = name
+        override var name = name
             get() = field
             private set(_value) {
                 field = _value
             }
-        var age = age
+        override var age = age
             get() = field
             private set(_value) {
                 field = _value
             }
-        var lastCall = lastCall
+        override var lastCall = lastCall
             get() = field
             private set(_value) {
                 field = _value
             }
-        var address = address
+        override var address = address
             get() = field
             private set(_value) {
                 field = _value
             }
-        var favoriteColor = favoriteColor
+        override var favoriteColor = favoriteColor
             get() = field
             private set(_value) {
                 field = _value
             }
-        var birthDayMonth = birthDayMonth
+        override var birthDayMonth = birthDayMonth
             get() = field
             private set(_value) {
                 field = _value
             }
-        var birthDayDOM = birthDayDOM
+        override var birthDayDOM = birthDayDOM
             get() = field
             private set(_value) {
                 field = _value
@@ -315,10 +332,14 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    class Gold_Alias(val_: String = "") : WasmEntity {
+    interface Gold_Alias_Slice : WasmEntity {
+        val val_: String
+    }
 
-        var val_ = val_
+    @Suppress("UNCHECKED_CAST")
+    class Gold_Alias(val_: String = "") : WasmEntity, Gold_Alias_Slice {
+
+        override var val_ = val_
             get() = field
             private set(_value) {
                 field = _value
@@ -385,10 +406,14 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    class Foo(num: Double = 0.0) : WasmEntity {
+    interface FooSlice : WasmEntity {
+        val num: Double
+    }
 
-        var num = num
+    @Suppress("UNCHECKED_CAST")
+    class Foo(num: Double = 0.0) : WasmEntity, FooSlice {
+
+        override var num = num
             get() = field
             private set(_value) {
                 field = _value
@@ -455,6 +480,10 @@ abstract class AbstractGold : WasmParticleImpl() {
         }
     }
 
+    interface Gold_QCollection_Slice : Gold_AllPeople_Slice {
+
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Gold_QCollection(
         name: String = "",
@@ -464,39 +493,39 @@ abstract class AbstractGold : WasmParticleImpl() {
         favoriteColor: String = "",
         birthDayMonth: Double = 0.0,
         birthDayDOM: Double = 0.0
-    ) : WasmEntity {
+    ) : WasmEntity, Gold_QCollection_Slice {
 
-        var name = name
+        override var name = name
             get() = field
             private set(_value) {
                 field = _value
             }
-        var age = age
+        override var age = age
             get() = field
             private set(_value) {
                 field = _value
             }
-        var lastCall = lastCall
+        override var lastCall = lastCall
             get() = field
             private set(_value) {
                 field = _value
             }
-        var address = address
+        override var address = address
             get() = field
             private set(_value) {
                 field = _value
             }
-        var favoriteColor = favoriteColor
+        override var favoriteColor = favoriteColor
             get() = field
             private set(_value) {
                 field = _value
             }
-        var birthDayMonth = birthDayMonth
+        override var birthDayMonth = birthDayMonth
             get() = field
             private set(_value) {
                 field = _value
             }
-        var birthDayDOM = birthDayDOM
+        override var birthDayDOM = birthDayDOM
             get() = field
             private set(_value) {
                 field = _value

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -50,9 +50,9 @@ class GoldTestHarness<P : Particle>(
         setOf(Gold_Collection)
     )
 )) {
-    val data: arcs.sdk.ReadWriteSingletonHandle<Gold_Data, Gold_Data_Slice> by handleMap
-    val allPeople: arcs.sdk.ReadWriteCollectionHandle<Gold_AllPeople, Gold_AllPeople_Slice> by handleMap
-    val qCollection: arcs.sdk.ReadWriteQueryCollectionHandle<Gold_QCollection, Gold_QCollection_Slice, String> by handleMap
-    val alias: arcs.sdk.ReadWriteSingletonHandle<Gold_Alias, Gold_Alias_Slice> by handleMap
-    val collection: arcs.sdk.ReadWriteCollectionHandle<Gold_Collection, Gold_Collection_Slice> by handleMap
+    val data: arcs.sdk.ReadWriteSingletonHandle<Gold_Data, Gold_Data> by handleMap
+    val allPeople: arcs.sdk.ReadWriteCollectionHandle<Gold_AllPeople, Gold_AllPeople> by handleMap
+    val qCollection: arcs.sdk.ReadWriteQueryCollectionHandle<Gold_QCollection, Gold_QCollection, String> by handleMap
+    val alias: arcs.sdk.ReadWriteSingletonHandle<Gold_Alias, Gold_Alias> by handleMap
+    val collection: arcs.sdk.ReadWriteCollectionHandle<Gold_Collection, Gold_Collection> by handleMap
 }

--- a/src/tools/tests/goldens/generated-test-harness.kt
+++ b/src/tools/tests/goldens/generated-test-harness.kt
@@ -50,9 +50,9 @@ class GoldTestHarness<P : Particle>(
         setOf(Gold_Collection)
     )
 )) {
-    val data: arcs.sdk.ReadWriteSingletonHandle<Gold_Data, Gold_Data> by handleMap
-    val allPeople: arcs.sdk.ReadWriteCollectionHandle<Gold_AllPeople, Gold_AllPeople> by handleMap
-    val qCollection: arcs.sdk.ReadWriteQueryCollectionHandle<Gold_QCollection, Gold_QCollection, String> by handleMap
-    val alias: arcs.sdk.ReadWriteSingletonHandle<Gold_Alias, Gold_Alias> by handleMap
-    val collection: arcs.sdk.ReadWriteCollectionHandle<Gold_Collection, Gold_Collection> by handleMap
+    val data: arcs.sdk.ReadWriteSingletonHandle<Gold_Data, Gold_Data_Slice> by handleMap
+    val allPeople: arcs.sdk.ReadWriteCollectionHandle<Gold_AllPeople, Gold_AllPeople_Slice> by handleMap
+    val qCollection: arcs.sdk.ReadWriteQueryCollectionHandle<Gold_QCollection, Gold_QCollection_Slice, String> by handleMap
+    val alias: arcs.sdk.ReadWriteSingletonHandle<Gold_Alias, Gold_Alias_Slice> by handleMap
+    val collection: arcs.sdk.ReadWriteCollectionHandle<Gold_Collection, Gold_Collection_Slice> by handleMap
 }

--- a/src/tools/tests/goldens/kotlin-entity-class.cgtest
+++ b/src/tools/tests/goldens/kotlin-entity-class.cgtest
@@ -12,6 +12,8 @@ particle T
   h1: reads Thing {num: Number}
 -----[results]-----
 
+    
+
     @Suppress("UNCHECKED_CAST")
     class Thing(
         num: Double = 0.0,
@@ -80,6 +82,8 @@ generates entity for WASM
 particle T
   h1: reads Thing {num: Number}
 -----[results]-----
+
+    
 
     @Suppress("UNCHECKED_CAST")
     class Thing(num: Double = 0.0) : WasmEntity {
@@ -158,6 +162,8 @@ generates variable entity with private constructor
 particle T
   h1: reads ~a with {num: Number}
 -----[results]-----
+
+    
 
     @Suppress("UNCHECKED_CAST")
     class T_H1 private constructor(

--- a/src/tools/tests/goldens/kotlin-handles-class-declarations.cgtest
+++ b/src/tools/tests/goldens/kotlin-handles-class-declarations.cgtest
@@ -36,20 +36,76 @@ class Handles : arcs.sdk.HandleHolderBase(
 -----[end]-----
 
 -----[name]-----
-read, write and query handles
+read, write and query entity handles
 -----[input]-----
 particle P
   h1: reads Person {name: Text}
   h2: writes Person {name: Text}
-  h3: reads [Person {name: Text} [name == ?]]
+  h3: reads writes Person {name: Text}
+
+  h4: reads [Person {name: Text}]
+  h5: writes [Person {name: Text}]
+  h6: reads writes [Person {name: Text}]
+
+  h7: reads [Person {name: Text} [name == ?]]
+  h8: writes [Person {name: Text} [name == ?]]
+  h9: reads writes [Person {name: Text} [name == ?]]
 -----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
-        mapOf("h1" to setOf(P_H1), "h2" to setOf(P_H2), "h3" to setOf(P_H3))
+        mapOf(
+            "h1" to setOf(P_H1),
+            "h2" to setOf(P_H2),
+            "h3" to setOf(P_H3),
+            "h4" to setOf(P_H4),
+            "h5" to setOf(P_H5),
+            "h6" to setOf(P_H6),
+            "h7" to setOf(P_H7),
+            "h8" to setOf(P_H8),
+            "h9" to setOf(P_H9)
+        )
     ) {
         val h1: arcs.sdk.ReadSingletonHandle<P_H1> by handles
         val h2: arcs.sdk.WriteSingletonHandle<P_H2> by handles
-        val h3: arcs.sdk.ReadQueryCollectionHandle<P_H3, String> by handles
+        val h3: arcs.sdk.ReadWriteSingletonHandle<P_H3, P_H3> by handles
+        val h4: arcs.sdk.ReadCollectionHandle<P_H4> by handles
+        val h5: arcs.sdk.WriteCollectionHandle<P_H5> by handles
+        val h6: arcs.sdk.ReadWriteCollectionHandle<P_H6, P_H6> by handles
+        val h7: arcs.sdk.ReadQueryCollectionHandle<P_H7, String> by handles
+        val h8: arcs.sdk.WriteQueryCollectionHandle<P_H8, String> by handles
+        val h9: arcs.sdk.ReadWriteQueryCollectionHandle<P_H9, P_H9, String> by handles
+    }
+-----[end]-----
+
+-----[name]-----
+read and write reference handles
+-----[input]-----
+particle P
+  h1: reads &{name: Text}
+  h2: writes &{name: Text}
+  h3: reads writes &{name: Text}
+
+  h4: reads [&{name: Text}]
+  h5: writes [&{name: Text}]
+  h6: reads writes [&{name: Text}]
+-----[results]-----
+class Handles : arcs.sdk.HandleHolderBase(
+        "P",
+        mapOf(
+            "h1" to setOf(PInternal1),
+            "h2" to setOf(PInternal1),
+            "h3" to setOf(PInternal1),
+            "h4" to setOf(PInternal1),
+            "h5" to setOf(PInternal1),
+            "h6" to setOf(PInternal1)
+        )
+    ) {
+        val h1: arcs.sdk.ReadSingletonHandle<arcs.sdk.Reference<PInternal1>> by handles
+        val h2: arcs.sdk.WriteSingletonHandle<arcs.sdk.Reference<PInternal1>> by handles
+        val h3: arcs.sdk.ReadWriteSingletonHandle<arcs.sdk.Reference<PInternal1>, arcs.sdk.Reference<PInternal1>> by handles
+        val h4: arcs.sdk.ReadCollectionHandle<arcs.sdk.Reference<PInternal1>> by handles
+        val h5: arcs.sdk.WriteCollectionHandle<arcs.sdk.Reference<PInternal1>> by handles
+        val h6: arcs.sdk.ReadWriteCollectionHandle<arcs.sdk.Reference<PInternal1>, arcs.sdk.Reference<PInternal1>> by handles
     }
 -----[end]-----
 
@@ -80,18 +136,19 @@ class Handles : arcs.sdk.HandleHolderBase(
 handle with a tuple
 -----[input]-----
 particle P
-  h1: reads (
+  h1: reads writes (
     &Person {name: Text},
     &Accommodation {squareFootage: Number},
-    &Address {streetAddress: Text, postCode: Text}
+    Address {streetAddress: Text, postCode: Text}
   )
 -----[results]-----
 class Handles : arcs.sdk.HandleHolderBase(
         "P",
         mapOf("h1" to setOf(Person, Accommodation, Address))
     ) {
-        val h1: arcs.sdk.ReadSingletonHandle<
-    arcs.core.entity.Tuple3<arcs.sdk.Reference<Person>, arcs.sdk.Reference<Accommodation>, arcs.sdk.Reference<Address>>
+        val h1: arcs.sdk.ReadWriteSingletonHandle<
+    arcs.core.entity.Tuple3<arcs.sdk.Reference<Person>, arcs.sdk.Reference<Accommodation>, Address>,
+    arcs.core.entity.Tuple3<arcs.sdk.Reference<Person>, arcs.sdk.Reference<Accommodation>, Address>
 > by handles
     }
 -----[end]-----

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -20,24 +20,28 @@ import arcs.sdk.toBigInt
 import javax.annotation.Generated
 
 typealias KotlinPrimitivesGolden_Data_Ref = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref
-typealias KotlinPrimitivesGolden_Data_Ref_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref
+typealias KotlinPrimitivesGolden_Data_Ref_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref_Slice
 typealias KotlinPrimitivesGolden_Data_Thinglst = AbstractKotlinPrimitivesGolden.Thing
-typealias KotlinPrimitivesGolden_Data_Thinglst_Slice = AbstractKotlinPrimitivesGolden.Thing
+typealias KotlinPrimitivesGolden_Data_Thinglst_Slice = AbstractKotlinPrimitivesGolden.ThingSlice
 typealias KotlinPrimitivesGolden_Data_Detail_Nested = AbstractKotlinPrimitivesGolden.Nested
-typealias KotlinPrimitivesGolden_Data_Detail_Nested_Slice = AbstractKotlinPrimitivesGolden.Nested
+typealias KotlinPrimitivesGolden_Data_Detail_Nested_Slice = AbstractKotlinPrimitivesGolden.NestedSlice
 typealias KotlinPrimitivesGolden_Data_Colors = AbstractKotlinPrimitivesGolden.Color
-typealias KotlinPrimitivesGolden_Data_Colors_Slice = AbstractKotlinPrimitivesGolden.Color
+typealias KotlinPrimitivesGolden_Data_Colors_Slice = AbstractKotlinPrimitivesGolden.ColorSlice
 typealias KotlinPrimitivesGolden_Data_Products = AbstractKotlinPrimitivesGolden.Product
-typealias KotlinPrimitivesGolden_Data_Products_Slice = AbstractKotlinPrimitivesGolden.Product
+typealias KotlinPrimitivesGolden_Data_Products_Slice = AbstractKotlinPrimitivesGolden.ProductSlice
 typealias KotlinPrimitivesGolden_Data_Detail = AbstractKotlinPrimitivesGolden.Detail
-typealias KotlinPrimitivesGolden_Data_Detail_Slice = AbstractKotlinPrimitivesGolden.Detail
+typealias KotlinPrimitivesGolden_Data_Detail_Slice = AbstractKotlinPrimitivesGolden.DetailSlice
 typealias KotlinPrimitivesGolden_Data = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data
-typealias KotlinPrimitivesGolden_Data_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data
+typealias KotlinPrimitivesGolden_Data_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Slice
 
 @Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 
+
+    interface KotlinPrimitivesGolden_Data_Ref_Slice : arcs.sdk.Entity {
+        val val_: String
+    }
 
     @Suppress("UNCHECKED_CAST")
     class KotlinPrimitivesGolden_Data_Ref(
@@ -52,9 +56,9 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ) {
+    ), KotlinPrimitivesGolden_Data_Ref_Slice {
 
-        var val_: String
+        override var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
             private set(_value) = super.setSingletonValue("val", _value)
 
@@ -105,15 +109,19 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface ThingSlice : arcs.sdk.Entity {
+        val name: String
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Thing(
         name: String = "",
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+    ) : arcs.sdk.EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), ThingSlice {
 
-        var name: String
+        override var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
 
@@ -164,6 +172,11 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface NestedSlice : arcs.sdk.Entity {
+        val txt: String
+        val num: Double
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Nested(
         txt: String = "",
@@ -171,12 +184,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Nested", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+    ) : arcs.sdk.EntityBase("Nested", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), NestedSlice {
 
-        var txt: String
+        override var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        var num: Double
+        override var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
 
@@ -232,6 +245,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface ColorSlice : arcs.sdk.Entity {
+        val red: Char
+        val green: Char
+        val blue: Char
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Color(
         red: Char = '\u0000',
@@ -240,15 +259,15 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Color", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
+    ) : arcs.sdk.EntityBase("Color", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true), ColorSlice {
 
-        var red: Char
+        override var red: Char
             get() = super.getSingletonValue("red") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("red", _value)
-        var green: Char
+        override var green: Char
             get() = super.getSingletonValue("green") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("green", _value)
-        var blue: Char
+        override var blue: Char
             get() = super.getSingletonValue("blue") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("blue", _value)
 
@@ -307,6 +326,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface ProductSlice : arcs.sdk.Entity {
+        val name: String
+        val price: Float
+        val stock: Int
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Product(
         name: String = "",
@@ -315,15 +340,15 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Product", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
+    ) : arcs.sdk.EntityBase("Product", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true), ProductSlice {
 
-        var name: String
+        override var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
-        var price: Float
+        override var price: Float
             get() = super.getSingletonValue("price") as Float? ?: 0.0f
             private set(_value) = super.setSingletonValue("price", _value)
-        var stock: Int
+        override var stock: Int
             get() = super.getSingletonValue("stock") as Int? ?: 0
             private set(_value) = super.setSingletonValue("stock", _value)
 
@@ -382,6 +407,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface DetailSlice : arcs.sdk.Entity {
+        val nested: Nested
+        val txt: String
+        val num: Double
+    }
+
     @Suppress("UNCHECKED_CAST")
     class Detail(
         nested: Nested = Nested(),
@@ -390,15 +421,15 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Detail", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
+    ) : arcs.sdk.EntityBase("Detail", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), DetailSlice {
 
-        var nested: Nested
+        override var nested: Nested
             get() = super.getSingletonValue("nested") as Nested? ?: Nested()
             private set(_value) = super.setSingletonValue("nested", _value)
-        var txt: String
+        override var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        var num: Double
+        override var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
 
@@ -457,6 +488,29 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
+    interface KotlinPrimitivesGolden_Data_Slice : arcs.sdk.Entity {
+        val num: Double
+        val txt: String
+        val lnk: String
+        val flg: Boolean
+        val ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
+        val bt: Byte
+        val shrt: Short
+        val integer: Int
+        val long_val: Long
+        val big: BigInt
+        val instant: ArcsInstant
+        val chr: Char
+        val flt: Float
+        val dbl: Double
+        val txtlst: List<String>
+        val lnglst: List<Long>
+        val thinglst: List<arcs.sdk.Reference<Thing>>
+        val detail: Detail
+        val colors: Set<Color>
+        val products: List<Product>
+    }
+
     @Suppress("UNCHECKED_CAST")
     class KotlinPrimitivesGolden_Data(
         num: Double = 0.0,
@@ -489,66 +543,66 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ) {
+    ), KotlinPrimitivesGolden_Data_Slice {
 
-        var num: Double
+        override var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
-        var txt: String
+        override var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        var lnk: String
+        override var lnk: String
             get() = super.getSingletonValue("lnk") as String? ?: ""
             private set(_value) = super.setSingletonValue("lnk", _value)
-        var flg: Boolean
+        override var flg: Boolean
             get() = super.getSingletonValue("flg") as Boolean? ?: false
             private set(_value) = super.setSingletonValue("flg", _value)
-        var ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
+        override var ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
             get() = super.getSingletonValue("ref") as arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
             private set(_value) = super.setSingletonValue("ref", _value)
-        var bt: Byte
+        override var bt: Byte
             get() = super.getSingletonValue("bt") as Byte? ?: 0.toByte()
             private set(_value) = super.setSingletonValue("bt", _value)
-        var shrt: Short
+        override var shrt: Short
             get() = super.getSingletonValue("shrt") as Short? ?: 0.toShort()
             private set(_value) = super.setSingletonValue("shrt", _value)
-        var integer: Int
+        override var integer: Int
             get() = super.getSingletonValue("integer") as Int? ?: 0
             private set(_value) = super.setSingletonValue("integer", _value)
-        var long_val: Long
+        override var long_val: Long
             get() = super.getSingletonValue("long_val") as Long? ?: 0L
             private set(_value) = super.setSingletonValue("long_val", _value)
-        var big: BigInt
+        override var big: BigInt
             get() = super.getSingletonValue("big") as BigInt? ?: BigInt.ZERO
             private set(_value) = super.setSingletonValue("big", _value)
-        var instant: ArcsInstant
+        override var instant: ArcsInstant
             get() = super.getSingletonValue("instant") as ArcsInstant? ?: ArcsInstant.ofEpochMilli(-1L)
             private set(_value) = super.setSingletonValue("instant", _value)
-        var chr: Char
+        override var chr: Char
             get() = super.getSingletonValue("chr") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("chr", _value)
-        var flt: Float
+        override var flt: Float
             get() = super.getSingletonValue("flt") as Float? ?: 0.0f
             private set(_value) = super.setSingletonValue("flt", _value)
-        var dbl: Double
+        override var dbl: Double
             get() = super.getSingletonValue("dbl") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("dbl", _value)
-        var txtlst: List<String>
+        override var txtlst: List<String>
             get() = super.getSingletonValue("txtlst") as List<String>? ?: emptyList()
             private set(_value) = super.setSingletonValue("txtlst", _value)
-        var lnglst: List<Long>
+        override var lnglst: List<Long>
             get() = super.getSingletonValue("lnglst") as List<Long>? ?: emptyList()
             private set(_value) = super.setSingletonValue("lnglst", _value)
-        var thinglst: List<arcs.sdk.Reference<Thing>>
+        override var thinglst: List<arcs.sdk.Reference<Thing>>
             get() = super.getSingletonValue("thinglst") as List<arcs.sdk.Reference<Thing>>? ?: emptyList()
             private set(_value) = super.setSingletonValue("thinglst", _value)
-        var detail: Detail
+        override var detail: Detail
             get() = super.getSingletonValue("detail") as Detail? ?: Detail()
             private set(_value) = super.setSingletonValue("detail", _value)
-        var colors: Set<Color>
+        override var colors: Set<Color>
             get() = super.getCollectionValue("colors") as Set<Color>
             private set(_value) = super.setCollectionValue("colors", _value)
-        var products: List<Product>
+        override var products: List<Product>
             get() = super.getSingletonValue("products") as List<Product>? ?: emptyList()
             private set(_value) = super.setSingletonValue("products", _value)
 

--- a/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
+++ b/src/tools/tests/goldens/kt_generated-schemas.jvm.kt
@@ -20,28 +20,26 @@ import arcs.sdk.toBigInt
 import javax.annotation.Generated
 
 typealias KotlinPrimitivesGolden_Data_Ref = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref
-typealias KotlinPrimitivesGolden_Data_Ref_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref_Slice
+typealias KotlinPrimitivesGolden_Data_Ref_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Ref
 typealias KotlinPrimitivesGolden_Data_Thinglst = AbstractKotlinPrimitivesGolden.Thing
-typealias KotlinPrimitivesGolden_Data_Thinglst_Slice = AbstractKotlinPrimitivesGolden.ThingSlice
+typealias KotlinPrimitivesGolden_Data_Thinglst_Slice = AbstractKotlinPrimitivesGolden.Thing
 typealias KotlinPrimitivesGolden_Data_Detail_Nested = AbstractKotlinPrimitivesGolden.Nested
-typealias KotlinPrimitivesGolden_Data_Detail_Nested_Slice = AbstractKotlinPrimitivesGolden.NestedSlice
+typealias KotlinPrimitivesGolden_Data_Detail_Nested_Slice = AbstractKotlinPrimitivesGolden.Nested
 typealias KotlinPrimitivesGolden_Data_Colors = AbstractKotlinPrimitivesGolden.Color
-typealias KotlinPrimitivesGolden_Data_Colors_Slice = AbstractKotlinPrimitivesGolden.ColorSlice
+typealias KotlinPrimitivesGolden_Data_Colors_Slice = AbstractKotlinPrimitivesGolden.Color
 typealias KotlinPrimitivesGolden_Data_Products = AbstractKotlinPrimitivesGolden.Product
-typealias KotlinPrimitivesGolden_Data_Products_Slice = AbstractKotlinPrimitivesGolden.ProductSlice
+typealias KotlinPrimitivesGolden_Data_Products_Slice = AbstractKotlinPrimitivesGolden.Product
 typealias KotlinPrimitivesGolden_Data_Detail = AbstractKotlinPrimitivesGolden.Detail
-typealias KotlinPrimitivesGolden_Data_Detail_Slice = AbstractKotlinPrimitivesGolden.DetailSlice
+typealias KotlinPrimitivesGolden_Data_Detail_Slice = AbstractKotlinPrimitivesGolden.Detail
 typealias KotlinPrimitivesGolden_Data = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data
-typealias KotlinPrimitivesGolden_Data_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data_Slice
+typealias KotlinPrimitivesGolden_Data_Slice = AbstractKotlinPrimitivesGolden.KotlinPrimitivesGolden_Data
 
 @Generated("src/tools/schema2kotlin.ts")
 abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
     override val handles: Handles = Handles()
 
 
-    interface KotlinPrimitivesGolden_Data_Ref_Slice : arcs.sdk.Entity {
-        val val_: String
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class KotlinPrimitivesGolden_Data_Ref(
@@ -56,9 +54,9 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ), KotlinPrimitivesGolden_Data_Ref_Slice {
+    ) {
 
-        override var val_: String
+        var val_: String
             get() = super.getSingletonValue("val") as String? ?: ""
             private set(_value) = super.setSingletonValue("val", _value)
 
@@ -109,9 +107,7 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface ThingSlice : arcs.sdk.Entity {
-        val name: String
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Thing(
@@ -119,9 +115,9 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), ThingSlice {
+    ) : arcs.sdk.EntityBase("Thing", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
-        override var name: String
+        var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
 
@@ -172,10 +168,7 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface NestedSlice : arcs.sdk.Entity {
-        val txt: String
-        val num: Double
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Nested(
@@ -184,12 +177,12 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Nested", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), NestedSlice {
+    ) : arcs.sdk.EntityBase("Nested", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
-        override var txt: String
+        var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        override var num: Double
+        var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
 
@@ -245,11 +238,7 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface ColorSlice : arcs.sdk.Entity {
-        val red: Char
-        val green: Char
-        val blue: Char
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Color(
@@ -259,15 +248,15 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Color", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true), ColorSlice {
+    ) : arcs.sdk.EntityBase("Color", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
 
-        override var red: Char
+        var red: Char
             get() = super.getSingletonValue("red") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("red", _value)
-        override var green: Char
+        var green: Char
             get() = super.getSingletonValue("green") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("green", _value)
-        override var blue: Char
+        var blue: Char
             get() = super.getSingletonValue("blue") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("blue", _value)
 
@@ -326,11 +315,7 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface ProductSlice : arcs.sdk.Entity {
-        val name: String
-        val price: Float
-        val stock: Int
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Product(
@@ -340,15 +325,15 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Product", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true), ProductSlice {
+    ) : arcs.sdk.EntityBase("Product", SCHEMA, entityId, creationTimestamp, expirationTimestamp, true) {
 
-        override var name: String
+        var name: String
             get() = super.getSingletonValue("name") as String? ?: ""
             private set(_value) = super.setSingletonValue("name", _value)
-        override var price: Float
+        var price: Float
             get() = super.getSingletonValue("price") as Float? ?: 0.0f
             private set(_value) = super.setSingletonValue("price", _value)
-        override var stock: Int
+        var stock: Int
             get() = super.getSingletonValue("stock") as Int? ?: 0
             private set(_value) = super.setSingletonValue("stock", _value)
 
@@ -407,11 +392,7 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface DetailSlice : arcs.sdk.Entity {
-        val nested: Nested
-        val txt: String
-        val num: Double
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class Detail(
@@ -421,15 +402,15 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         entityId: String? = null,
         creationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP,
         expirationTimestamp: Long = arcs.core.data.RawEntity.UNINITIALIZED_TIMESTAMP
-    ) : arcs.sdk.EntityBase("Detail", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false), DetailSlice {
+    ) : arcs.sdk.EntityBase("Detail", SCHEMA, entityId, creationTimestamp, expirationTimestamp, false) {
 
-        override var nested: Nested
+        var nested: Nested
             get() = super.getSingletonValue("nested") as Nested? ?: Nested()
             private set(_value) = super.setSingletonValue("nested", _value)
-        override var txt: String
+        var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        override var num: Double
+        var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
 
@@ -488,28 +469,7 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         }
     }
 
-    interface KotlinPrimitivesGolden_Data_Slice : arcs.sdk.Entity {
-        val num: Double
-        val txt: String
-        val lnk: String
-        val flg: Boolean
-        val ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
-        val bt: Byte
-        val shrt: Short
-        val integer: Int
-        val long_val: Long
-        val big: BigInt
-        val instant: ArcsInstant
-        val chr: Char
-        val flt: Float
-        val dbl: Double
-        val txtlst: List<String>
-        val lnglst: List<Long>
-        val thinglst: List<arcs.sdk.Reference<Thing>>
-        val detail: Detail
-        val colors: Set<Color>
-        val products: List<Product>
-    }
+
 
     @Suppress("UNCHECKED_CAST")
     class KotlinPrimitivesGolden_Data(
@@ -543,66 +503,66 @@ abstract class AbstractKotlinPrimitivesGolden : arcs.sdk.BaseParticle() {
         creationTimestamp,
         expirationTimestamp,
         false
-    ), KotlinPrimitivesGolden_Data_Slice {
+    ) {
 
-        override var num: Double
+        var num: Double
             get() = super.getSingletonValue("num") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("num", _value)
-        override var txt: String
+        var txt: String
             get() = super.getSingletonValue("txt") as String? ?: ""
             private set(_value) = super.setSingletonValue("txt", _value)
-        override var lnk: String
+        var lnk: String
             get() = super.getSingletonValue("lnk") as String? ?: ""
             private set(_value) = super.setSingletonValue("lnk", _value)
-        override var flg: Boolean
+        var flg: Boolean
             get() = super.getSingletonValue("flg") as Boolean? ?: false
             private set(_value) = super.setSingletonValue("flg", _value)
-        override var ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
+        var ref: arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
             get() = super.getSingletonValue("ref") as arcs.sdk.Reference<KotlinPrimitivesGolden_Data_Ref>?
             private set(_value) = super.setSingletonValue("ref", _value)
-        override var bt: Byte
+        var bt: Byte
             get() = super.getSingletonValue("bt") as Byte? ?: 0.toByte()
             private set(_value) = super.setSingletonValue("bt", _value)
-        override var shrt: Short
+        var shrt: Short
             get() = super.getSingletonValue("shrt") as Short? ?: 0.toShort()
             private set(_value) = super.setSingletonValue("shrt", _value)
-        override var integer: Int
+        var integer: Int
             get() = super.getSingletonValue("integer") as Int? ?: 0
             private set(_value) = super.setSingletonValue("integer", _value)
-        override var long_val: Long
+        var long_val: Long
             get() = super.getSingletonValue("long_val") as Long? ?: 0L
             private set(_value) = super.setSingletonValue("long_val", _value)
-        override var big: BigInt
+        var big: BigInt
             get() = super.getSingletonValue("big") as BigInt? ?: BigInt.ZERO
             private set(_value) = super.setSingletonValue("big", _value)
-        override var instant: ArcsInstant
+        var instant: ArcsInstant
             get() = super.getSingletonValue("instant") as ArcsInstant? ?: ArcsInstant.ofEpochMilli(-1L)
             private set(_value) = super.setSingletonValue("instant", _value)
-        override var chr: Char
+        var chr: Char
             get() = super.getSingletonValue("chr") as Char? ?: '\u0000'
             private set(_value) = super.setSingletonValue("chr", _value)
-        override var flt: Float
+        var flt: Float
             get() = super.getSingletonValue("flt") as Float? ?: 0.0f
             private set(_value) = super.setSingletonValue("flt", _value)
-        override var dbl: Double
+        var dbl: Double
             get() = super.getSingletonValue("dbl") as Double? ?: 0.0
             private set(_value) = super.setSingletonValue("dbl", _value)
-        override var txtlst: List<String>
+        var txtlst: List<String>
             get() = super.getSingletonValue("txtlst") as List<String>? ?: emptyList()
             private set(_value) = super.setSingletonValue("txtlst", _value)
-        override var lnglst: List<Long>
+        var lnglst: List<Long>
             get() = super.getSingletonValue("lnglst") as List<Long>? ?: emptyList()
             private set(_value) = super.setSingletonValue("lnglst", _value)
-        override var thinglst: List<arcs.sdk.Reference<Thing>>
+        var thinglst: List<arcs.sdk.Reference<Thing>>
             get() = super.getSingletonValue("thinglst") as List<arcs.sdk.Reference<Thing>>? ?: emptyList()
             private set(_value) = super.setSingletonValue("thinglst", _value)
-        override var detail: Detail
+        var detail: Detail
             get() = super.getSingletonValue("detail") as Detail? ?: Detail()
             private set(_value) = super.setSingletonValue("detail", _value)
-        override var colors: Set<Color>
+        var colors: Set<Color>
             get() = super.getCollectionValue("colors") as Set<Color>
             private set(_value) = super.setCollectionValue("colors", _value)
-        override var products: List<Product>
+        var products: List<Product>
             get() = super.getSingletonValue("products") as List<Product>? ?: emptyList()
             private set(_value) = super.setSingletonValue("products", _value)
 

--- a/src/tools/tests/schema2kotlin-codegen-test-suite.ts
+++ b/src/tools/tests/schema2kotlin-codegen-test-suite.ts
@@ -59,7 +59,8 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
       );
     }
     async computeFromManifest({particles}, opts: object) {
-      const schema2kotlin = new Schema2Kotlin({_: [], wasm: opts['wasm'] || false});
+      // TODO(b/182330900): set type_slicing to true when flag is flipped to 'READY'
+      const schema2kotlin = new Schema2Kotlin({_: [], wasm: opts['wasm'] || false, type_slicing: false});
       const generators = (await schema2kotlin.calculateNodeAndGenerators(particles[0]));
       return Promise.all(generators.map(gn => (gn.generator as KotlinEntityGenerator).generateClasses()));
     }
@@ -72,7 +73,7 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
       );
     }
     async computeFromManifest({particles}, opts: object) {
-      const schema2kotlin = new Schema2Kotlin({_: [], wasm: opts['wasm'] || false});
+      const schema2kotlin = new Schema2Kotlin({_: [], wasm: opts['wasm'] || false, type_slicing: false});
       let generators = (await schema2kotlin.calculateNodeAndGenerators(particles[0]));
       if (opts['assertedSchema']) {
         generators = generators.filter(gn => gn.node.schema.name === opts['assertedSchema']);
@@ -113,7 +114,7 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
     }
     async computeFromManifest({particles}) {
       const graph = new SchemaGraph(particles[0]);
-      const generatorBase = new GeneratorBase(false, '');
+      const generatorBase = new GeneratorBase({_: [], type_slicing: false}, '');
       return particles[0].connections.map(c => generatorBase.handleInterfaceType(c, graph.nodes, true));
     }
   }(),
@@ -125,7 +126,7 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
       );
     }
     async computeFromManifest({particles}) {
-      const schema2kotlin = new Schema2Kotlin({_: []});
+      const schema2kotlin = new Schema2Kotlin({_: [], type_slicing: false});
       const nodeGenerators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
       const particleGenerator = new KotlinParticleGenerator(schema2kotlin, particles[0], nodeGenerators);
       const components = await particleGenerator.generateParticleClassComponents();
@@ -140,7 +141,7 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
       );
     }
     async computeFromManifest({particles}) {
-      const schema2kotlin = new Schema2Kotlin({_: []});
+      const schema2kotlin = new Schema2Kotlin({_: [], type_slicing: false});
       const nodeGenerators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
       const particleGenerator = new KotlinParticleGenerator(schema2kotlin, particles[0], nodeGenerators);
       const components = await particleGenerator.generateParticleClassComponents();
@@ -155,7 +156,7 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
       );
     }
     async computeFromManifest({particles}) {
-      const schema2kotlin = new Schema2Kotlin({_: []});
+      const schema2kotlin = new Schema2Kotlin({_: [], type_slicing: false});
       const generators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
       return schema2kotlin.generateTestHarness(particles[0], generators.map(g => g.node));
     }

--- a/third_party/java/arcs/build_defs/internal/cpp.bzl
+++ b/third_party/java/arcs/build_defs/internal/cpp.bzl
@@ -30,4 +30,5 @@ def arcs_cc_schema(name, src, deps = [], out = None):
         language_flag = "--cpp",
         wasm = False,
         test_harness = False,
+        type_slicing = False,
     )

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -22,6 +22,7 @@ load(
     "java_library",
     "java_test",
 )
+load("//third_party/java/arcs/flags:flags.bzl", "ARCS_BUILD_FLAGS")
 load("//tools/build_defs/android:rules.bzl", "android_local_test")
 load(
     "//tools/build_defs/kotlin:rules.bzl",
@@ -46,7 +47,6 @@ load(
     "merge_lists",
     "replace_arcs_suffix",
 )
-load("//third_party/java/arcs/flags:flags.bzl", "ARCS_BUILD_FLAGS")
 
 _WASM_SUFFIX = "-wasm"
 
@@ -99,14 +99,16 @@ DEFAULT_LIBRARY_PLATFORMS = ["jvm"]
 DEFAULT_PARTICLE_PLATFORMS = ["jvm"]
 
 # Controls output of type slicing interfaces for entities in generated particle classes.
+# Note that this uses the default value of the flag as defined in flags.bzl rather than
+# being overridden by clients.
 # TODO(b/182330900): hard-code to 'on' once type slicing has fully launched.
-def set_type_slicing_flag():
-  for flag in ARCS_BUILD_FLAGS:
-    if flag.name == "particle_type_slicing":
-      return flag.status != "NOT_READY"
-  return False
+def is_type_slicing_enabled():
+    for flag in ARCS_BUILD_FLAGS:
+        if flag.name == "particle_type_slicing":
+            return flag.status == "LAUNCHED"
+    return False
 
-KOTLIN_ENABLE_TYPE_SLICING = set_type_slicing_flag()
+KOTLIN_ENABLE_TYPE_SLICING = is_type_slicing_enabled()
 
 def arcs_java_library(**kwargs):
     """Wrapper around java_library for Arcs.
@@ -687,6 +689,7 @@ def arcs_kt_schema(
       platforms: list of target platforms (currently, `jvm` and `wasm` supported).
       test_harness: whether to generate a test harness target
       visibility: visibility of the generated arcs_kt_library
+      force_enable_type_slicing: temporary argument to force generation of type slicing interfaces
 
     Returns:
       Dictionary of:
@@ -785,6 +788,7 @@ def arcs_kt_gen(
       platforms: list of target platforms (currently, `jvm` and `wasm` supported).
       test_harness: whether to generate a test harness target
       visibility: visibility of the generated arcs_kt_library
+      force_enable_type_slicing: temporary argument to force generation of type slicing interfaces
     """
 
     manifest_name = name + "_manifest"

--- a/third_party/java/arcs/build_defs/internal/kotlin.bzl
+++ b/third_party/java/arcs/build_defs/internal/kotlin.bzl
@@ -46,6 +46,7 @@ load(
     "merge_lists",
     "replace_arcs_suffix",
 )
+load("//third_party/java/arcs/flags:flags.bzl", "ARCS_BUILD_FLAGS")
 
 _WASM_SUFFIX = "-wasm"
 
@@ -96,6 +97,16 @@ DEFAULT_LIBRARY_PLATFORMS = ["jvm"]
 
 # Default set of platforms for Kotlin particles.
 DEFAULT_PARTICLE_PLATFORMS = ["jvm"]
+
+ARCS_BUILD_FLAGS_MAP = {flag.name: flag for flag in ARCS_BUILD_FLAGS}
+
+# Controls output of type slicing interfaces for entities in generated particle classes.
+# TODO(b/182330900): hard-code to 'on' once type slicing has fully launched.
+def set_type_slicing_flag():
+  flag = ARCS_BUILD_FLAGS_MAP.get("particle_type_slicing")
+  return flag and flag.status != "NOT_READY"
+
+KOTLIN_ENABLE_TYPE_SLICING = set_type_slicing_flag()
 
 def arcs_java_library(**kwargs):
     """Wrapper around java_library for Arcs.
@@ -472,7 +483,8 @@ def arcs_kt_jvm_test_suite(
         data = [],
         constraints = [],
         size = "small",
-        flaky = False):
+        flaky = False,
+        build_flag = ""):
     """Defines Kotlin JVM test targets for a directory.
 
     Defines a Kotlin JVM library (kt_jvm_library) for all of the sources
@@ -492,7 +504,18 @@ def arcs_kt_jvm_test_suite(
         "medium", "large".
       flaky: boolean indicating whether the test is flaky and should be re-run
         on failure.
+      build_flag: Optional name of an Arcs build flag that conditionally guards this test rule.
+        If the flag status is NOT_READY, no build output will be produced for this rule.
+        See java/arcs/flags/flags.bzl for the list of flags.
     """
+    if build_flag:
+      flag = ARCS_BUILD_FLAGS_MAP.get(build_flag)
+      if not flag:
+        fail("invalid build flag name '%s' for test suite '%s'" % (build_flag, name))
+      if flag.status == "NOT_READY":
+        print("Test rule '%s' disabled by build flag '%s'" % (name, build_flag))
+        return
+
     if not srcs:
         srcs = native.glob(["*.kt"])
 
@@ -706,6 +729,7 @@ def arcs_kt_schema(
                 language_name = "Kotlin",
                 wasm = wasm,
                 test_harness = False,
+                type_slicing = KOTLIN_ENABLE_TYPE_SLICING,
             )
 
     arcs_kt_library(
@@ -732,6 +756,7 @@ def arcs_kt_schema(
                 language_name = "Kotlin",
                 wasm = False,
                 test_harness = True,
+                type_slicing = KOTLIN_ENABLE_TYPE_SLICING,
             )
 
         arcs_kt_library(

--- a/third_party/java/arcs/build_defs/internal/tools.oss.bzl
+++ b/third_party/java/arcs/build_defs/internal/tools.oss.bzl
@@ -50,14 +50,24 @@ def arcs_tool_manifest2proto(name, srcs, outs, deps):
     )
 
 # buildifier: disable=function-docstring
-def arcs_tool_schema2wasm(name, srcs, outs, deps, language_name, language_flag, wasm, test_harness):
-    # TODO: generated header guard should contain whole workspace-relative
-    # path to file.
+def arcs_tool_schema2wasm(
+        name,
+        srcs,
+        outs,
+        deps,
+        language_name,
+        language_flag,
+        wasm,
+        test_harness,
+        type_slicing):
+    # TODO: generated header guard should contain whole workspace-relative path to file.
     sigh_cmd = "schema2wasm " + language_flag
     if wasm:
         sigh_cmd += " --wasm"
     if test_harness:
         sigh_cmd += " --test_harness"
+    if type_slicing:
+        sigh_cmd += " --type_slicing"
     sigh_cmd += " --outdir $(dirname {OUT}) --outfile $(basename {OUT}) {SRC}"
 
     sigh_command(

--- a/third_party/java/arcs/flags/flags.bzl
+++ b/third_party/java/arcs/flags/flags.bzl
@@ -118,6 +118,13 @@ ARCS_BUILD_FLAGS = [
             "storage.?key.?reduction",
         ],
     ),
+    # This is an unusual flag:
+    #  - It is not affected by any flag overrides; the value defined here will always
+    #    control the behaviour of affected code.
+    #  - Becuase it is build-time only, the onyl valid status values are NOT_READY and
+    #    LAUNCHED. Once it's turned on, the generated interfaces are available to all
+    #    clients; once any clients start relying on the slicing behaviour, turning the
+    #    flag off will break them.
     arcs_build_flag(
         name = "particle_type_slicing",
         desc = "Output of entity type slicing interfaces in generated particle classes",

--- a/third_party/java/arcs/flags/flags.bzl
+++ b/third_party/java/arcs/flags/flags.bzl
@@ -118,6 +118,15 @@ ARCS_BUILD_FLAGS = [
             "storage.?key.?reduction",
         ],
     ),
+    arcs_build_flag(
+        name = "particle_type_slicing",
+        desc = "Output of entity type slicing interfaces in generated particle classes",
+        bug_id = "b/182330900",
+        status = "NOT_READY",
+        stopwords = [
+            "particle.?type.?slicing",
+        ],
+    ),
 ]
 
 validate_flag_list(ARCS_BUILD_FLAGS)


### PR DESCRIPTION
Generated entity classes will have a corresponding "slice" interface that enables automatic type conversion between entities within a particle.