### PR TITLE
Set up an '@edge' annotation to codegen "edge particles".

### DIFF
--- a/java/arcs/core/entity/Handle.kt
+++ b/java/arcs/core/entity/Handle.kt
@@ -181,7 +181,12 @@ interface ReadSingletonHandle<E : Storable> : ReadableHandle<E?, SingletonDelta<
   fun fetch(): E?
 }
 
-/** A singleton handle with write access. [I] is the interface for an entity class. */
+/**
+ * A singleton handle with write access. [I] is the interface for an entity class.
+ *
+ * Write operations return a Job that will be completed once the op has been sent to the backing
+ * store for this handle.
+ */
 interface WriteSingletonHandle<I : Storable> : Handle {
   /** Sets the value of the singleton. */
   fun store(element: I): Job
@@ -209,7 +214,12 @@ interface ReadCollectionHandle<E : Storable> : ReadableHandle<Set<E>, Collection
   fun fetchById(entityId: String): E?
 }
 
-/** A collection handle with write access. [I] is the interface for an entity class. */
+/**
+ * A collection handle with write access. [I] is the interface for an entity class.
+ *
+ * Write operations return a Job that will be completed once the op has been sent to the backing
+ * store for this handle.
+ */
 interface WriteCollectionHandle<I : Storable> : Handle {
   /** Adds the given [element] to the collection. */
   fun store(element: I): Job

--- a/java/arcs/sdk/EdgeHandles.kt
+++ b/java/arcs/sdk/EdgeHandles.kt
@@ -1,0 +1,161 @@
+package arcs.sdk
+
+import arcs.core.entity.Handle
+import arcs.core.entity.ReadCollectionHandle
+import arcs.core.entity.ReadSingletonHandle
+import arcs.core.entity.Storable
+import arcs.core.entity.WriteCollectionHandle
+import arcs.core.entity.WriteSingletonHandle
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
+
+/*
+ * To facilitate safe read/write access to data handles in running arcs, particles can be
+ * annotated with '@edge' in the manifest. This will cause the following set of changes to
+ * the code generation output:
+ *  - The generated class will be concrete and final instead of an abstract base class.
+ *  - The particle lifecycle will be managed internally to this class; clients will not have
+ *    any access to lifecycle events.
+ *  - Handles will be exposed via the Edge*Handle interfaces given below. All edge handle methods
+ *    are asynchronous and may be invoked at any time after the particle has been created.
+ *  - All read operations will return a CompletableDeferred around the requested value.
+ *  - All write operations will be applied immediately, but the APIs still need to be asynchronous
+ *    so they can operate on the handle's dispatcher.
+ *
+ * Query handles are not supported at this time.
+ */
+
+interface EdgeReadSingletonHandle<E> {
+  suspend fun fetch(): CompletableDeferred<E?>
+}
+
+interface EdgeWriteSingletonHandle<I> {
+  suspend fun store(element: I): Job
+  suspend fun clear(): Job
+}
+
+interface EdgeReadWriteSingletonHandle<E, I> :
+  EdgeReadSingletonHandle<E>, EdgeWriteSingletonHandle<I>
+
+interface EdgeReadCollectionHandle<E> {
+  suspend fun size(): CompletableDeferred<Int>
+  suspend fun isEmpty(): CompletableDeferred<Boolean>
+  suspend fun fetchAll(): CompletableDeferred<Set<E>>
+  suspend fun fetchById(entityId: String): CompletableDeferred<E?>
+}
+
+interface EdgeWriteCollectionHandle<I> {
+  suspend fun store(element: I): Job
+  suspend fun storeAll(elements: Collection<I>): Job
+  suspend fun clear(): Job
+  suspend fun remove(element: I): Job
+  suspend fun removeById(id: String): Job
+}
+
+interface EdgeReadWriteCollectionHandle<E, I> :
+  EdgeReadCollectionHandle<E>, EdgeWriteCollectionHandle<I>
+
+/**
+ * Base class for the edge handle implementations. This provides the latching and lifecycle logic
+ * that queues read operations for later completion once the backing handle has been synchronized.
+ */
+abstract class EdgeHandle {
+
+  /** Holds a read operation that was invoked prior to the onReady lifecycle event. */
+  class PendingOp<T>(val op: () -> T, val deferred: CompletableDeferred<T>) {
+    fun complete() = deferred.complete(op())
+  }
+
+  // The "real" arc handle; assigned by setHandles() in the generated particle implementation.
+  lateinit var handle: Handle
+  private var ready = false
+  private val pending = mutableListOf<PendingOp<*>>()
+
+  protected val dispatcher: CoroutineDispatcher
+    get() = handle.dispatcher
+
+  // For read operations: if the particle has reached onReady, execute the operation and complete
+  // the returned deferred object immediately. Otherwise, queue the op for later invocation.
+  suspend fun <T> executeOrDefer(op: () -> T) = withContext(dispatcher) {
+    CompletableDeferred<T>().also {
+      if (ready) {
+        it.complete(op())
+      } else {
+        pending.add(PendingOp(op, it))
+      }
+    }
+  }
+
+  // Invoked by onReady in the generated particle implementation.
+  fun moveToReady() {
+    ready = true
+    pending.forEach { it.complete() }
+    pending.clear()
+  }
+}
+
+@Suppress("UNCHECKED_CAST")
+class EdgeSingletonHandle<E : Storable, I : Storable> :
+  EdgeHandle(), EdgeReadWriteSingletonHandle<E, I> {
+
+  override suspend fun fetch() = executeOrDefer {
+    (handle as ReadSingletonHandle<E>).fetch()
+  }
+
+  override suspend fun store(element: I) = withContext(dispatcher) {
+    (handle as WriteSingletonHandle<I>).store(element)
+  }
+
+  override suspend fun clear() = withContext(dispatcher) {
+    (handle as WriteSingletonHandle<I>).clear()
+  }
+}
+
+@Suppress("UNCHECKED_CAST")
+class EdgeCollectionHandle<E : Storable, I : Storable> :
+  EdgeHandle(), EdgeReadWriteCollectionHandle<E, I> {
+
+  private val readHandle: ReadCollectionHandle<E>
+    get() = handle as ReadCollectionHandle<E>
+
+  private val writeHandle: WriteCollectionHandle<I>
+    get() = handle as WriteCollectionHandle<I>
+
+  override suspend fun size() = executeOrDefer {
+    readHandle.size()
+  }
+
+  override suspend fun isEmpty() = executeOrDefer {
+    readHandle.isEmpty()
+  }
+
+  override suspend fun fetchAll() = executeOrDefer {
+    readHandle.fetchAll()
+  }
+
+  override suspend fun fetchById(entityId: String) = executeOrDefer {
+    readHandle.fetchById(entityId)
+  }
+
+  override suspend fun store(element: I) = withContext(dispatcher) {
+    writeHandle.store(element)
+  }
+
+  override suspend fun storeAll(elements: Collection<I>) = withContext(dispatcher) {
+    writeHandle.storeAll(elements)
+  }
+
+  override suspend fun clear() = withContext(dispatcher) {
+    writeHandle.clear()
+  }
+
+  override suspend fun remove(element: I) = withContext(dispatcher) {
+    writeHandle.remove(element)
+  }
+
+  override suspend fun removeById(id: String) = withContext(dispatcher) {
+    writeHandle.removeById(id)
+  }
+}

--- a/javatests/arcs/sdk/EdgeParticleTest.kt
+++ b/javatests/arcs/sdk/EdgeParticleTest.kt
@@ -41,6 +41,7 @@ abstract class FakeHandle<V, U> : ReadableHandle<V, U> {
   protected fun wrap(block: () -> Unit) = CompletableDeferred(Unit).also { block() }
 }
 
+@Suppress("UnsafeCoroutineCrossing")
 class FakeSingletonHandle : FakeHandle<EntityBase?, SingletonDelta<EntityBase>>(),
   ReadWriteSingletonHandle<EntityBase, Entity> {
 
@@ -53,6 +54,7 @@ class FakeSingletonHandle : FakeHandle<EntityBase?, SingletonDelta<EntityBase>>(
   override fun clear() = wrap { stored = null }
 }
 
+@Suppress("UnsafeCoroutineCrossing")
 class FakeCollectionHandle : FakeHandle<Set<EntityBase>, CollectionDelta<EntityBase>>(),
   ReadWriteCollectionHandle<EntityBase, Entity> {
 

--- a/javatests/arcs/sdk/EdgeParticleTest.kt
+++ b/javatests/arcs/sdk/EdgeParticleTest.kt
@@ -42,7 +42,8 @@ abstract class FakeHandle<V, U> : ReadableHandle<V, U> {
 }
 
 @Suppress("UnsafeCoroutineCrossing")
-class FakeSingletonHandle : FakeHandle<EntityBase?, SingletonDelta<EntityBase>>(),
+class FakeSingletonHandle :
+  FakeHandle<EntityBase?, SingletonDelta<EntityBase>>(),
   ReadWriteSingletonHandle<EntityBase, Entity> {
 
   var stored: EntityBase? = null
@@ -55,7 +56,8 @@ class FakeSingletonHandle : FakeHandle<EntityBase?, SingletonDelta<EntityBase>>(
 }
 
 @Suppress("UnsafeCoroutineCrossing")
-class FakeCollectionHandle : FakeHandle<Set<EntityBase>, CollectionDelta<EntityBase>>(),
+class FakeCollectionHandle :
+  FakeHandle<Set<EntityBase>, CollectionDelta<EntityBase>>(),
   ReadWriteCollectionHandle<EntityBase, Entity> {
 
   val stored = mutableMapOf<String, EntityBase>()
@@ -87,6 +89,7 @@ typealias EdgeParticleInternal1 = EdgeParticle.EdgeParticleInternal1
 
 /** Tests for code-generated edge particles. */
 @OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("UnsafeCoroutineCrossing")
 @RunWith(JUnit4::class)
 class EdgeParticleTest {
   lateinit var particle: EdgeParticle

--- a/javatests/arcs/sdk/EdgeParticleTest.kt
+++ b/javatests/arcs/sdk/EdgeParticleTest.kt
@@ -1,0 +1,346 @@
+package arcs.sdk
+
+import arcs.core.testutil.runTest
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import arcs.core.data.HandleMode
+import arcs.core.entity.CollectionDelta
+import arcs.core.entity.SingletonDelta
+import arcs.core.entity.ReadableHandle
+import arcs.core.storage.StorageProxy.StorageEvent
+
+abstract class FakeHandle<V, U> : ReadableHandle<V, U> {
+  override val name = "fakeHandle"
+  override val mode = HandleMode.ReadWrite
+  override val dispatcher = Dispatchers.Default
+
+  // Handle interface
+  override fun onReady(action: () -> Unit) = Unit
+  override fun close() = Unit
+  override fun registerForStorageEvents(notify: (StorageEvent) -> Unit) = Unit
+  override fun unregisterForStorageEvents() = Unit
+  override fun maybeInitiateSync() = Unit
+  override fun getProxy() = throw Exception("unimplemented")
+  override suspend fun <E : Entity> createForeignReference(spec: EntitySpec<E>, id: String) =
+    throw Exception("unimplemented")
+
+  // ReadableHandle interface
+  override fun onUpdate(action: (U) -> Unit) = Unit
+  override fun onDesync(action: () -> Unit) = Unit
+  override fun onResync(action: () -> Unit) = Unit
+  override suspend fun <E : Entity> createReference(entity: E) = throw Exception("unimplemented")
+
+  // Execute a specific action and return an immediately-completed Job.
+  protected fun wrap(block: () -> Unit) = CompletableDeferred(Unit).also { block() }
+}
+
+class FakeSingletonHandle : FakeHandle<EntityBase?, SingletonDelta<EntityBase>>(),
+  ReadWriteSingletonHandle<EntityBase, Entity> {
+
+  var stored: EntityBase? = null
+
+  override fun fetch() = stored
+
+  override fun store(element: Entity) = wrap { stored = element as EntityBase }
+
+  override fun clear() = wrap { stored = null }
+}
+
+class FakeCollectionHandle : FakeHandle<Set<EntityBase>, CollectionDelta<EntityBase>>(),
+  ReadWriteCollectionHandle<EntityBase, Entity> {
+
+  val stored = mutableMapOf<String, EntityBase>()
+
+  override fun size() = stored.size
+
+  override fun isEmpty() = stored.isEmpty()
+
+  override fun fetchAll() = stored.values.toSet()
+
+  override fun fetchById(entityId: String) = stored.get(entityId)
+
+  override fun store(element: Entity) = wrap {
+    stored.set(requireNotNull(element.entityId), element as EntityBase)
+  }
+
+  override fun storeAll(elements: Collection<Entity>) = wrap {
+    elements.forEach { stored.set(requireNotNull(it.entityId), it as EntityBase) }
+  }
+
+  override fun clear() = wrap { stored.clear() }
+
+  override fun remove(element: Entity) = removeById(requireNotNull(element.entityId))
+
+  override fun removeById(id: String) = wrap { stored.remove(id) }
+}
+
+typealias EdgeParticleInternal1 = EdgeParticle.EdgeParticleInternal1
+
+/** Tests for code-generated edge particles. */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(JUnit4::class)
+class EdgeParticleTest {
+  lateinit var particle: EdgeParticle
+  lateinit var handles: EdgeParticle.Handles
+  lateinit var backingSingleton: FakeSingletonHandle
+  lateinit var backingCollection: FakeCollectionHandle
+
+  @Before
+  fun setUp() {
+    particle = EdgeParticle()
+    handles = particle.handles
+    backingSingleton = FakeSingletonHandle().also {
+      handles.setHandle("sr", it)
+      handles.setHandle("sw", it)
+      handles.setHandle("sb", it)
+    }
+    backingCollection = FakeCollectionHandle().also {
+      handles.setHandle("cr", it)
+      handles.setHandle("cw", it)
+      handles.setHandle("cb", it)
+    }
+  }
+
+  @Test
+  fun singleton_verifyHandleInterfaces() = runTest {
+    particle.onReady()
+
+    // Check fetch on sr and store/clear on sw.
+    handles.sw.store(EdgeParticleInternal1("abc")).join()
+    assertThat(handles.sr.fetch().await()).isEqualTo(EdgeParticleInternal1("abc"))
+
+    handles.sw.clear().join()
+    assertThat(handles.sr.fetch().await()).isNull()
+
+    // Check all three on sb.
+    handles.sb.store(EdgeParticleInternal1("abc")).join()
+    assertThat(handles.sb.fetch().await()).isEqualTo(EdgeParticleInternal1("abc"))
+
+    handles.sb.clear().join()
+    assertThat(handles.sb.fetch().await()).isNull()
+  }
+
+  @Test
+  fun singleton_fetchBeforeAndAfterReady() = runTest {
+    // Seed the handle data.
+    backingSingleton.store(EdgeParticleInternal1("def"))
+
+    // Reads before onReady should be queued to complete after onReady.
+    val queuedFetches = listOf(
+      handles.sr.fetch().also { assertThat(it.isCompleted).isFalse() },
+      handles.sr.fetch().also { assertThat(it.isCompleted).isFalse() },
+      handles.sb.fetch().also { assertThat(it.isCompleted).isFalse() }
+    )
+
+    particle.onReady()
+
+    queuedFetches.forEach {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).isEqualTo(EdgeParticleInternal1("def"))
+    }
+
+    // Reads after onReady should be completed immediately.
+    listOf(handles.sr.fetch(), handles.sb.fetch()).forEach {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).isEqualTo(EdgeParticleInternal1("def"))
+    }
+  }
+
+  @Test
+  fun singleton_storeBeforeReady() = runTest {
+    handles.sw.store(EdgeParticleInternal1("ghi"))
+    particle.onReady()
+    assertThat(backingSingleton.fetch()).isEqualTo(EdgeParticleInternal1("ghi"))
+  }
+
+  @Test
+  fun singleton_clearBeforeReady() = runTest {
+    backingSingleton.store(EdgeParticleInternal1("jkl"))
+    handles.sw.clear()
+    particle.onReady()
+    assertThat(backingSingleton.fetch()).isNull()
+  }
+
+  @Test
+  fun singleton_deferredReadsReturnValueAsSetAtOnReady() = runTest {
+    backingSingleton.store(EdgeParticleInternal1("ignored1"))
+
+    val queuedFetch = handles.sb.fetch()
+    assertThat(queuedFetch.isCompleted).isFalse()
+
+    backingSingleton.store(EdgeParticleInternal1("mno"))
+
+    // Queued operations should be fulfilled with the state of the handle as of now.
+    particle.onReady()
+
+    backingSingleton.store(EdgeParticleInternal1("ignored2"))
+
+    queuedFetch.let {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).isEqualTo(EdgeParticleInternal1("mno"))
+    }
+  }
+
+  @Test
+  fun collection_verifyHandleInterfaces_readOnlyAndWriteOnly() = runTest {
+    val e1 = EdgeParticleInternal1("e1", entityId = "id1")
+    val e2 = EdgeParticleInternal1("e2", entityId = "id2")
+    val e3 = EdgeParticleInternal1("e3", entityId = "id3")
+    particle.onReady()
+
+    handles.cw.store(e1)
+    handles.cw.storeAll(listOf(e2, e3))
+
+    assertThat(handles.cr.size().await()).isEqualTo(3)
+    assertThat(handles.cr.isEmpty().await()).isFalse()
+    assertThat(handles.cr.fetchAll().await()).containsExactly(e1, e2, e3)
+    assertThat(handles.cr.fetchById("id2").await()).isEqualTo(e2)
+
+    handles.cw.remove(e1)
+    assertThat(handles.cr.fetchAll().await()).containsExactly(e2, e3)
+
+    handles.cw.removeById("id3")
+    assertThat(handles.cr.fetchAll().await()).containsExactly(e2)
+
+    handles.cw.clear()
+    assertThat(handles.cr.size().await()).isEqualTo(0)
+    assertThat(handles.cr.isEmpty().await()).isTrue()
+    assertThat(handles.cr.fetchAll().await()).isEmpty()
+  }
+
+  @Test
+  fun collection_verifyHandleInterfaces_readAndWrite() = runTest {
+    val e1 = EdgeParticleInternal1("e1", entityId = "id1")
+    val e2 = EdgeParticleInternal1("e2", entityId = "id2")
+    val e3 = EdgeParticleInternal1("e3", entityId = "id3")
+    particle.onReady()
+
+    handles.cb.store(e1)
+    handles.cb.storeAll(listOf(e2, e3))
+
+    assertThat(handles.cb.size().await()).isEqualTo(3)
+    assertThat(handles.cb.isEmpty().await()).isFalse()
+    assertThat(handles.cb.fetchAll().await()).containsExactly(e1, e2, e3)
+    assertThat(handles.cb.fetchById("id2").await()).isEqualTo(e2)
+
+    handles.cb.remove(e1)
+    assertThat(handles.cb.fetchAll().await()).containsExactly(e2, e3)
+
+    handles.cb.removeById("id3")
+    assertThat(handles.cb.fetchAll().await()).containsExactly(e2)
+
+    handles.cb.clear()
+    assertThat(handles.cb.size().await()).isEqualTo(0)
+    assertThat(handles.cb.isEmpty().await()).isTrue()
+    assertThat(handles.cb.fetchAll().await()).isEmpty()
+  }
+
+  @Test
+  fun collection_readBeforeAndAfterReady() = runTest {
+    val e1 = EdgeParticleInternal1("e1", entityId = "id1")
+
+    // Seed the handle data.
+    backingCollection.store(e1)
+
+    // Reads before onReady should be queued to complete after onReady.
+    val queuedSize = listOf(handles.cr.size(), handles.cb.size())
+    val queuedIsEmpty = listOf(handles.cr.isEmpty(), handles.cb.isEmpty())
+    val queuedFetchAll = listOf(handles.cr.fetchAll(), handles.cb.fetchAll())
+    val queuedFetchById = listOf(handles.cr.fetchById("id1"), handles.cb.fetchById("id1"))
+
+    val allQueued = listOf(queuedSize, queuedIsEmpty, queuedFetchAll, queuedFetchById).flatten()
+    allQueued.forEach { assertThat(it.isCompleted).isFalse() }
+
+    particle.onReady()
+
+    allQueued.forEach { assertThat(it.isCompleted).isTrue() }
+
+    queuedSize.forEach { assertThat(it.await()).isEqualTo(1) }
+    queuedIsEmpty.forEach { assertThat(it.await()).isFalse() }
+    queuedFetchAll.forEach { assertThat(it.await()).containsExactly(e1) }
+    queuedFetchById.forEach { assertThat(it.await()).isEqualTo(e1) }
+
+    // Reads after onReady should be completed immediately.
+    handles.cr.size().let {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).isEqualTo(1)
+    }
+    handles.cb.isEmpty().let {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).isFalse()
+    }
+    handles.cr.fetchAll().let {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).containsExactly(e1)
+    }
+    handles.cb.fetchById("id1").let {
+      assertThat(it.isCompleted).isTrue()
+      assertThat(it.await()).isEqualTo(e1)
+    }
+  }
+
+  @Test
+  fun collection_storeBeforeReady() = runTest {
+    val e1 = EdgeParticleInternal1("e1", entityId = "id1")
+    val e2 = EdgeParticleInternal1("e2", entityId = "id2")
+    handles.cw.store(e1)
+    handles.cb.storeAll(listOf(e2))
+    particle.onReady()
+    assertThat(backingCollection.fetchAll()).containsExactly(e1, e2)
+  }
+
+  @Test
+  fun collection_clearBeforeReady() = runTest {
+    backingCollection.store(EdgeParticleInternal1("e1", entityId = "id1"))
+    handles.cw.clear()
+    particle.onReady()
+    assertThat(backingCollection.fetchAll()).isEmpty()
+  }
+
+  @Test
+  fun collection_removeBeforeReady() = runTest {
+    val e1 = EdgeParticleInternal1("e1", entityId = "id1")
+    val e2 = EdgeParticleInternal1("e2", entityId = "id2")
+    val e3 = EdgeParticleInternal1("e3", entityId = "id3")
+    backingCollection.storeAll(listOf(e1, e2, e3))
+    handles.cw.remove(e1)
+    handles.cb.removeById("id2")
+    particle.onReady()
+    assertThat(backingCollection.fetchAll()).containsExactly(e3)
+  }
+
+  @Test
+  fun collection_deferredReadsReturnValueAsSetAtOnReady() = runTest {
+    val e1 = EdgeParticleInternal1("e1", entityId = "id1")
+    val e2 = EdgeParticleInternal1("e2", entityId = "id2")
+
+    backingCollection.store(e1)
+
+    val queuedSize = handles.cb.size()
+    val queuedIsEmpty = handles.cr.isEmpty()
+    val queuedFetchAll = handles.cb.fetchAll()
+    val queuedFetchById = handles.cr.fetchById("id2") // Note e2 is not stored yet!
+
+    val allQueued = listOf(queuedSize, queuedIsEmpty, queuedFetchAll, queuedFetchById)
+    allQueued.forEach { assertThat(it.isCompleted).isFalse() }
+
+    backingCollection.store(e2)
+
+    // Queued operations should be fulfilled with the state of the handle as of now.
+    particle.onReady()
+
+    backingCollection.clear()
+
+    allQueued.forEach { assertThat(it.isCompleted).isTrue() }
+    assertThat(queuedSize.await()).isEqualTo(2)
+    assertThat(queuedIsEmpty.await()).isFalse()
+    assertThat(queuedFetchAll.await()).containsExactly(e1, e2)
+    assertThat(queuedFetchById.await()).isEqualTo(e2)
+  }
+}

--- a/javatests/arcs/sdk/edge_particles.arcs
+++ b/javatests/arcs/sdk/edge_particles.arcs
@@ -1,0 +1,12 @@
+meta
+  namespace: arcs.sdk
+
+@edge
+particle EdgeParticle
+  sr: reads {txt: Text}
+  sw: writes {txt: Text}
+  sb: reads writes {txt: Text}
+
+  cr: reads [{txt: Text}]
+  cw: writes [{txt: Text}]
+  cb: reads writes [{txt: Text}]

--- a/src/runtime/canonical-manifest.ts
+++ b/src/runtime/canonical-manifest.ts
@@ -88,9 +88,14 @@ annotation hardRef
   doc: 'It can be used on reference fields: a hard reference indicates that the entity with that field should be deleted when the referenced entity is deleted.'
 
 annotation actor(name: Text)
-    targets: [HandleConnection]
-    retention: Source
-    doc: 'Add an ActorId to reduce storage overhead'
+  targets: [HandleConnection]
+  retention: Source
+  doc: 'Add an ActorId to reduce storage overhead'
+
+annotation edge
+  targets: [Particle]
+  retention: Source
+  doc: 'The given particle will be generated as a concrete "edge" particle instead of an abstract base class, with handles that can treated as standard asynchronous data sources.'
 
 ${canonicalPolicyAnnotations}
 `;

--- a/src/tools/kotlin-entity-generator.ts
+++ b/src/tools/kotlin-entity-generator.ts
@@ -64,13 +64,13 @@ export class KotlinEntityGenerator implements EntityGenerator {
     return '';
   }
 
-  generateAliases(particleName: string): string[] {
+  generateAliases(particleName: string, prefix: string): string[] {
     const res = [];
     for (const s of this.node.sources) {
-      res.push(`typealias ${s.fullName} = Abstract${particleName}.${this.className}`);
+      res.push(`typealias ${s.fullName} = ${prefix}${particleName}.${this.className}`);
       // TODO(b/182330900): hard-code to interfaceName() once type slicing has fully launched
       const sliceName = this.opts.type_slicing ? interfaceName(this.className) : this.className;
-      res.push(`typealias ${interfaceName(s.fullName)} = Abstract${particleName}.${sliceName}`);
+      res.push(`typealias ${interfaceName(s.fullName)} = ${prefix}${particleName}.${sliceName}`);
     }
     return res;
   }

--- a/src/tools/schema2kotlin.ts
+++ b/src/tools/schema2kotlin.ts
@@ -92,6 +92,8 @@ ${imports.join('\n')}
 }
 
 export class GeneratorBase {
+  isEdgeParticle = false;
+
   constructor(readonly opts: minimist.ParsedArgs, readonly namespace: string) {}
 
   /**
@@ -121,7 +123,29 @@ export class GeneratorBase {
     if (queryType) {
       typeArguments.push(queryType);
     }
-    return `arcs.sdk.${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
+
+    const edge = this.isEdgeParticle ? 'Edge' : '';
+    return `arcs.sdk.${edge}${handleMode}${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
+  }
+
+  /**
+   * Similar to [handleInterfaceType], but generates the type for a delegated edge handle. It will not
+   * have the read/write component in the name and will always use the 'reads writes' generic typing.
+   *
+   * For example, if handleInterfaceType returns 'arcs.sdk.EdgeReadSingletonHandle<MyEntity>', this will
+   * return 'arcs.sdk.EdgeSingletonHandle<MyEntity, MyEntitySlice>'.
+   */
+  protected edgeDelegateType(connection: HandleConnectionSpec, nodes: SchemaNode[]) {
+    const direction = connection.direction;
+    connection.direction = 'reads writes';
+    const containerType = this.handleContainerType(connection.type);
+    const typeArguments = this.handleTypeArguments(connection, nodes, /* particleScope = */ true);
+    const queryType = this.getQueryType(connection);
+    if (queryType) {
+      typeArguments.push(queryType);
+    }
+    connection.direction = direction;
+    return `arcs.sdk.Edge${containerType}Handle<${ktUtils.joinWithIndents(typeArguments, {startIndent: 4})}>`;
   }
 
   protected async handleSpec(handleName: string, connection: HandleConnectionSpec, nodes: SchemaNode[]): Promise<string> {
@@ -233,22 +257,41 @@ export class GeneratorBase {
 export class KotlinParticleGenerator extends GeneratorBase {
   constructor(parent: Schema2Kotlin, readonly particle: ParticleSpec, readonly nodeGenerators: NodeAndGenerator[]) {
     super(parent.opts, parent.namespace);
+    this.isEdgeParticle = this.particle.getAnnotation('edge') != null;
   }
 
   async generateParticleClass(): Promise<string> {
+    const classHeader = this.generateParticleClassHeader();
     const {typeAliases, classes, handleClassDecl} = await this.generateParticleClassComponents();
     return `
 ${typeAliases.join(`\n`)}
 
 @Generated("src/tools/schema2kotlin.ts")
-abstract class Abstract${this.particle.name} : ${this.opts.wasm ? 'WasmParticleImpl' : 'arcs.sdk.BaseParticle'}() {
-    ${this.opts.wasm ? '' : 'override '}val handles: Handles = Handles(${this.opts.wasm ? 'this' : ''})
+${classHeader}
 
     ${ktUtils.indentFollowing(classes, 1)}
 
     ${handleClassDecl}
 }
 `;
+  }
+
+  generateParticleClassHeader() {
+    if (this.opts.wasm) {
+      return `abstract class Abstract${this.particle.name} : WasmParticleImpl() {
+    val handles: Handles = Handles(this)`;
+    } else if (this.isEdgeParticle) {
+      return `class ${this.particle.name} : arcs.sdk.BaseParticle() {
+    private val edgeHandles = mutableMapOf<String, arcs.sdk.EdgeHandle>()
+    override val handles: Handles = Handles(edgeHandles)
+
+    override fun onReady() {
+      edgeHandles.values.forEach { it.moveToReady() }
+    }`;
+    } else {
+      return `abstract class Abstract${this.particle.name} : arcs.sdk.BaseParticle() {
+    override val handles: Handles = Handles()`;
+    }
   }
 
   async generateParticleClassComponents() {
@@ -260,7 +303,7 @@ abstract class Abstract${this.particle.name} : ${this.opts.wasm ? 'WasmParticleI
     for (const nodeGenerator of this.nodeGenerators) {
       const kotlinGenerator = nodeGenerator.generator as KotlinEntityGenerator;
       classes.push(await kotlinGenerator.generateClasses());
-      typeAliases.push(...kotlinGenerator.generateAliases(this.particle.name));
+      typeAliases.push(...kotlinGenerator.generateAliases(this.particle.name, this.isEdgeParticle ? '' : 'Abstract'));
     }
 
     const nodes = this.nodeGenerators.map(ng => ng.node);
@@ -273,21 +316,44 @@ abstract class Abstract${this.particle.name} : ${this.opts.wasm ? 'WasmParticleI
         handleDecls.push(`val ${handleName}: ${handleInterfaceType} = ${handleInterfaceType}(particle, "${handleName}", ${entityNames[0]})`);
       } else {
         specDecls.push(`"${handleName}" to ${ktUtils.setOf(entityNames)}`);
-        handleDecls.push(`val ${handleName}: ${handleInterfaceType} by handles`);
+        if (this.isEdgeParticle) {
+          // This can be written as a single initialiser statement, but that hits a compiler bug: https://youtrack.jetbrains.com/issue/KT-45609
+          handleDecls.push(`val ${handleName}: ${handleInterfaceType}
+        init {
+            ${this.edgeDelegateType(connection, nodes)}().let {
+                ${handleName} = object : ${handleInterfaceType} by it {}
+                edgeHandles.set("${handleName}", it)
+            }
+        }
+        `);
+        } else {
+          handleDecls.push(`val ${handleName}: ${handleInterfaceType} by handles`);
+        }
       }
     }
 
-    const header = this.opts.wasm
-      ? `${handleDecls.length ? '' : '@Suppress("UNUSED_PARAMETER")\n    '}class Handles(
+    let header: string;
+    let footer = '';
+    if (this.opts.wasm) {
+      header = `${handleDecls.length ? '' : '@Suppress("UNUSED_PARAMETER")\n    '}class Handles(
         particle: WasmParticleImpl
-    )`
-      : `class Handles : arcs.sdk.HandleHolderBase(
+    )`;
+    } else {
+      const arg = this.isEdgeParticle ? '(val edgeHandles: MutableMap<String, arcs.sdk.EdgeHandle>)' : '';
+      header = `class Handles${arg} : arcs.sdk.HandleHolderBase(
         "${this.particle.name}",
         mapOf(${ktUtils.joinWithIndents(specDecls, {startIndent: 4, numberOfIndents: 3})})
     )`;
-
+      if (this.isEdgeParticle) {
+        footer = `
+        override fun setHandle(handleName: String, handle: arcs.sdk.Handle) {
+          super.setHandle(handleName, handle)
+          edgeHandles.get(handleName)!!.handle = handle
+        }`;
+      }
+    }
     const handleClassDecl = `${header} {
-        ${ktUtils.indentFollowing(handleDecls, 2)}
+        ${ktUtils.indentFollowing(handleDecls, 2)}${footer}
     }`;
 
     return {typeAliases, classes, handleClassDecl};

--- a/src/tools/tests/goldens/kotlin-edge-particles.cgtest
+++ b/src/tools/tests/goldens/kotlin-edge-particles.cgtest
@@ -1,0 +1,152 @@
+-----[header]-----
+Kotlin Edge Particles
+
+Expectations can be updated with:
+$ ./tools/sigh updateCodegenUnitTests
+-----[end_header]-----
+
+-----[name]-----
+standard particle
+-----[input]-----
+particle P
+  sr: reads {name: Text}
+  sw: writes {name: Text}
+  sb: reads writes {name: Text}
+  cr: reads [{nun: Int}]
+  cw: writes [{nun: Int}]
+  cb: reads writes [{nun: Int}]
+-----[results]-----
+typealias P_Sr = AbstractP.PInternal1
+typealias P_Sr_Slice = AbstractP.PInternal1
+typealias P_Sw = AbstractP.PInternal1
+typealias P_Sw_Slice = AbstractP.PInternal1
+typealias P_Sb = AbstractP.PInternal1
+typealias P_Sb_Slice = AbstractP.PInternal1
+typealias P_Cr = AbstractP.PInternal2
+typealias P_Cr_Slice = AbstractP.PInternal2
+typealias P_Cw = AbstractP.PInternal2
+typealias P_Cw_Slice = AbstractP.PInternal2
+typealias P_Cb = AbstractP.PInternal2
+typealias P_Cb_Slice = AbstractP.PInternal2
+-----[next]-----
+abstract class AbstractP : arcs.sdk.BaseParticle() {
+    override val handles: Handles = Handles()
+-----[next]-----
+class Handles : arcs.sdk.HandleHolderBase(
+        "P",
+        mapOf(
+            "sr" to setOf(P_Sr),
+            "sw" to setOf(P_Sw),
+            "sb" to setOf(P_Sb),
+            "cr" to setOf(P_Cr),
+            "cw" to setOf(P_Cw),
+            "cb" to setOf(P_Cb)
+        )
+    ) {
+        val sr: arcs.sdk.ReadSingletonHandle<P_Sr> by handles
+        val sw: arcs.sdk.WriteSingletonHandle<P_Sw> by handles
+        val sb: arcs.sdk.ReadWriteSingletonHandle<P_Sb, P_Sb> by handles
+        val cr: arcs.sdk.ReadCollectionHandle<P_Cr> by handles
+        val cw: arcs.sdk.WriteCollectionHandle<P_Cw> by handles
+        val cb: arcs.sdk.ReadWriteCollectionHandle<P_Cb, P_Cb> by handles
+    }
+-----[end]-----
+
+-----[name]-----
+edge particle
+-----[input]-----
+@edge
+particle P
+  sr: reads {name: Text}
+  sw: writes {name: Text}
+  sb: reads writes {name: Text}
+  cr: reads [{nun: Int}]
+  cw: writes [{nun: Int}]
+  cb: reads writes [{nun: Int}]
+-----[results]-----
+typealias P_Sr = P.PInternal1
+typealias P_Sr_Slice = P.PInternal1
+typealias P_Sw = P.PInternal1
+typealias P_Sw_Slice = P.PInternal1
+typealias P_Sb = P.PInternal1
+typealias P_Sb_Slice = P.PInternal1
+typealias P_Cr = P.PInternal2
+typealias P_Cr_Slice = P.PInternal2
+typealias P_Cw = P.PInternal2
+typealias P_Cw_Slice = P.PInternal2
+typealias P_Cb = P.PInternal2
+typealias P_Cb_Slice = P.PInternal2
+-----[next]-----
+class P : arcs.sdk.BaseParticle() {
+    private val edgeHandles = mutableMapOf<String, arcs.sdk.EdgeHandle>()
+    override val handles: Handles = Handles(edgeHandles)
+
+    override fun onReady() {
+      edgeHandles.values.forEach { it.moveToReady() }
+    }
+-----[next]-----
+class Handles(val edgeHandles: MutableMap<String, arcs.sdk.EdgeHandle>) : arcs.sdk.HandleHolderBase(
+        "P",
+        mapOf(
+            "sr" to setOf(P_Sr),
+            "sw" to setOf(P_Sw),
+            "sb" to setOf(P_Sb),
+            "cr" to setOf(P_Cr),
+            "cw" to setOf(P_Cw),
+            "cb" to setOf(P_Cb)
+        )
+    ) {
+        val sr: arcs.sdk.EdgeReadSingletonHandle<P_Sr>
+        init {
+            arcs.sdk.EdgeSingletonHandle<P_Sr, P_Sr>().let {
+                sr = object : arcs.sdk.EdgeReadSingletonHandle<P_Sr> by it {}
+                edgeHandles.set("sr", it)
+            }
+        }
+        
+        val sw: arcs.sdk.EdgeWriteSingletonHandle<P_Sw>
+        init {
+            arcs.sdk.EdgeSingletonHandle<P_Sw, P_Sw>().let {
+                sw = object : arcs.sdk.EdgeWriteSingletonHandle<P_Sw> by it {}
+                edgeHandles.set("sw", it)
+            }
+        }
+        
+        val sb: arcs.sdk.EdgeReadWriteSingletonHandle<P_Sb, P_Sb>
+        init {
+            arcs.sdk.EdgeSingletonHandle<P_Sb, P_Sb>().let {
+                sb = object : arcs.sdk.EdgeReadWriteSingletonHandle<P_Sb, P_Sb> by it {}
+                edgeHandles.set("sb", it)
+            }
+        }
+        
+        val cr: arcs.sdk.EdgeReadCollectionHandle<P_Cr>
+        init {
+            arcs.sdk.EdgeCollectionHandle<P_Cr, P_Cr>().let {
+                cr = object : arcs.sdk.EdgeReadCollectionHandle<P_Cr> by it {}
+                edgeHandles.set("cr", it)
+            }
+        }
+        
+        val cw: arcs.sdk.EdgeWriteCollectionHandle<P_Cw>
+        init {
+            arcs.sdk.EdgeCollectionHandle<P_Cw, P_Cw>().let {
+                cw = object : arcs.sdk.EdgeWriteCollectionHandle<P_Cw> by it {}
+                edgeHandles.set("cw", it)
+            }
+        }
+        
+        val cb: arcs.sdk.EdgeReadWriteCollectionHandle<P_Cb, P_Cb>
+        init {
+            arcs.sdk.EdgeCollectionHandle<P_Cb, P_Cb>().let {
+                cb = object : arcs.sdk.EdgeReadWriteCollectionHandle<P_Cb, P_Cb> by it {}
+                edgeHandles.set("cb", it)
+            }
+        }
+        
+        override fun setHandle(handleName: String, handle: arcs.sdk.Handle) {
+          super.setHandle(handleName, handle)
+          edgeHandles.get(handleName)!!.handle = handle
+        }
+    }
+-----[end]-----

--- a/src/tools/tests/schema2kotlin-codegen-test-suite.ts
+++ b/src/tools/tests/schema2kotlin-codegen-test-suite.ts
@@ -121,6 +121,22 @@ export const schema2KotlinTestSuite: CodegenUnitTest[] = [
   new class extends ManifestCodegenUnitTest {
     constructor() {
       super(
+        'Kotlin Edge Particles',
+        'kotlin-edge-particles.cgtest'
+      );
+    }
+    async computeFromManifest({particles}) {
+      const schema2kotlin = new Schema2Kotlin({_: []});
+      const nodeGenerators = await schema2kotlin.calculateNodeAndGenerators(particles[0]);
+      const particleGenerator = new KotlinParticleGenerator(schema2kotlin, particles[0], nodeGenerators);
+      const classHeader = particleGenerator.generateParticleClassHeader();
+      const {typeAliases, handleClassDecl} = await particleGenerator.generateParticleClassComponents();
+      return [typeAliases.join('\n'), classHeader, handleClassDecl];
+    }
+  }(),
+  new class extends ManifestCodegenUnitTest {
+    constructor() {
+      super(
         'Kotlin Handles Class Declarations',
         'kotlin-handles-class-declarations.cgtest'
       );


### PR DESCRIPTION
These are concrete particle impls (not abstract bases) with edge handle interfaces designed to allow direct-method-style access, with the particle lifecycle internally managed.